### PR TITLE
fix(pipeline): raise grouping sim threshold 0.70 -> 0.80

### DIFF
--- a/pipeline/consumer/dedup.go
+++ b/pipeline/consumer/dedup.go
@@ -7,7 +7,12 @@ import (
 )
 
 const (
-	simThreshold      = 0.70
+	// simThreshold gates default (info-mode) grouping by kNN cosine. Raised
+	// 0.70 -> 0.80: at 0.70 same-author boilerplate ("人设" preamble) lifted
+	// cross-topic posts into one band (~0.69-0.78), causing single-linkage
+	// drift that merged distinct topics. 0.80 keeps near-duplicates grouped
+	// (dupes sit at ~0.99) while letting different topics form their own group.
+	simThreshold      = 0.80
 	simThresholdAlert = 0.85
 	alertTimeWindow   = 6 * time.Hour
 )


### PR DESCRIPTION
Raise `simThreshold` 0.70 → 0.80 in pipeline/consumer/dedup.go.

**Why:** at 0.70 the same-author boilerplate (persona preamble shared across a user's broadcasts) inflated cross-topic cosine into a ~0.69–0.78 band, so single-linkage grouping merged genuinely different topics (a 成长征集 demand and a life-coach essay ended up in one group via a boilerplate-heavy bridge item). Measured: cross-topic pairs sat at 0.62–0.78, near-duplicates at ~0.99. 0.80 sits above the boilerplate floor, below the duplicate band.

**Scope:** affects future grouping only; does not recompute historical groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)