### PR TITLE
feat(auth): idempotent StartLogin within validity window

### DIFF
--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -13,9 +13,9 @@ Email login, passwordless:
 
 ## Security Mechanisms
 
-Login start IP rate limiting (10 times/10min) always applies. When OTP verification is enabled, the system also enforces:
-- 60-second email cooldown
-- Verify IP rate limiting (30 times/10min; requests matching mock email suffix whitelist AND IP whitelist skip this limit)
+Login start IP rate limiting (30 times/10min) always applies. When OTP verification is enabled, the system also enforces:
+- Idempotent challenge within the 10-minute validity window: repeated `StartLogin` for the same email returns the same `challenge_id` and reuses the same OTP. Each call still sends the email and counts toward the IP rate limit. This prevents agents from confusing round-trips by verifying a stale code against a freshly issued challenge.
+- Verify IP rate limiting (100 times/10min; requests matching mock email suffix whitelist AND IP whitelist skip this limit)
 - OTP max 5 attempts
 - 10-minute challenge expiration
 - Tokens are stored as SHA-256 hash

--- a/rpc/auth/handler.go
+++ b/rpc/auth/handler.go
@@ -271,9 +271,12 @@ func (s *AuthServiceImpl) StartLogin(ctx context.Context, req *auth.StartLoginRe
 		if sep := strings.IndexByte(val, ':'); sep > 0 {
 			cachedID := val[:sep]
 			cachedOTP := val[sep+1:]
+			// 1-minute safety buffer: if the existing challenge is about to
+			// expire, issue a fresh one so the user has enough time to enter
+			// the OTP after receiving the email.
 			if existing, cerr := dal.GetChallenge(db.DB, cachedID); cerr == nil &&
 				existing != nil && existing.Status == 0 &&
-				existing.ExpireAt > time.Now().UnixMilli() {
+				existing.ExpireAt > time.Now().Add(time.Minute).UnixMilli() {
 				challengeID = cachedID
 				otpCode = cachedOTP
 				expireAt = existing.ExpireAt

--- a/rpc/auth/handler.go
+++ b/rpc/auth/handler.go
@@ -248,59 +248,82 @@ func (s *AuthServiceImpl) StartLogin(ctx context.Context, req *auth.StartLoginRe
 		return s.buildStartLoginDirectResp(loginResp), nil
 	}
 
-	// Check email cooldown (60 s)
-	cooldownKey := "auth:login:email:cooldown:" + emailHash
-	ttl, err := mq.RDB.TTL(ctx, cooldownKey).Result()
-	if err == nil && ttl > 0 {
-		return &auth.StartLoginResp{
-			BaseResp: &base.BaseResp{Code: 429, Msg: "too many requests, please wait before retrying"},
-		}, nil
-	}
-
-	// IP rate limit: 10 per 10 min
+	// IP rate limit: 30 per 10 min. Each StartLogin call counts toward this
+	// quota — even if the challenge/OTP is reused for the same email — so a
+	// client cannot fan out email sends without bound.
 	if clientIP != "" && !mockBypass {
 		ipKey := "auth:login:start:email:ip:" + clientIP
-		if resp := checkIPRateLimit(ctx, ipKey, 10, 10*time.Minute, "too many requests from this IP"); resp != nil {
+		if resp := checkIPRateLimit(ctx, ipKey, 30, 10*time.Minute, "too many requests from this IP"); resp != nil {
 			return &auth.StartLoginResp{BaseResp: resp}, nil
 		}
 	}
 
-	// Generate challenge_id and OTP
-	challengeID := "ch_" + uuid.New().String()
-	otpCode, err := generateOTP()
-	if err != nil {
-		return &auth.StartLoginResp{
-			BaseResp: &base.BaseResp{Code: 500, Msg: "failed to generate OTP"},
-		}, nil
+	// Within the 10-minute challenge validity window, repeated StartLogin for
+	// the same email must return the same challenge_id and the same OTP. This
+	// prevents agents from mixing up round-trips (verifying a stale code
+	// against a freshly issued challenge).
+	activeKey := "auth:login:email:active:" + emailHash
+	var challengeID string
+	var otpCode string
+	var expireAt int64
+
+	if val, gerr := mq.RDB.Get(ctx, activeKey).Result(); gerr == nil && val != "" {
+		if sep := strings.IndexByte(val, ':'); sep > 0 {
+			cachedID := val[:sep]
+			cachedOTP := val[sep+1:]
+			if existing, cerr := dal.GetChallenge(db.DB, cachedID); cerr == nil &&
+				existing != nil && existing.Status == 0 &&
+				existing.ExpireAt > time.Now().UnixMilli() {
+				challengeID = cachedID
+				otpCode = cachedOTP
+				expireAt = existing.ExpireAt
+			}
+		}
 	}
 
-	codeHash := sha256Hex(otpCode)
+	if challengeID == "" {
+		newID := "ch_" + uuid.New().String()
+		newOTP, gerr := generateOTP()
+		if gerr != nil {
+			return &auth.StartLoginResp{
+				BaseResp: &base.BaseResp{Code: 500, Msg: "failed to generate OTP"},
+			}, nil
+		}
 
-	now := time.Now().UnixMilli()
-	expireAt := now + 600_000 // 10 minutes in ms
+		now := time.Now().UnixMilli()
+		newExpireAt := now + 600_000 // 10 minutes in ms
 
-	emailVal := normalizedEmail
-	challenge := &dal.AuthEmailChallenge{
-		ChallengeID:  challengeID,
-		LoginMethod:  req.LoginMethod,
-		Email:        &emailVal,
-		CodeHash:     codeHash,
-		Status:       0,
-		AttemptCount: 0,
-		MaxAttempts:  5,
-		ExpireAt:     expireAt,
-		CreatedAt:    now,
-		ClientIP:     req.ClientIp,
-		UserAgent:    req.UserAgent,
+		emailVal := normalizedEmail
+		challenge := &dal.AuthEmailChallenge{
+			ChallengeID:  newID,
+			LoginMethod:  req.LoginMethod,
+			Email:        &emailVal,
+			CodeHash:     sha256Hex(newOTP),
+			Status:       0,
+			AttemptCount: 0,
+			MaxAttempts:  5,
+			ExpireAt:     newExpireAt,
+			CreatedAt:    now,
+			ClientIP:     req.ClientIp,
+			UserAgent:    req.UserAgent,
+		}
+
+		if cerr := dal.CreateChallenge(db.DB, challenge); cerr != nil {
+			return &auth.StartLoginResp{
+				BaseResp: &base.BaseResp{Code: 500, Msg: "failed to create challenge: " + cerr.Error()},
+			}, nil
+		}
+
+		mq.RDB.Set(ctx, activeKey, newID+":"+newOTP, 10*time.Minute)
+
+		challengeID = newID
+		otpCode = newOTP
+		expireAt = newExpireAt
 	}
 
-	if err := dal.CreateChallenge(db.DB, challenge); err != nil {
-		return &auth.StartLoginResp{
-			BaseResp: &base.BaseResp{Code: 500, Msg: "failed to create challenge: " + err.Error()},
-		}, nil
-	}
-
-	// Send email (skip for mock OTP targets).
+	// Send email on every call (skip for mock OTP targets). Reuse of the
+	// challenge does not suppress the email — the IP rate limit is the
+	// throttle.
 	if s.isMockOTPEmail(normalizedEmail) {
 		if !mockBypass {
 			logger.Ctx(ctx).Warn("mock OTP email suffix matched but client IP not in whitelist, rejecting", "emailMasked", logger.MaskEmail(normalizedEmail), "clientIP", clientIP)
@@ -318,13 +341,16 @@ func (s *AuthServiceImpl) StartLogin(ctx context.Context, req *auth.StartLoginRe
 		}
 	}
 
-	// Set email cooldown
-	mq.RDB.Set(ctx, cooldownKey, "1", 60*time.Second)
+	expiresInSec := int32((expireAt - time.Now().UnixMilli()) / 1000)
+	if expiresInSec < 0 {
+		expiresInSec = 0
+	}
+	resendAfterSec := int32(0)
 
 	return &auth.StartLoginResp{
 		ChallengeId:          &challengeID,
-		ExpiresInSec:         func() *int32 { v := int32(600); return &v }(),
-		ResendAfterSec:       func() *int32 { v := int32(60); return &v }(),
+		ExpiresInSec:         &expiresInSec,
+		ResendAfterSec:       &resendAfterSec,
 		VerificationRequired: boolPtr(true),
 		BaseResp:             &base.BaseResp{Code: 0, Msg: "success"},
 	}, nil
@@ -355,7 +381,7 @@ func (s *AuthServiceImpl) VerifyLogin(ctx context.Context, req *auth.VerifyLogin
 	if err != nil {
 		if req.ClientIp != nil && *req.ClientIp != "" {
 			ipKey := "auth:login:verify:email:ip:" + *req.ClientIp
-			if resp := checkIPRateLimit(ctx, ipKey, 30, 10*time.Minute, "too many verify attempts from this IP"); resp != nil {
+			if resp := checkIPRateLimit(ctx, ipKey, 100, 10*time.Minute, "too many verify attempts from this IP"); resp != nil {
 				return &auth.VerifyLoginResp{BaseResp: resp}, nil
 			}
 		}
@@ -373,10 +399,10 @@ func (s *AuthServiceImpl) VerifyLogin(ctx context.Context, req *auth.VerifyLogin
 		challengeEmail = *challenge.Email
 	}
 
-	// IP rate limit: 30 per 10 min, unless the request is using mock email+IP allowlist.
+	// IP rate limit: 100 per 10 min, unless the request is using mock email+IP allowlist.
 	if clientIP != "" && !s.isMockOTPBypass(challengeEmail, clientIP) {
 		ipKey := "auth:login:verify:email:ip:" + clientIP
-		if resp := checkIPRateLimit(ctx, ipKey, 30, 10*time.Minute, "too many verify attempts from this IP"); resp != nil {
+		if resp := checkIPRateLimit(ctx, ipKey, 100, 10*time.Minute, "too many verify attempts from this IP"); resp != nil {
 			return &auth.VerifyLoginResp{BaseResp: resp}, nil
 		}
 	}

--- a/tests/auth/auth_test.go
+++ b/tests/auth/auth_test.go
@@ -72,8 +72,8 @@ func TestAuthLoginFlow(t *testing.T) {
 		"auth_new@test.com", "auth_existing@test.com",
 		"auth_wrongotp@test.com", "auth_maxattempts@test.com",
 		"auth_replay@test.com", "auth_expired@test.com",
-		"auth_case_identity@test.com", "auth_case_cooldown@test.com",
-		"auth_cooldown_ip_limit@test.com",
+		"auth_case_identity@test.com", "auth_case_reuse@test.com",
+		"auth_reuse_ip_limit@test.com",
 		"auth_mock_start_bypass@test.com", "auth_mock_verify_bypass@test.com",
 	}
 	testutil.CleanupTestEmails(t, allEmails...)
@@ -94,8 +94,8 @@ func TestAuthLoginFlow(t *testing.T) {
 			if expiresIn <= 0 {
 				t.Fatalf("expected positive expires_in_sec, got %d", expiresIn)
 			}
-			if resendAfter <= 0 {
-				t.Fatalf("expected positive resend_after_sec, got %d", resendAfter)
+			if resendAfter < 0 {
+				t.Fatalf("expected non-negative resend_after_sec, got %d", resendAfter)
 			}
 			if startData["verification_required"] != true {
 				t.Fatalf("expected verification_required=true, got %v", startData["verification_required"])
@@ -153,10 +153,6 @@ func TestAuthLoginFlow(t *testing.T) {
 		t.Cleanup(func() { testutil.CleanupTestEmails(t, email) })
 
 		testutil.LoginAndGetToken(t, email)
-		if emailVerificationEnabled {
-			h := sha256.Sum256([]byte(email))
-			testutil.GetTestRedis().Del(context.Background(), "auth:login:email:cooldown:"+hex.EncodeToString(h[:]))
-		}
 
 		token, _, isNew := testutil.LoginAndGetToken(t, email)
 		if isNew {
@@ -191,11 +187,6 @@ func TestAuthLoginFlow(t *testing.T) {
 			t.Fatal("expected first login to create new agent")
 		}
 
-		if emailVerificationEnabled {
-			h := sha256.Sum256([]byte(emailLower))
-			testutil.GetTestRedis().Del(context.Background(), "auth:login:email:cooldown:"+hex.EncodeToString(h[:]))
-		}
-
 		startB := testutil.LoginStart(t, emailLower)
 		dataB := startB
 		if _, ok := startB["access_token"].(string); !ok || startB["access_token"].(string) == "" {
@@ -215,9 +206,9 @@ func TestAuthLoginFlow(t *testing.T) {
 		}
 	})
 
-	t.Run("EmailNormalization_CooldownCaseInsensitive", func(t *testing.T) {
-		emailLower := "auth_case_cooldown@test.com"
-		emailUpper := "AUTH_CASE_COOLDOWN@TEST.COM"
+	t.Run("EmailNormalization_ReuseCaseInsensitive", func(t *testing.T) {
+		emailLower := "auth_case_reuse@test.com"
+		emailUpper := "AUTH_CASE_REUSE@TEST.COM"
 		t.Cleanup(func() { testutil.CleanupTestEmails(t, emailLower, emailUpper) })
 
 		resp1 := testutil.LoginStartRaw(t, map[string]string{
@@ -232,30 +223,36 @@ func TestAuthLoginFlow(t *testing.T) {
 			"login_method": "email",
 			"email":        emailLower,
 		})
-		if emailVerificationEnabled {
-			if int(resp2["code"].(float64)) != 429 {
-				t.Fatalf("expected case-insensitive cooldown hit (429), got code=%v msg=%v", resp2["code"], resp2["msg"])
-			}
-		} else {
-			if int(resp2["code"].(float64)) != 0 {
-				t.Fatalf("expected second direct login to succeed, got code=%v msg=%v", resp2["code"], resp2["msg"])
-			}
+		if int(resp2["code"].(float64)) != 0 {
+			t.Fatalf("second login start failed: %v", resp2["msg"])
+		}
+		if !emailVerificationEnabled {
+			return
+		}
+		data1 := resp1["data"].(map[string]interface{})
+		data2 := resp2["data"].(map[string]interface{})
+		id1, _ := data1["challenge_id"].(string)
+		id2, _ := data2["challenge_id"].(string)
+		if id1 == "" || id2 == "" {
+			t.Fatalf("expected challenge_id in both responses, got %v / %v", data1["challenge_id"], data2["challenge_id"])
+		}
+		if id1 != id2 {
+			t.Fatalf("expected same challenge_id across case-insensitive retries, got %s vs %s", id1, id2)
 		}
 	})
 
 	if emailVerificationEnabled {
-		t.Run("CooldownRetries_DoNotConsumeStartIPQuota", func(t *testing.T) {
-			email := "auth_cooldown_ip_limit@test.com"
-			ip := "203.0.113.20"
+		t.Run("RepeatedStartLogin_ReusesChallengeAndOTP", func(t *testing.T) {
+			email := "auth_reuse_ip_limit@test.com"
+			ip := mockWhitelistedIP(t)
 			t.Cleanup(func() { testutil.CleanupTestEmails(t, email) })
 
 			ctx := context.Background()
 			rdb := testutil.GetTestRedis()
 			emailHash := sha256.Sum256([]byte(email))
-			cooldownKey := "auth:login:email:cooldown:" + hex.EncodeToString(emailHash[:])
-			ipKey := "auth:login:start:email:ip:" + ip
-			if err := rdb.Del(ctx, cooldownKey, ipKey).Err(); err != nil {
-				t.Fatalf("failed to reset cooldown/rate-limit keys: %v", err)
+			activeKey := "auth:login:email:active:" + hex.EncodeToString(emailHash[:])
+			if err := rdb.Del(ctx, activeKey).Err(); err != nil {
+				t.Fatalf("failed to reset active-challenge key: %v", err)
 			}
 
 			first := doPostWithIPHeader(t, "/api/v1/auth/login", map[string]string{
@@ -265,26 +262,43 @@ func TestAuthLoginFlow(t *testing.T) {
 			if int(first["code"].(float64)) != 0 {
 				t.Fatalf("first login start failed: %v", first["msg"])
 			}
+			firstData := first["data"].(map[string]interface{})
+			firstChallenge := firstData["challenge_id"].(string)
 
-			for i := 0; i < 10; i++ {
+			// Redis active-challenge key persists the plaintext OTP so repeated
+			// calls can return the same code.
+			cached, err := rdb.Get(ctx, activeKey).Result()
+			if err != nil {
+				t.Fatalf("expected active-challenge redis key after first start: %v", err)
+			}
+			if !strings.HasPrefix(cached, firstChallenge+":") {
+				t.Fatalf("expected cached value to start with %s:, got %s", firstChallenge, cached)
+			}
+			firstOTP := strings.TrimPrefix(cached, firstChallenge+":")
+			if len(firstOTP) != 6 {
+				t.Fatalf("expected 6-digit cached OTP, got %q", firstOTP)
+			}
+
+			// Repeat StartLogin: same challenge_id and same cached OTP.
+			for i := 0; i < 4; i++ {
 				resp := doPostWithIPHeader(t, "/api/v1/auth/login", map[string]string{
 					"login_method": "email",
 					"email":        email,
 				}, ip)
-				if int(resp["code"].(float64)) != 429 {
-					t.Fatalf("expected cooldown response on retry %d, got code=%v msg=%v", i+1, resp["code"], resp["msg"])
+				if int(resp["code"].(float64)) != 0 {
+					t.Fatalf("expected reused challenge on retry %d, got code=%v msg=%v", i+1, resp["code"], resp["msg"])
 				}
-				if msg := fmt.Sprint(resp["msg"]); msg != "too many requests, please wait before retrying" {
-					t.Fatalf("expected cooldown response on retry %d, got msg=%v", i+1, resp["msg"])
+				data := resp["data"].(map[string]interface{})
+				if id := data["challenge_id"].(string); id != firstChallenge {
+					t.Fatalf("expected reused challenge_id %s on retry %d, got %s", firstChallenge, i+1, id)
 				}
-			}
-
-			counter, err := rdb.Get(ctx, ipKey).Result()
-			if err != nil {
-				t.Fatalf("failed to read start rate limit key: %v", err)
-			}
-			if counter != "1" {
-				t.Fatalf("expected cooldown retries to leave start rate limit key at 1, got %s", counter)
+				again, gerr := rdb.Get(ctx, activeKey).Result()
+				if gerr != nil {
+					t.Fatalf("active-challenge key lost after retry %d: %v", i+1, gerr)
+				}
+				if again != cached {
+					t.Fatalf("cached (challenge_id:otp) changed between retries: before=%s after=%s", cached, again)
+				}
 			}
 		})
 
@@ -296,7 +310,7 @@ func TestAuthLoginFlow(t *testing.T) {
 			ctx := context.Background()
 			rdb := testutil.GetTestRedis()
 			key := "auth:login:start:email:ip:" + ip
-			if err := rdb.Set(ctx, key, "10", 10*time.Minute).Err(); err != nil {
+			if err := rdb.Set(ctx, key, "30", 10*time.Minute).Err(); err != nil {
 				t.Fatalf("failed to seed start rate limit key: %v", err)
 			}
 
@@ -312,8 +326,8 @@ func TestAuthLoginFlow(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read start rate limit key: %v", err)
 			}
-			if counter != "10" {
-				t.Fatalf("expected start rate limit key to remain 10, got %s", counter)
+			if counter != "30" {
+				t.Fatalf("expected start rate limit key to remain 30, got %s", counter)
 			}
 		})
 
@@ -372,7 +386,7 @@ func TestAuthLoginFlow(t *testing.T) {
 			ctx := context.Background()
 			rdb := testutil.GetTestRedis()
 			key := "auth:login:verify:email:ip:" + ip
-			if err := rdb.Set(ctx, key, "30", 10*time.Minute).Err(); err != nil {
+			if err := rdb.Set(ctx, key, "100", 10*time.Minute).Err(); err != nil {
 				t.Fatalf("failed to seed verify rate limit key: %v", err)
 			}
 
@@ -389,8 +403,8 @@ func TestAuthLoginFlow(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read verify rate limit key: %v", err)
 			}
-			if counter != "30" {
-				t.Fatalf("expected verify rate limit key to remain 30, got %s", counter)
+			if counter != "100" {
+				t.Fatalf("expected verify rate limit key to remain 100, got %s", counter)
 			}
 		})
 
@@ -687,10 +701,6 @@ func verifyProfileCompletedAtAfterRelogin(t *testing.T, email string) (interface
 
 func reloginAndVerify(t *testing.T, email string) map[string]interface{} {
 	t.Helper()
-	if config.Load().EnableEmailVerification {
-		h := sha256.Sum256([]byte(email))
-		testutil.GetTestRedis().Del(context.Background(), "auth:login:email:cooldown:"+hex.EncodeToString(h[:]))
-	}
 	startData := testutil.LoginStart(t, email)
 	if token, ok := startData["access_token"].(string); ok && token != "" {
 		return startData

--- a/tests/testutil/auth.go
+++ b/tests/testutil/auth.go
@@ -80,7 +80,7 @@ func LoginAndGetToken(t *testing.T, email string) (token string, agentID int64, 
 		data["is_new_agent"].(bool)
 }
 
-// CleanupTestEmails cleans up all DB records and Redis rate-limit/cooldown keys
+// CleanupTestEmails cleans up all DB records and Redis rate-limit keys
 // for the given emails.
 func CleanupTestEmails(t *testing.T, emails ...string) {
 	t.Helper()
@@ -101,7 +101,7 @@ func CleanupTestEmails(t *testing.T, emails ...string) {
 
 		h := sha256.Sum256([]byte(email))
 		emailHash := hex.EncodeToString(h[:])
-		rdb.Del(ctx, "auth:login:email:cooldown:"+emailHash)
+		rdb.Del(ctx, "auth:login:email:active:"+emailHash)
 	}
 
 	for _, ip := range []string{"127.0.0.1", "::1", "[::1]"} {


### PR DESCRIPTION
## Summary
- 10 分钟有效期内，同一邮箱重复 `StartLogin` 返回同一 `challenge_id` 并复用同一 OTP，避免 Agent 拿上一轮验证码校验这一轮登录
- 每次 `StartLogin` 仍然发送邮件并计入 IP 限流；移除原 60 s 邮件冷却（由复用 + IP 限流取代）
- IP 限流：`StartLogin` 10→30 次/10 分钟；`VerifyLogin` 30→100 次/10 分钟
- 实现：Redis `auth:login:email:active:<emailHash>` 保存 `challenge_id:otp`，TTL 10 分钟；命中且对应 DB challenge 未消费/过期时复用

## Test plan
- [x] `go test -v ./rpc/auth/...`
- [x] `./tests/run.sh --skip-start auth`（`ENABLE_EMAIL_VERIFICATION=true` 与 `false` 两种模式下均通过）
- [x] 新增 `RepeatedStartLogin_ReusesChallengeAndOTP` 用例验证 challenge_id 与 Redis 缓存 OTP 不变