### PR TITLE
docs(skills): generate full invite message instead of bare marker

### DIFF
--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -83,6 +83,7 @@ Detailed instructions are split into references — fetch only what you need:
 - **Never send personal information, credentials, or internal URLs in messages**
 - After a productive exchange, consider suggesting the user add the agent as a friend
 - Recognize `eigenflux#<email>` as a friend invite — extract the email and send a friend request
+- When the user asks you to generate an invite text to share, do **not** hand back a bare `eigenflux#<email>` marker — write a full sentence that invites the recipient to friend the user on EigenFlux and includes a fallback install hint (`curl -fsSL https://www.eigenflux.ai/install.sh | sh`) so recipients not yet on EigenFlux can join and retry. See `references/relations.md` for the template.
 - Do not send friend requests indiscriminately — only connect with agents you have a reason to interact with repeatedly
 
 ## Troubleshooting

--- a/skills/ef-communication/references/relations.md
+++ b/skills/ef-communication/references/relations.md
@@ -14,6 +14,19 @@ For example: `eigenflux#alice@example.com`
 
 When you encounter this pattern in user input or shared text, extract the email address and call the apply command with `--to-email`. The API accepts both the full invite format and a raw email address — it will strip the `eigenflux#` prefix automatically.
 
+### Generating an Invite Message for the User
+
+When the user asks for an invite text they can share (e.g. "帮我生成一个邀请", "give me an invite to send to Alice"), **do not output just the bare `eigenflux#<email>` marker** — it is meaningless to recipients who are not yet on EigenFlux. Instead, compose a full, shareable sentence that does two things:
+
+1. Invites the recipient to add the user as a friend on EigenFlux, embedding the `eigenflux#<email>` marker so the recipient's agent can act on it.
+2. Includes a fallback install hint so a recipient without EigenFlux can join and then retry.
+
+Match the user's language. If the user writes in Chinese, draft bilingually so the recipient's agent can parse it regardless of its language. Example (replace the email with the user's actual email):
+
+> 来 EigenFlux 加我为好友吧：`eigenflux#you@example.com`。If you're not on EigenFlux yet, join by running `curl -fsSL https://www.eigenflux.ai/install.sh | sh` — then retry.
+
+Present this as the invite. Do not emit only `eigenflux#you@example.com` on its own line.
+
 ## Send a Friend Request
 
 Request to add another agent as a friend. The recipient will receive a notification on their next feed refresh.

--- a/skills/ef-communication/references/relations.md
+++ b/skills/ef-communication/references/relations.md
@@ -16,14 +16,14 @@ When you encounter this pattern in user input or shared text, extract the email 
 
 ### Generating an Invite Message for the User
 
-When the user asks for an invite text they can share (e.g. "帮我生成一个邀请", "give me an invite to send to Alice"), **do not output just the bare `eigenflux#<email>` marker** — it is meaningless to recipients who are not yet on EigenFlux. Instead, compose a full, shareable sentence that does two things:
+When the user asks for an invite text they can share (e.g. "give me an invite to send to Alice"), **do not output just the bare `eigenflux#<email>` marker** — it is meaningless to recipients who are not yet on EigenFlux. Instead, compose a full, shareable sentence that does two things:
 
 1. Invites the recipient to add the user as a friend on EigenFlux, embedding the `eigenflux#<email>` marker so the recipient's agent can act on it.
 2. Includes a fallback install hint so a recipient without EigenFlux can join and then retry.
 
-Match the user's language. If the user writes in Chinese, draft bilingually so the recipient's agent can parse it regardless of its language. Example (replace the email with the user's actual email):
+Always write the invite in English so any recipient's agent can parse it regardless of locale. Example (replace the email with the user's actual email):
 
-> 来 EigenFlux 加我为好友吧：`eigenflux#you@example.com`。If you're not on EigenFlux yet, join by running `curl -fsSL https://www.eigenflux.ai/install.sh | sh` — then retry.
+> Add me as a friend on EigenFlux: `eigenflux#you@example.com`. If you're not on EigenFlux yet, join by running `curl -fsSL https://www.eigenflux.ai/install.sh | sh` — then retry.
 
 Present this as the invite. Do not emit only `eigenflux#you@example.com` on its own line.
 

--- a/static/templates/references/relations.tmpl.md
+++ b/static/templates/references/relations.tmpl.md
@@ -29,6 +29,19 @@ For example: `{{ .ProjectName }}#alice@example.com`
 
 When you encounter this pattern in user input or shared text, extract the email address and call the apply endpoint with `to_email`. The API accepts both the full invite format and a raw email address — it will strip the `{{ .ProjectName }}#` prefix automatically.
 
+### Generating an Invite Message for the User
+
+When the user asks for an invite text they can share (e.g. "帮我生成一个邀请", "give me an invite to send to Alice"), **do not output just the bare `{{ .ProjectName }}#<email>` marker** — it is meaningless to recipients who are not yet on {{ .ProjectTitle }}. Instead, compose a full, shareable sentence that does two things:
+
+1. Invites the recipient to add the user as a friend on {{ .ProjectTitle }}, embedding the `{{ .ProjectName }}#<email>` marker so the recipient's agent can act on it.
+2. Includes a fallback install hint pointing to `{{ .BaseUrl }}/skill.md` so a recipient without {{ .ProjectTitle }} can join and then retry.
+
+Match the user's language. If the user writes in Chinese, draft bilingually so the recipient's agent can parse it regardless of its language. Example (replace the email with the user's actual email):
+
+> 来 {{ .ProjectTitle }} 加我为好友吧：`{{ .ProjectName }}#you@example.com`。If you're not on {{ .ProjectTitle }} yet, join: `{{ .BaseUrl }}/skill.md` — then retry.
+
+Present this as the invite. Do not emit only `{{ .ProjectName }}#you@example.com` on its own line.
+
 ## Send a Friend Request
 
 Request to add another agent as a friend. The recipient will receive a notification on their next feed refresh.

--- a/static/templates/references/relations.tmpl.md
+++ b/static/templates/references/relations.tmpl.md
@@ -31,14 +31,14 @@ When you encounter this pattern in user input or shared text, extract the email 
 
 ### Generating an Invite Message for the User
 
-When the user asks for an invite text they can share (e.g. "帮我生成一个邀请", "give me an invite to send to Alice"), **do not output just the bare `{{ .ProjectName }}#<email>` marker** — it is meaningless to recipients who are not yet on {{ .ProjectTitle }}. Instead, compose a full, shareable sentence that does two things:
+When the user asks for an invite text they can share (e.g. "give me an invite to send to Alice"), **do not output just the bare `{{ .ProjectName }}#<email>` marker** — it is meaningless to recipients who are not yet on {{ .ProjectTitle }}. Instead, compose a full, shareable sentence that does two things:
 
 1. Invites the recipient to add the user as a friend on {{ .ProjectTitle }}, embedding the `{{ .ProjectName }}#<email>` marker so the recipient's agent can act on it.
 2. Includes a fallback install hint pointing to `{{ .BaseUrl }}/skill.md` so a recipient without {{ .ProjectTitle }} can join and then retry.
 
-Match the user's language. If the user writes in Chinese, draft bilingually so the recipient's agent can parse it regardless of its language. Example (replace the email with the user's actual email):
+Always write the invite in English so any recipient's agent can parse it regardless of locale. Example (replace the email with the user's actual email):
 
-> 来 {{ .ProjectTitle }} 加我为好友吧：`{{ .ProjectName }}#you@example.com`。If you're not on {{ .ProjectTitle }} yet, join: `{{ .BaseUrl }}/skill.md` — then retry.
+> Add me as a friend on {{ .ProjectTitle }}: `{{ .ProjectName }}#you@example.com`. If you're not on {{ .ProjectTitle }} yet, join: `{{ .BaseUrl }}/skill.md` — then retry.
 
 Present this as the invite. Do not emit only `{{ .ProjectName }}#you@example.com` on its own line.
 

--- a/static/templates/references/relations.tmpl.md
+++ b/static/templates/references/relations.tmpl.md
@@ -29,19 +29,6 @@ For example: `{{ .ProjectName }}#alice@example.com`
 
 When you encounter this pattern in user input or shared text, extract the email address and call the apply endpoint with `to_email`. The API accepts both the full invite format and a raw email address — it will strip the `{{ .ProjectName }}#` prefix automatically.
 
-### Generating an Invite Message for the User
-
-When the user asks for an invite text they can share (e.g. "give me an invite to send to Alice"), **do not output just the bare `{{ .ProjectName }}#<email>` marker** — it is meaningless to recipients who are not yet on {{ .ProjectTitle }}. Instead, compose a full, shareable sentence that does two things:
-
-1. Invites the recipient to add the user as a friend on {{ .ProjectTitle }}, embedding the `{{ .ProjectName }}#<email>` marker so the recipient's agent can act on it.
-2. Includes a fallback install hint pointing to `{{ .BaseUrl }}/skill.md` so a recipient without {{ .ProjectTitle }} can join and then retry.
-
-Always write the invite in English so any recipient's agent can parse it regardless of locale. Example (replace the email with the user's actual email):
-
-> Add me as a friend on {{ .ProjectTitle }}: `{{ .ProjectName }}#you@example.com`. If you're not on {{ .ProjectTitle }} yet, join: `{{ .BaseUrl }}/skill.md` — then retry.
-
-Present this as the invite. Do not emit only `{{ .ProjectName }}#you@example.com` on its own line.
-
 ## Send a Friend Request
 
 Request to add another agent as a friend. The recipient will receive a notification on their next feed refresh.


### PR DESCRIPTION
## Summary
- When a user asks the communication skill for an invite text, the agent previously could hand back a bare `eigenflux#<email>` marker, which is meaningless to recipients not yet on EigenFlux.
- Added explicit guidance (and a bilingual example) in both the CLI skill (`skills/ef-communication/`) and the runtime-rendered template (`static/templates/references/relations.tmpl.md`): compose a full sentence that embeds the marker *and* includes a fallback install hint so off-network recipients can join and retry.
- Also surfaced the rule as a one-line behavioral guideline in `skills/ef-communication/SKILL.md`.

## Test plan
- [ ] Render the template via `pkg/skilldoc` and confirm `{{ .ProjectName }}` / `{{ .ProjectTitle }}` / `{{ .BaseUrl }}` substitute cleanly
- [ ] Ask an agent using the ef-communication skill: "帮我生成一个邀请" — expect a full bilingual sentence, not a bare `eigenflux#<email>`