### PR TITLE
feat(feed): expose original url in feed response

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1346,6 +1346,9 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "integer"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },
@@ -1530,25 +1533,17 @@ const docTemplate = `{
                 }
             }
         }
-    },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "Enter your access token, e.g. \"at_e489...\"",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        }
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
+	Version:          "",
 	Host:             "",
-	BasePath:         "/",
+	BasePath:         "",
 	Schemes:          []string{},
-	Title:            "eigenflux_server API",
-	Description:      "EigenFlux Information Distribution Platform API",
+	Title:            "",
+	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1533,17 +1533,25 @@ const docTemplate = `{
                 }
             }
         }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "description": "Enter your access token, e.g. \"at_e489...\"",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "",
+	Version:          "1.0",
 	Host:             "",
-	BasePath:         "",
+	BasePath:         "/",
 	Schemes:          []string{},
-	Title:            "",
-	Description:      "",
+	Title:            "eigenflux_server API",
+	Description:      "EigenFlux Information Distribution Platform API",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -1,12 +1,8 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "EigenFlux Information Distribution Platform API",
-        "title": "eigenflux_server API",
-        "contact": {},
-        "version": "1.0"
+        "contact": {}
     },
-    "basePath": "/",
     "paths": {
         "/api/v1/agents/items": {
             "get": {
@@ -1339,6 +1335,9 @@
                 },
                 "updated_at": {
                     "type": "integer"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },
@@ -1522,14 +1521,6 @@
                     "type": "string"
                 }
             }
-        }
-    },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "Enter your access token, e.g. \"at_e489...\"",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
         }
     }
 }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -1,8 +1,12 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "EigenFlux Information Distribution Platform API",
+        "title": "eigenflux_server API",
+        "contact": {},
+        "version": "1.0"
     },
+    "basePath": "/",
     "paths": {
         "/api/v1/agents/items": {
             "get": {
@@ -1521,6 +1525,14 @@
                     "type": "string"
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "description": "Enter your access token, e.g. \"at_e489...\"",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
         }
     }
 }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1,4 +1,3 @@
-basePath: /
 definitions:
   api.BaseResp:
     properties:
@@ -407,6 +406,8 @@ definitions:
         type: string
       updated_at:
         type: integer
+      url:
+        type: string
     type: object
   eigenflux_server_api_handler_gen_eigenflux_api.FeedNotification:
     properties:
@@ -527,9 +528,6 @@ definitions:
     type: object
 info:
   contact: {}
-  description: EigenFlux Information Distribution Platform API
-  title: eigenflux_server API
-  version: "1.0"
 paths:
   /api/v1/agents/items:
     get:
@@ -979,10 +977,4 @@ paths:
   /api/v1/website/stats:
     get:
       responses: {}
-securityDefinitions:
-  BearerAuth:
-    description: Enter your access token, e.g. "at_e489..."
-    in: header
-    name: Authorization
-    type: apiKey
 swagger: "2.0"

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /
 definitions:
   api.BaseResp:
     properties:
@@ -528,6 +529,9 @@ definitions:
     type: object
 info:
   contact: {}
+  description: EigenFlux Information Distribution Platform API
+  title: eigenflux_server API
+  version: "1.0"
 paths:
   /api/v1/agents/items:
     get:
@@ -977,4 +981,10 @@ paths:
   /api/v1/website/stats:
     get:
       responses: {}
+securityDefinitions:
+  BearerAuth:
+    description: Enter your access token, e.g. "at_e489..."
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -566,6 +566,9 @@ func Feed(ctx context.Context, c *app.RequestContext) {
 		if it.AuthorAgentId != nil {
 			item["author_agent_id"] = strconv.FormatInt(*it.AuthorAgentId, 10)
 		}
+		if it.RawUrl != nil && *it.RawUrl != "" {
+			item["url"] = *it.RawUrl
+		}
 		items = append(items, item)
 	}
 

--- a/api/handler_gen/eigenflux/api/response.go
+++ b/api/handler_gen/eigenflux/api/response.go
@@ -144,6 +144,7 @@ type FeedItem struct {
 	SourceType       string   `json:"source_type,omitempty"`
 	ExpectedResponse string   `json:"expected_response,omitempty"`
 	GroupID          string   `json:"group_id,omitempty"`
+	URL              string   `json:"url,omitempty"`
 	UpdatedAt        int64    `json:"updated_at"`
 }
 

--- a/docs/dev/feed_and_cache.md
+++ b/docs/dev/feed_and_cache.md
@@ -8,6 +8,7 @@ API Gateway -> FeedService -> SortService (calculates match scores, bloom filter
 - FeedService only handles content delivery; it has no notification awareness
 - On `refresh`, API Gateway directly calls NotificationService.ListPending (which aggregates milestone and system notifications), merges notifications into the HTTP response, and asynchronously calls NotificationService.AckNotifications to record deliveries
 - SortService collapses same-`group_id` candidates before thresholding so low-count feeds spend slots on distinct topics, then applies cross-request bloom-filter dedup
+- Each feed item carries `url` when the publisher supplied `raw_url` at publish time; the API gateway renames the internal `raw_url` field to `url` on the public boundary
 
 ## Impression Recording (pkg/impr)
 

--- a/idl/feed.thrift
+++ b/idl/feed.thrift
@@ -15,6 +15,7 @@ struct FeedItem {
     10: optional i64 group_id
     11: required i64 updated_at
     12: optional i64 author_agent_id
+    13: optional string raw_url
 }
 
 struct FetchFeedReq {

--- a/kitex_gen/eigenflux/feed/feed.go
+++ b/kitex_gen/eigenflux/feed/feed.go
@@ -21,6 +21,7 @@ type FeedItem struct {
 	GroupId          *int64   `thrift:"group_id,10,optional" frugal:"10,optional,i64" json:"group_id,omitempty"`
 	UpdatedAt        int64    `thrift:"updated_at,11,required" frugal:"11,required,i64" json:"updated_at"`
 	AuthorAgentId    *int64   `thrift:"author_agent_id,12,optional" frugal:"12,optional,i64" json:"author_agent_id,omitempty"`
+	RawUrl           *string  `thrift:"raw_url,13,optional" frugal:"13,optional,string" json:"raw_url,omitempty"`
 }
 
 func NewFeedItem() *FeedItem {
@@ -122,6 +123,15 @@ func (p *FeedItem) GetAuthorAgentId() (v int64) {
 	}
 	return *p.AuthorAgentId
 }
+
+var FeedItem_RawUrl_DEFAULT string
+
+func (p *FeedItem) GetRawUrl() (v string) {
+	if !p.IsSetRawUrl() {
+		return FeedItem_RawUrl_DEFAULT
+	}
+	return *p.RawUrl
+}
 func (p *FeedItem) SetItemId(val int64) {
 	p.ItemId = val
 }
@@ -157,6 +167,9 @@ func (p *FeedItem) SetUpdatedAt(val int64) {
 }
 func (p *FeedItem) SetAuthorAgentId(val *int64) {
 	p.AuthorAgentId = val
+}
+func (p *FeedItem) SetRawUrl(val *string) {
+	p.RawUrl = val
 }
 
 func (p *FeedItem) IsSetSummary() bool {
@@ -195,6 +208,10 @@ func (p *FeedItem) IsSetAuthorAgentId() bool {
 	return p.AuthorAgentId != nil
 }
 
+func (p *FeedItem) IsSetRawUrl() bool {
+	return p.RawUrl != nil
+}
+
 func (p *FeedItem) String() string {
 	if p == nil {
 		return "<nil>"
@@ -215,6 +232,7 @@ var fieldIDToName_FeedItem = map[int16]string{
 	10: "group_id",
 	11: "updated_at",
 	12: "author_agent_id",
+	13: "raw_url",
 }
 
 type FetchFeedReq struct {

--- a/kitex_gen/eigenflux/feed/k-feed.go
+++ b/kitex_gen/eigenflux/feed/k-feed.go
@@ -217,6 +217,20 @@ func (p *FeedItem) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 13:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField13(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -439,6 +453,20 @@ func (p *FeedItem) FastReadField12(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *FeedItem) FastReadField13(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.RawUrl = _field
+	return offset, nil
+}
+
 func (p *FeedItem) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -458,6 +486,7 @@ func (p *FeedItem) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
 		offset += p.fastWriteField9(buf[offset:], w)
+		offset += p.fastWriteField13(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
 	return offset
@@ -478,6 +507,7 @@ func (p *FeedItem) BLength() int {
 		l += p.field10Length()
 		l += p.field11Length()
 		l += p.field12Length()
+		l += p.field13Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -599,6 +629,15 @@ func (p *FeedItem) fastWriteField12(buf []byte, w thrift.NocopyWriter) int {
 	return offset
 }
 
+func (p *FeedItem) fastWriteField13(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetRawUrl() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 13)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.RawUrl)
+	}
+	return offset
+}
+
 func (p *FeedItem) field1Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
@@ -705,6 +744,15 @@ func (p *FeedItem) field12Length() int {
 	if p.IsSetAuthorAgentId() {
 		l += thrift.Binary.FieldBeginLength()
 		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
+func (p *FeedItem) field13Length() int {
+	l := 0
+	if p.IsSetRawUrl() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.RawUrl)
 	}
 	return l
 }

--- a/rpc/feed/handler.go
+++ b/rpc/feed/handler.go
@@ -365,7 +365,7 @@ func (s *FeedServiceImpl) handleLoadMore(ctx context.Context, agentID int64, lim
 func (s *FeedServiceImpl) buildFeedItems(groupIDs []int64, itemMap map[int64]*item.ProcessedItem) []*feed.FeedItem {
 	var feedItems []*feed.FeedItem
 
-	// Collect item IDs for batch author lookup
+	// Collect item IDs for batch raw_items lookup
 	itemIDs := make([]int64, 0, len(groupIDs))
 	for _, gid := range groupIDs {
 		if pi, ok := itemMap[gid]; ok {
@@ -373,11 +373,11 @@ func (s *FeedServiceImpl) buildFeedItems(groupIDs []int64, itemMap map[int64]*it
 		}
 	}
 
-	// Batch get author IDs
-	authorMap, err := itemDal.BatchGetRawItemAuthors(db.DB, itemIDs)
+	// Batch get author + raw_url
+	rawInfoMap, err := itemDal.BatchGetRawItemInfo(db.DB, itemIDs)
 	if err != nil {
-		logger.Default().Warn("failed to batch get authors", "err", err)
-		authorMap = make(map[int64]int64) // Continue with empty map
+		logger.Default().Warn("failed to batch get raw item info", "err", err)
+		rawInfoMap = make(map[int64]itemDal.RawItemInfo) // Continue with empty map
 	}
 
 	for _, gid := range groupIDs {
@@ -401,9 +401,13 @@ func (s *FeedServiceImpl) buildFeedItems(groupIDs []int64, itemMap map[int64]*it
 			UpdatedAt:        pi.UpdatedAt,
 		}
 
-		// Add author_agent_id if found
-		if authorID, found := authorMap[pi.ItemId]; found {
+		if info, found := rawInfoMap[pi.ItemId]; found {
+			authorID := info.AuthorAgentID
 			feedItem.AuthorAgentId = &authorID
+			if info.RawURL != "" {
+				rawURL := info.RawURL
+				feedItem.RawUrl = &rawURL
+			}
 		}
 
 		feedItems = append(feedItems, feedItem)

--- a/rpc/item/dal/db.go
+++ b/rpc/item/dal/db.go
@@ -518,19 +518,26 @@ func GetItemsByGroupID(db *gorm.DB, groupID int64) ([]*ProcessedItem, error) {
 	return items, nil
 }
 
-// BatchGetRawItemAuthors retrieves author_agent_id for multiple items
-func BatchGetRawItemAuthors(db *gorm.DB, itemIDs []int64) (map[int64]int64, error) {
+// RawItemInfo is the per-item lookup result used by Feed to enrich responses.
+type RawItemInfo struct {
+	AuthorAgentID int64
+	RawURL        string // empty string when column is NULL
+}
+
+// BatchGetRawItemInfo retrieves author_agent_id and raw_url for multiple items.
+func BatchGetRawItemInfo(db *gorm.DB, itemIDs []int64) (map[int64]RawItemInfo, error) {
 	if len(itemIDs) == 0 {
-		return make(map[int64]int64), nil
+		return make(map[int64]RawItemInfo), nil
 	}
 
 	var results []struct {
 		ItemID        int64
 		AuthorAgentID int64
+		RawURL        *string
 	}
 
 	err := db.Table("raw_items").
-		Select("item_id, author_agent_id").
+		Select("item_id, author_agent_id, raw_url").
 		Where("item_id IN ?", itemIDs).
 		Find(&results).Error
 
@@ -538,10 +545,14 @@ func BatchGetRawItemAuthors(db *gorm.DB, itemIDs []int64) (map[int64]int64, erro
 		return nil, err
 	}
 
-	authorMap := make(map[int64]int64, len(results))
+	info := make(map[int64]RawItemInfo, len(results))
 	for _, r := range results {
-		authorMap[r.ItemID] = r.AuthorAgentID
+		entry := RawItemInfo{AuthorAgentID: r.AuthorAgentID}
+		if r.RawURL != nil {
+			entry.RawURL = *r.RawURL
+		}
+		info[r.ItemID] = entry
 	}
 
-	return authorMap, nil
+	return info, nil
 }

--- a/rpc/item/dal/db.go
+++ b/rpc/item/dal/db.go
@@ -521,7 +521,7 @@ func GetItemsByGroupID(db *gorm.DB, groupID int64) ([]*ProcessedItem, error) {
 // RawItemInfo is the per-item lookup result used by Feed to enrich responses.
 type RawItemInfo struct {
 	AuthorAgentID int64
-	RawURL        string // empty string when column is NULL
+	RawURL        string // empty string when no URL was provided at publish time
 }
 
 // BatchGetRawItemInfo retrieves author_agent_id and raw_url for multiple items.
@@ -533,7 +533,7 @@ func BatchGetRawItemInfo(db *gorm.DB, itemIDs []int64) (map[int64]RawItemInfo, e
 	var results []struct {
 		ItemID        int64
 		AuthorAgentID int64
-		RawURL        *string
+		RawURL        string
 	}
 
 	err := db.Table("raw_items").
@@ -547,11 +547,10 @@ func BatchGetRawItemInfo(db *gorm.DB, itemIDs []int64) (map[int64]RawItemInfo, e
 
 	info := make(map[int64]RawItemInfo, len(results))
 	for _, r := range results {
-		entry := RawItemInfo{AuthorAgentID: r.AuthorAgentID}
-		if r.RawURL != nil {
-			entry.RawURL = *r.RawURL
+		info[r.ItemID] = RawItemInfo{
+			AuthorAgentID: r.AuthorAgentID,
+			RawURL:        r.RawURL,
 		}
-		info[r.ItemID] = entry
 	}
 
 	return info, nil

--- a/rpc/item/dal/db_test.go
+++ b/rpc/item/dal/db_test.go
@@ -1,0 +1,64 @@
+package dal
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"eigenflux_server/pkg/config"
+	"eigenflux_server/pkg/db"
+)
+
+func TestBatchGetRawItemInfo(t *testing.T) {
+	cfg := config.Load()
+
+	// Probe connectivity without calling db.Init (which calls os.Exit on failure).
+	probe, err := sql.Open("pgx", cfg.PgDSN)
+	if err != nil {
+		t.Skipf("db not available: %v", err)
+	}
+	if err := probe.Ping(); err != nil {
+		probe.Close()
+		t.Skipf("db not available: %v", err)
+	}
+	probe.Close()
+
+	db.Init(cfg.PgDSN)
+
+	authorID := int64(999900001)
+	withURLID := int64(999900100)
+	withoutURLID := int64(999900101)
+
+	db.DB.Exec("DELETE FROM raw_items WHERE item_id IN (?, ?)", withURLID, withoutURLID)
+	t.Cleanup(func() {
+		db.DB.Exec("DELETE FROM raw_items WHERE item_id IN (?, ?)", withURLID, withoutURLID)
+	})
+
+	if err := db.DB.Exec(
+		"INSERT INTO raw_items (item_id, author_agent_id, raw_content, raw_url, created_at) VALUES (?, ?, 'x', 'https://ex.test/a', extract(epoch from now())::bigint)",
+		withURLID, authorID,
+	).Error; err != nil {
+		t.Fatalf("insert with url: %v", err)
+	}
+	if err := db.DB.Exec(
+		"INSERT INTO raw_items (item_id, author_agent_id, raw_content, created_at) VALUES (?, ?, 'x', extract(epoch from now())::bigint)",
+		withoutURLID, authorID,
+	).Error; err != nil {
+		t.Fatalf("insert without url: %v", err)
+	}
+
+	got, err := BatchGetRawItemInfo(db.DB, []int64{withURLID, withoutURLID})
+	if err != nil {
+		t.Fatalf("BatchGetRawItemInfo: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[withURLID].AuthorAgentID != authorID || got[withURLID].RawURL != "https://ex.test/a" {
+		t.Errorf("with-url row wrong: %+v", got[withURLID])
+	}
+	if got[withoutURLID].AuthorAgentID != authorID || got[withoutURLID].RawURL != "" {
+		t.Errorf("without-url row wrong: %+v", got[withoutURLID])
+	}
+}

--- a/tests/e2e/feed_test.go
+++ b/tests/e2e/feed_test.go
@@ -84,15 +84,32 @@ func TestFeedProtocol(t *testing.T) {
 		return
 	}
 
-	// Collect group_ids from first fetch
+	// Collect group_ids and urls from first fetch
 	groupIDs1 := make(map[string]bool)
+	seenURLs := make(map[string]bool)
 	for _, it := range items1 {
 		item := it.(map[string]interface{})
 		if groupID, ok := item["group_id"].(string); ok && groupID != "" {
 			groupIDs1[groupID] = true
 		}
+		if u, ok := item["url"].(string); ok && u != "" {
+			seenURLs[u] = true
+		}
 	}
 	t.Logf("First fetch returned %d unique groups", len(groupIDs1))
+
+	// Verify url is propagated from raw_items.raw_url on at least one item.
+	// All test items were published with distinct https://example.com/... URLs.
+	foundExpectedURL := false
+	for _, c := range contents {
+		if seenURLs[c.url] {
+			foundExpectedURL = true
+			break
+		}
+	}
+	if !foundExpectedURL {
+		t.Errorf("feed response did not include a url matching any published raw_url; seenURLs=%v", seenURLs)
+	}
 
 	// Test 2: Load more action
 	if hasMore1 {


### PR DESCRIPTION
## Summary
- Carry `raw_items.raw_url` end-to-end through the Feed RPC and surface it as the JSON field `url` (omitted when empty) on `GET /api/v1/items/feed`.
- Internally the field stays `raw_url` (DB column, `RawItem` IDL, new field 13 on `feed.FeedItem`); the rename to `url` happens only at the public API boundary to match the existing `ItemDetail.url` convention.
- Refactors the batched `raw_items` lookup in Feed from `BatchGetRawItemAuthors` → `BatchGetRawItemInfo` so author + URL come from a single query.

## Test plan
- [x] `go build ./...`
- [x] `go test ./rpc/item/dal/... ./rpc/feed/...`
- [x] `go test -run TestFeedProtocol ./tests/e2e/` — feed items returned with `url` matching the published `raw_url`
- [x] `grep BatchGetRawItemAuthors` — no remaining references