### PR TITLE
fix(install.sh): detect Homebrew paths on macOS; drop Windows branch

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -159,6 +159,5 @@ func main() {
 
 	log.Printf("API gateway starting on %s", listenAddr)
 	log.Printf("API base URL: %s", skilldoc.BuildAPIBaseURL(publicBaseURL))
-	log.Printf("Share this with your friends: 'Read %s and help me join %s'", skilldoc.BuildSkillURL(publicBaseURL), cfg.ProjectName)
 	h.Spin()
 }

--- a/scripts/local/start_local.sh
+++ b/scripts/local/start_local.sh
@@ -207,27 +207,6 @@ wait_for_http_ready() {
   return 1
 }
 
-print_api_share_message() {
-  local log_file="$LOG_DIR/api.log"
-  local line=""
-  local retries=0
-
-  while (( retries < 10 )); do
-    if [[ -f "$log_file" ]]; then
-      line=$(grep -F "Share this with your friends:" "$log_file" | tail -n 1 || true)
-      if [[ -n "$line" ]]; then
-        break
-      fi
-    fi
-    retries=$((retries+1))
-    sleep 1
-  done
-
-  if [[ -n "$line" ]]; then
-    echo -e "${CYAN}${line}${NC}"
-  fi
-}
-
 print_service_logs() {
   local name=$1
   local log_file="$LOG_DIR/${name}.log"
@@ -397,7 +376,3 @@ else
 fi
 
 echo -e "\n${GREEN}Done!${NC} View logs with: tail -f .log/<service>.log"
-
-if wait_for_http_ready "http://127.0.0.1:${API_PORT}/skill.md" 1; then
-  print_api_share_message
-fi

--- a/static/install.sh
+++ b/static/install.sh
@@ -221,8 +221,11 @@ setup_agents() {
   # from PATH. Add the standard locations so brew-installed tools (openclaw)
   # can be detected.
   if [ "$(uname -s)" = "Darwin" ]; then
-    for brew_bin in /opt/homebrew/bin /opt/homebrew/sbin /usr/local/bin /usr/local/sbin; do
-      if [ -d "$brew_bin" ] && ! echo ":$PATH:" | grep -q ":$brew_bin:"; then
+    # Iterate from lowest to highest priority: each iteration prepends, so
+    # the last one iterated ends up at the front of PATH. This makes
+    # /opt/homebrew/bin win on Apple Silicon where both trees may exist.
+    for brew_bin in /usr/local/sbin /usr/local/bin /opt/homebrew/sbin /opt/homebrew/bin; do
+      if [ -d "$brew_bin" ] && ! echo ":$PATH:" | grep -Fq ":$brew_bin:"; then
         PATH="$brew_bin:$PATH"
       fi
     done

--- a/static/install.sh
+++ b/static/install.sh
@@ -26,8 +26,7 @@ install_cli() {
     case "$(uname -s)" in
       Linux*)  echo "linux" ;;
       Darwin*) echo "darwin" ;;
-      MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
-      *) err "Unsupported OS: $(uname -s)"; exit 1 ;;
+      *) err "Unsupported OS: $(uname -s). Windows users: use install.ps1 instead."; exit 1 ;;
     esac
   }
 
@@ -42,9 +41,6 @@ install_cli() {
   OS=$(detect_os)
   ARCH=$(detect_arch)
   BIN_NAME="eigenflux-${OS}-${ARCH}"
-  if [ "$OS" = "windows" ]; then
-    BIN_NAME="${BIN_NAME}.exe"
-  fi
 
   info "Detected: ${OS}/${ARCH}"
 
@@ -220,6 +216,19 @@ migrate_config() {
 # ── Step 4: Detect and configure AI agents ────────────────────
 
 setup_agents() {
+  # `curl | sh` runs in a non-interactive, non-login shell that does not
+  # source ~/.zshrc or ~/.zprofile, so Homebrew's bin dirs may be missing
+  # from PATH. Add the standard locations so brew-installed tools (openclaw)
+  # can be detected.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    for brew_bin in /opt/homebrew/bin /opt/homebrew/sbin /usr/local/bin /usr/local/sbin; do
+      if [ -d "$brew_bin" ] && ! echo ":$PATH:" | grep -q ":$brew_bin:"; then
+        PATH="$brew_bin:$PATH"
+      fi
+    done
+    export PATH
+  fi
+
   if command -v openclaw >/dev/null 2>&1; then
     info ""
     info "OpenClaw environment detected."


### PR DESCRIPTION
## Summary
- On macOS, \`curl -fsSL .../install.sh | sh\` runs in a non-interactive non-login shell that does not source \`~/.zshrc\`/\`~/.zprofile\`. Homebrew's bin dirs are therefore missing from PATH, which caused \`command -v openclaw\` in \`setup_agents\` to miss brew-installed \`openclaw\` on Apple Silicon. Fix by prepending \`/opt/homebrew/{bin,sbin}\` and \`/usr/local/{bin,sbin}\` to PATH on Darwin before the probe.
- Windows installation is handled by \`install.ps1\`, so the MINGW/MSYS/CYGWIN branch in \`detect_os\` and the \`.exe\` suffix logic in \`install_cli\` are removed. Unsupported-OS error now points Windows users at \`install.ps1\`.

## Test plan
- [ ] Apple Silicon macOS with brew-installed openclaw, running via \`curl | sh\` in a fresh shell: \`setup_agents\` detects openclaw and prompts/installs plugin.
- [ ] Apple Silicon macOS without openclaw: script completes without spurious errors.
- [ ] Linux with openclaw: detection path unchanged, still works.
- [ ] Running under MINGW/Cygwin: now exits with the updated message pointing to install.ps1.