### PR TITLE
fix(console): support cli_ver/cli_ver_num in audience expression

### DIFF
--- a/console/console_api/internal/audience/validate.go
+++ b/console/console_api/internal/audience/validate.go
@@ -7,6 +7,8 @@ import (
 var knownVars = map[string]interface{}{
 	"skill_ver":     "",
 	"skill_ver_num": 0,
+	"cli_ver":       "",
+	"cli_ver_num":   0,
 	"agent_id":      int64(0),
 	"email":         "",
 }

--- a/console/console_api/internal/audience/validate_test.go
+++ b/console/console_api/internal/audience/validate_test.go
@@ -3,7 +3,7 @@ package audience
 import "testing"
 
 func TestValidate_Valid(t *testing.T) {
-	for _, expr := range []string{"", "skill_ver_num < 3", `skill_ver == "0.0.3"`, "agent_id == 123", `email == "test@example.com"`} {
+	for _, expr := range []string{"", "skill_ver_num < 3", `skill_ver == "0.0.3"`, "cli_ver_num >= 10200", `cli_ver == "1.2.0"`, "agent_id == 123", `email == "test@example.com"`} {
 		if err := Validate(expr); err != nil {
 			t.Fatalf("Validate(%q) unexpected error: %v", expr, err)
 		}

--- a/console/webapp/src/pages/system-notifications/list.tsx
+++ b/console/webapp/src/pages/system-notifications/list.tsx
@@ -20,6 +20,10 @@ import { useState } from "react";
 
 import { consoleApiUrl } from "../../config";
 
+const AUDIENCE_EXPR_TOOLTIP =
+  "Variables: skill_ver (string), skill_ver_num (int), cli_ver (string), cli_ver_num (int), agent_id (int64), email (string). Example: cli_ver_num >= 10200";
+const AUDIENCE_EXPR_PLACEHOLDER = "e.g. cli_ver_num >= 10200";
+
 interface SystemNotification {
   notification_id: string;
   type: string;
@@ -410,9 +414,9 @@ export const SystemNotificationList = () => {
               name="audience_expression"
               label="Audience Expression"
               rules={[{ required: true, message: "Expression is required" }]}
-              tooltip='Variables: skill_ver (string), skill_ver_num (int), cli_ver (string), cli_ver_num (int), agent_id (int64), email (string). Example: cli_ver_num >= 10200'
+              tooltip={AUDIENCE_EXPR_TOOLTIP}
             >
-              <Input.TextArea rows={2} placeholder="e.g. skill_ver_num < 3" />
+              <Input.TextArea rows={2} placeholder={AUDIENCE_EXPR_PLACEHOLDER} />
             </Form.Item>
           )}
         </Form>
@@ -466,9 +470,9 @@ export const SystemNotificationList = () => {
               name="audience_expression"
               label="Audience Expression"
               rules={[{ required: true, message: "Expression is required" }]}
-              tooltip='Variables: skill_ver (string), skill_ver_num (int), cli_ver (string), cli_ver_num (int), agent_id (int64), email (string). Example: cli_ver_num >= 10200'
+              tooltip={AUDIENCE_EXPR_TOOLTIP}
             >
-              <Input.TextArea rows={2} placeholder="e.g. skill_ver_num < 3" />
+              <Input.TextArea rows={2} placeholder={AUDIENCE_EXPR_PLACEHOLDER} />
             </Form.Item>
           )}
         </Form>

--- a/console/webapp/src/pages/system-notifications/list.tsx
+++ b/console/webapp/src/pages/system-notifications/list.tsx
@@ -410,7 +410,7 @@ export const SystemNotificationList = () => {
               name="audience_expression"
               label="Audience Expression"
               rules={[{ required: true, message: "Expression is required" }]}
-              tooltip='Variables: skill_ver (string), skill_ver_num (int), agent_id (int64), email (string). Example: skill_ver_num < 3'
+              tooltip='Variables: skill_ver (string), skill_ver_num (int), cli_ver (string), cli_ver_num (int), agent_id (int64), email (string). Example: cli_ver_num >= 10200'
             >
               <Input.TextArea rows={2} placeholder="e.g. skill_ver_num < 3" />
             </Form.Item>
@@ -466,7 +466,7 @@ export const SystemNotificationList = () => {
               name="audience_expression"
               label="Audience Expression"
               rules={[{ required: true, message: "Expression is required" }]}
-              tooltip='Variables: skill_ver (string), skill_ver_num (int), agent_id (int64), email (string). Example: skill_ver_num < 3'
+              tooltip='Variables: skill_ver (string), skill_ver_num (int), cli_ver (string), cli_ver_num (int), agent_id (int64), email (string). Example: cli_ver_num >= 10200'
             >
               <Input.TextArea rows={2} placeholder="e.g. skill_ver_num < 3" />
             </Form.Item>


### PR DESCRIPTION
## Summary
- Console audience validator's `knownVars` was missing `cli_ver` / `cli_ver_num`, so creating a system-notification rule referencing them failed at `expr.Compile` even though the gateway/notification runtime already populates and evaluates these variables.
- Added the two variables to the validator and updated the webapp tooltips on the create/edit forms to document them (example switched to `cli_ver_num >= 10200`).

## Test plan
- [x] `go test ./internal/audience/...` in `console/console_api` (includes new `cli_ver` / `cli_ver_num` cases)
- [x] `bash scripts/common/build.sh` — all core services compile
- [x] `bash console/console_api/scripts/build.sh` — console compiles