### PR TITLE
dashboard(pgc): NORTH_STAR 4-section reorg + doc sync

### DIFF
--- a/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
+++ b/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
@@ -28,47 +28,59 @@
 
 ## 设计原则
 
-- **北极星优先**：核心结果仍在首屏；owner cockpit 紧跟其后，因为它回答当前行动面。
-- **不超过 25 面板**：76 面板的教训 — 面板多了没人看，等于没有 dashboard。
+- **北极星优先**：价值(信号)在首屏顶层；三护栏紧随；诊断与运维依次下沉。
+- **段落对齐 NORTH_STAR 四轴**：价值 → 护栏(覆盖·准确·速度) → 诊断(降级) → 运维(各自独立)。
+- **控制在 ~35 面板内**：76 面板的教训 — 面板多了没人看，等于没有 dashboard。
   每加一个面板要能回答"看了之后我会做什么动作"，答不上来就不加。
 - **运维放底部且可折叠**：保底但不抢焦点。
 - **标题用问题句式**：面板标题应该是"赢/输"而不是 `pgc_event_real_wins`。
 - **description 字段写操作指引**：比如"超过 2h 说明 timer 卡了"。
 
-## 面板结构（2026-06-23 版本）
+## 面板结构（2026-06-30 版本 — 对齐 `docs/NORTH_STAR.md` 四段式）
 
-### Row 1: 核心结果 — 我们离事件有多近
+布局直接镜像 NORTH_STAR：**价值(顶层) → 三护栏 → 诊断(降级) → 运维(各自独立)**。
+35 个面板对象（含 5 个 row/text 分隔）。每段一个 row 标题。
+
+### 🎯 价值(信号) — 顶层目标
 | 面板 | Prometheus 指标 | 操作含义 |
 |------|----------------|---------|
-| 事件延迟中位数 | `pgc_event_latency_median_hours` | 北极星 — 越低越好 |
-| 真实对决 | `pgc_event_meaningful_races` | 分母 — 太小说明评测无统计意义 |
-| 真实胜率 | `pgc_event_real_win_rate` | 赢的比例 |
-| 过滤配对 | `pgc_event_non_meaningful` | 模型过滤掉的不可比配对数 |
-| 赢/输 | `pgc_event_real_wins` / `pgc_event_real_losses` | 绝对数 — 赢多输少 = 健康 |
+| 信号率 (价值·顶层) | `pgc_broadcast_signal_rate` | 北极星之顶 — 广播是信号还是噪声; <85 黄 <60 红 |
+| 噪声泄漏 (按类型) | `pgc_broadcast_noise_by_type` | 哪类噪声漏过门(体育/本地琐事领头) |
+| 错分类 (域填错) | `pgc_broadcast_miscategorized` | 域被 LLM 填错的条数; 越低越好 |
+
+### 🛡️ 护栏 — 覆盖 · 准确 · 速度（三条须各自绿）
+| 面板 | 指标 | 操作含义 |
+|------|------|---------|
+| 护栏·捕获召回(管线) | `pgc_coverage_recall_pct` | 决定处理的 benchmark 项中链路成功交付比例; 低=抓取/解析坏 |
+| 护栏·忠实率(准确) | `pgc_broadcast_faithfulness_pct` | 抽样广播忠于原文比例; 目标≥90 |
+| 护栏·首源入库(速度) | `pgc_first_party_ingest_median_minutes` | 一手源发布→入库 p50 分钟; 目标≤5 |
+| 护栏·错丢真损率(门) | `pgc_discard_false_loss_rate` | 门错杀真事件比例(真·过度丢弃); 低=好 |
+| 各域捕获召回率 | `pgc_coverage_recall_by_domain` | 低域=该域付费墙/抓取坏(law) |
+| 信源可信度构成 | `pgc_broadcast_reliability_share_pct` | 按可信度标签占比(决策#3); unverified+low 升=信任风险 |
+| 护栏·低可信占比 | `pgc_broadcast_low_trust_pct` | unverified+low 信源广播占比; 低=好 |
+
+### 📉 诊断 — 对标媒体 / 首发胜率（已降级, 非北极星）
+| 面板 | 指标 | 操作含义 |
+|------|------|---------|
+| 首发判定准确率 (诚实) | `pgc_event_win_precision` | 声称的赢里真同事件比例; 真信任数 |
+| 对决胜率 (诊断) | `pgc_event_real_win_rate` | 已假设对决为真的自我打分; 非信任指标 |
+| 真实对决 | `pgc_event_meaningful_races` | 分母 — 太小则评测无统计意义 |
+| 赢/输 | `pgc_event_real_wins` / `pgc_event_real_losses` | 绝对数 |
 | 判定数据年龄 | `pgc_event_verdicts_age_seconds / 3600` | 超 2h = timer 可能卡了 |
+| 首发走势 | `pgc_event_latency_*` / `_real_win_rate` / `_win_precision` / `first_source_speed_win_share` | 准确率·抢先率·延迟时序 |
 
-### Row 2: Owner Cockpit — 现在要看哪里
+### 🔧 运维 — 系统健康（各项独立, 永不合成单一待办数）
 | 面板 | 指标 | 操作含义 |
 |------|------|---------|
-| 立即要处理几件事 | `pgc_first_source_audit_attention + pgc_source_health_canaries_failed + pgc_source_health_sla_attention + pgc_signal_latency_actionable_breaches_3h{source_tier=~"T0\|T1"}` | owner action queue |
-| 首发关注 | `pgc_first_source_audit_attention` | benchmark/secondary items needing primary-source review |
-| T0/T1 仍超时 | `pgc_signal_latency_actionable_breaches_3h{source_tier=~"T0\|T1"}` | active high-priority source latency breaches |
-| Canary 失败 | `pgc_source_health_canaries_failed` | must-have source checks failing now |
-| 源 SLA 关注 | `pgc_source_health_sla_attention` | registry-defined source-health SLA breaches |
-| Twitter runway | `pgc_twitterapi_credits_days_to_empty` | paid X/Twitter source budget runway |
-| 风险趋势 | owner-action components over time | whether active risk is improving or worsening |
-| Active source drilldown | `pgc_signal_latency_active_source_breaches_3h{kind=~"source_latency\|source_feed_lag"}` | source/stage/tier/kind for current offenders |
-
-### Row 3: 走势 — 是否在上升
-- 事件延迟 + 真实胜率双线 timeseries（`pgc_event_latency_median_hours`, `pgc_event_real_win_rate`）
-
-### Row 4: 运维保底
-| 面板 | 指标 | 操作含义 |
-|------|------|---------|
-| 近 24h 发布数 | `increase(pgc_published_total[24h])` | 为 0 = 管道挂了 |
-| 队列积压 | `pgc_queue_*` sum | 持续增长 = 某阶段卡住 |
+| 近 24h 发布数 | `pgc_items_24h{status="published"}` | 为 0 = 管道挂了 (reset-safe, 非 increase()) |
+| 队列积压 | `sum(pgc_queue_*)` | 持续增长 = 某阶段卡住 |
 | Worker 最大空闲 | `max(pgc_worker_last_run_age_seconds)` | 超 600s = worker 可能死了 |
-| 发布量趋势 | `increase(pgc_published_total[1h])` 柱状图 | 直观看吞吐节奏 |
+| Twitter / NewsAPI / ScraperAPI 用量 | `pgc_twitterapi_credits_days_to_empty` / `pgc_newsapi_tokens_pct` / `pgc_scraperapi_credits_pct` | 付费源预算跑道 |
+| 我方管线延迟 | `sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~"T0\|T1",kind="source_latency"})` | T0/T1 抓取超时(修代码); 0=健康 |
+| Canary 失败 / 源 SLA 关注 / 首发关注 | `pgc_source_health_canaries_failed` / `_sla_attention` / `pgc_first_source_audit_attention` | 各自独立的关注项 |
+| 发布量趋势 | `pgc_items_24h/24` + `pgc_items_1h` | 24h 均值线 + 实时滑窗(均 reset-safe) |
+| 各源延迟明细 | `pgc_signal_latency_active_source_breaches_3h{kind=~"source_latency\|source_feed_lag"}` | 谁在拖延迟, 按源+类型拆 |
+| 运维行动项走势 | 5 条独立分量(首发关注/T0·T1超时/Canary/关键源/源SLA) | **按 NORTH_STAR 约定不再合成"总行动数"** |
 | Pipeline 日志 | Loki `{service="pgc-pipeline"}` | 排障用 |
 
 ## 演变记录
@@ -84,7 +96,9 @@
 | 2026-06-22 `ec15eda` | 意外恢复 76 面板（误判删减为丢失） | **76** |
 | 2026-06-22 | 以确信对决胜率为北极星重建 | **24** |
 | 2026-06-23 `329b47c` | 全面迁移至模型判定 (pgc_event_*)，删除所有旧 pgc_first_source_* 面板 | **22** |
-| 2026-06-23 当前 | 加 owner cockpit，并删除低优先级延迟分布和旧坏源面板，保持 25 面板上限 | **25** |
+| 2026-06-23 | 加 owner cockpit，删除低优先级延迟分布和旧坏源面板 | **25** |
+| 2026-06-29 | 迁移至价值(信号)为顶 + 覆盖/准确/速度护栏 (北极星重定义) | ~34 |
+| 2026-06-30 当前 | 按 `NORTH_STAR.md` 四段式重排(价值→护栏→诊断→运维); 删 `风险趋势` 的合成"总行动数"线(违背"不合成"约定); 校正下方两处过时声明 | **35** |
 
 **教训**：76 面板之所以出现，是因为每次有新指标就加面板，没人问"看了会做什么"。
 回退之所以发生，是因为另一个 session 看到"面板少了"就以为是 bug。
@@ -94,7 +108,7 @@
 
 1. 先读完本文档的设计原则。
 2. 新面板必须回答"看了之后我会做什么动作"。
-3. 总面板数不超过 25。要加就先砍一个。
+3. 总面板数控制在 ~35 以内（含 row/text 分隔）。要加就先砍一个。每段对齐 NORTH_STAR 四轴, 不要把诊断/运维面板塞回价值/护栏段。
 4. 改完跑 `python3 -c "import json; json.load(open('pgc-pipeline.json'))"` 验证 JSON。
 5. 推到 main 后，SSH 到 aliapmo 执行 `cd /data/git/eigenflux && git pull && docker compose -f docker-compose.monitor.yml restart grafana`。
 6. 更新本文档的面板结构表和演变记录。
@@ -108,7 +122,7 @@
 Prometheus scrape 配置在本仓 `configs/prometheus/prometheus.yml`（job: `pgc-pipeline`，端口 9090）。
 Datasource uid `pgc-prometheus` 指向 `pgc-prometheus` Docker 容器（端口 9091）。
 
-## 已退役的指标（2026-06-23）
+## 已退役的指标
 
 以下旧 leaderboard 指标不再有 dashboard 面板消费，但 Gauge 定义仍在 `metrics.py` 中（避免 scrape error）：
 - `pgc_first_source_confident_win_rate` — 旧北极星
@@ -119,5 +133,13 @@ Datasource uid `pgc-prometheus` 指向 `pgc-prometheus` Docker 容器（端口 9
 - `pgc_first_source_lead_median_hours` / `lag_median_hours`
 - `pgc_first_source_confident_races`
 
-对应的数据源 timer（`pgc-first-source-leaderboard.timer` 和 `pgc-improvement-loop.timer`）
-已于 2026-06-23 在 prod 上 `systemctl disable --now`。
+> **2026-06-30 校正**：旧版本曾写"`pgc-first-source-leaderboard.timer` 已 disable"。
+> 这是**过时/错误**的——prod 上该 timer 仍 `enabled` + `active`（每日 10:30 CST 运行），
+> 因为 `pgc_first_source_speed_win_share`（首发走势面板 #9 的"抢先率"线）仍由
+> `refresh_first_source_leaderboard()` 从 leaderboard 报告读取。改 dashboard 前请以
+> `ssh aliap systemctl list-timers 'pgc-*'` 的实际状态为准，勿信本文档的历史断言。
+
+> **`pgc_first_source_audit_attention`（运维·首发关注）的真实数据来源**：不是独立 timer，
+> 而是 `refresh_first_source_audit_report()` **优先读每日 source-health 报告内嵌的 audit**
+> （`pgc-source-health-report.timer` 写），standalone `data/first_source_audit/` 仅作人工回放兜底。
+> 报告缺失时 attention/critical/warn 置 **NaN**（面板显示 No-data），而非 0（避免假绿）。

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1,2103 +1,2110 @@
 {
- "uid": "pgc-pipeline",
- "title": "EigenFlux — PGC 北极星: 价值(信号) ▸ 覆盖·准确·速度",
- "editable": true,
- "graphTooltip": 0,
- "refresh": "5m",
- "schemaVersion": 39,
- "time": {
-  "from": "now-2d",
-  "to": "now"
- },
- "timezone": "Asia/Shanghai",
- "templating": {
-  "list": []
- },
- "annotations": {
-  "list": []
- },
- "links": [],
- "tags": [
-  "pgc"
- ],
- "panels": [
-  {
-   "id": 1,
-   "type": "text",
-   "title": "",
-   "gridPos": {
-    "x": 0,
-    "y": 0,
-    "w": 24,
-    "h": 3
-   },
-   "options": {
-    "mode": "markdown",
-    "content": "## PGC 北极星 — 价值(信号) 为顶, 覆盖·准确·速度 为护栏\n- **信号率(价值)**: 广播的是否是对 agent 有价值的信号, 而非噪声。**顶层目标**。\n- **护栏·覆盖**: 每个领域都在广播(无整域盲区)。\n- **护栏·准确**: 忠于原文事实, 无捏造。\n- **护栏·速度**: 事件→入库延迟(越接近T0越好)。\n- 三条护栏需各自保持绿; 顶层看价值。只测量不抑制。"
-   }
+  "uid": "pgc-pipeline",
+  "title": "EigenFlux — PGC 北极星: 价值(信号) ▸ 覆盖·准确·速度",
+  "editable": true,
+  "graphTooltip": 0,
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-2d",
+    "to": "now"
   },
-  {
-   "id": 2,
-   "type": "row",
-   "title": "🎯 北极星 — 价值(信号) ▸ 护栏: 覆盖·准确·速度",
-   "collapsed": false,
-   "gridPos": {
-    "x": 0,
-    "y": 3,
-    "w": 24,
-    "h": 1
-   },
-   "panels": []
+  "timezone": "Asia/Shanghai",
+  "templating": {
+    "list": []
   },
-  {
-   "id": 54,
-   "title": "信号率 (价值·顶层)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 4,
-    "w": 8,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_broadcast_signal_rate",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 60
-       },
-       {
-        "color": "green",
-        "value": 85
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "价值(顶层): 抽样已发布广播里, 经模型判定是'对陌生AI agent有价值的信号'(非体育/人情/本地琐事/梗/吹捧噪声)的比例。这是北极星的顶——覆盖/准确/速度只是护栏。只测量不抑制(PGC保持广播+接收方过滤)。<85%黄, <60%红。"
+  "annotations": {
+    "list": []
   },
-  {
-   "id": 55,
-   "title": "噪声泄漏 (按类型)",
-   "type": "timeseries",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 8,
-    "y": 4,
-    "w": 10,
-    "h": 5
-   },
-   "targets": [
+  "links": [],
+  "tags": [
+    "pgc"
+  ],
+  "panels": [
     {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_broadcast_noise_by_type",
-     "legendFormat": "{{noise_type}}",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "fillOpacity": 80,
-      "lineWidth": 1
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "right"
-    },
-    "tooltip": {
-     "mode": "single"
-    },
-    "orientation": "horizontal",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "values": true
-    }
-   },
-   "description": "漏过信号门被广播的噪声, 按类型。体育/本地琐事/人情是主泄漏。"
-  },
-  {
-   "id": 56,
-   "title": "错分类 (域填错)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 18,
-    "y": 4,
-    "w": 6,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_broadcast_miscategorized",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 10
-       },
-       {
-        "color": "red",
-        "value": 25
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "抽样里被判定'域明显填错'的条数(如板球比分填进新加坡, 印度地方政治填进地缘政治)。分母≈样本数(见信号率judged)。越低越好。"
-  },
-  {
-   "id": 50,
-   "title": "护栏·捕获召回(管线)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 9,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_coverage_recall_pct",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 90
-       },
-       {
-        "color": "green",
-        "value": 97
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "捕获召回(管线健康): benchmark 源里 PGC 决定处理的条目中, 链路成功交付(published+dedup)的比例; 分母只含 交付+捕获失败(error_extract/error_llm), 不含'故意丢弃'(那是实质门的判断, 不是故障)。低=抓取/解析坏了(如付费墙)。各域低=该域源付费墙(law=National Law Review 5/5 抓取失败)。门是否错丢真事件由'错丢真损率'单独衡量。"
-  },
-  {
-   "id": 52,
-   "title": "护栏·忠实率(准确)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 8,
-    "y": 9,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_broadcast_faithfulness_pct",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 70
-       },
-       {
-        "color": "green",
-        "value": 90
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "准确(忠实): 抽样已发布广播里, 经内容模型判定'忠于原文事实'的比例(每条的实体/数字/论断都有原文支撑; 无捏造/夸大/推断当事实)。主要失实类型=捏造+数字错误(见诊断区分解)。这才是你说的'准确'(不是首发判定准确率)。注: 这是~130条抽样的LLM判定, 有抽样误差; 目标≥90%, <70%红。"
-  },
-  {
-   "id": 51,
-   "title": "护栏·首源入库 (速度)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 16,
-    "y": 9,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_first_party_ingest_median_minutes",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "m",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 5
-       },
-       {
-        "color": "red",
-        "value": 30
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "速度(你的定义, 真实测量): 一手源发布→我们入库的中位分钟数(越接近T0越好)。p50≈2分钟=对典型首源很快; 慢尾(p90 见运维)多是期刊/registry回填日期或慢RSS=换源待办。替换了原先误导的 event_latency(8.7h, 基于LLM猜测的T0+取两侧min的小样本)。"
-  },
-  {
-   "id": 5,
-   "title": "真实对决（模型验证）",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 13,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_meaningful_races",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "blue",
-        "value": null
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "模型确认速度对比有意义的配对数。旧系统 76 对 → 模型过滤后仅留真正可比的。"
-  },
-  {
-   "id": 19,
-   "title": "赢 / 输",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 8,
-    "y": 13,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_real_wins",
-     "instant": true,
-     "legendFormat": "赢"
-    },
-    {
-     "refId": "B",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_real_losses",
-     "instant": true,
-     "legendFormat": "输"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "palette-classic"
-     }
-    },
-    "overrides": [
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "赢"
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 3
       },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "green"
-        }
-       }
-      ]
-     },
-     {
-      "matcher": {
-       "id": "byName",
-       "options": "输"
+      "options": {
+        "mode": "markdown",
+        "content": "## PGC 北极星 — 价值(信号) 为顶, 覆盖·准确·速度 为护栏\n**🎯 价值(顶层)**: 广播的是对陌生 AI agent 有价值的信号, 而非噪声。只测量不抑制(接收方过滤)。\n**🛡️ 三条护栏 (各自须绿)** — 覆盖: 每域有捕获、门不错杀真事件; 准确: 忠于原文、无捏造; 速度: 事件→入库越近 T0 越好。\n**📉 诊断**: 对标媒体/首发胜率 已降级 — 衡量'赢过媒体', 不是北极星。\n**🔧 运维**: 各健康项独立, 永不合成单一'待办数'。"
+      }
+    },
+    {
+      "id": 2,
+      "type": "row",
+      "title": "🎯 价值(信号) — 广播的是信号还是噪声?  [顶层目标]",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
       },
-      "properties": [
-       {
-        "id": "color",
-        "value": {
-         "mode": "fixed",
-         "fixedColor": "red"
+      "panels": [],
+      "datasource": null
+    },
+    {
+      "id": 61,
+      "type": "row",
+      "title": "🛡️ 护栏 — 覆盖 · 准确 · 速度 (三条须各自保持绿)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "panels": [],
+      "datasource": null
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "📉 诊断 — 对标媒体 / 首发胜率 (已降级, 非北极星)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": [],
+      "datasource": null
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "🔧 运维 — 系统健康 (各项独立, 不合成单一待办数)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "panels": [],
+      "datasource": null
+    },
+    {
+      "id": 54,
+      "title": "信号率 (价值·顶层)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_broadcast_signal_rate",
+          "instant": true
         }
-       }
-      ]
-     }
-    ]
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "价值(顶层): 抽样已发布广播里, 经模型判定是'对陌生AI agent有价值的信号'(非体育/人情/本地琐事/梗/吹捧噪声)的比例。这是北极星的顶——覆盖/准确/速度只是护栏。只测量不抑制(PGC保持广播+接收方过滤)。<85%黄, <60%红。"
     },
-    "orientation": "horizontal",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "none",
-    "justifyMode": "auto"
-   },
-   "description": "真实对决中，我们抢先的次数（赢）和对照媒体更快的次数（输）。"
-  },
-  {
-   "id": 7,
-   "title": "判定数据年龄",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 16,
-    "y": 13,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
     {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_verdicts_age_seconds / 3600",
-     "instant": true
+      "id": 55,
+      "title": "噪声泄漏 (按类型)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 10,
+        "x": 8,
+        "y": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_broadcast_noise_by_type",
+          "legendFormat": "{{noise_type}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": true
+        }
+      },
+      "description": "漏过信号门被广播的噪声, 按类型。体育/本地琐事/人情是主泄漏。"
+    },
+    {
+      "id": 56,
+      "title": "错分类 (域填错)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_broadcast_miscategorized",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "抽样里被判定'域明显填错'的条数(如板球比分填进新加坡, 印度地方政治填进地缘政治)。分母≈样本数(见信号率judged)。越低越好。"
+    },
+    {
+      "id": 50,
+      "title": "护栏·捕获召回(管线)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_coverage_recall_pct",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 97
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "捕获召回(管线健康): benchmark 源里 PGC 决定处理的条目中, 链路成功交付(published+dedup)的比例; 分母只含 交付+捕获失败(error_extract/error_llm), 不含'故意丢弃'(那是实质门的判断, 不是故障)。低=抓取/解析坏了(如付费墙)。各域低=该域源付费墙(law=National Law Review 5/5 抓取失败)。门是否错丢真事件由'错丢真损率'单独衡量。"
+    },
+    {
+      "id": 52,
+      "title": "护栏·忠实率(准确)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 10
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_broadcast_faithfulness_pct",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "准确(忠实): 抽样已发布广播里, 经内容模型判定'忠于原文事实'的比例(每条的实体/数字/论断都有原文支撑; 无捏造/夸大/推断当事实)。主要失实类型=捏造+数字错误(见诊断区分解)。这才是你说的'准确'(不是首发判定准确率)。注: 这是~130条抽样的LLM判定, 有抽样误差; 目标≥90%, <70%红。"
+    },
+    {
+      "id": 51,
+      "title": "护栏·首源入库 (速度)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 10
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_first_party_ingest_median_minutes",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "速度(你的定义, 真实测量): 一手源发布→我们入库的中位分钟数(越接近T0越好)。p50≈2分钟=对典型首源很快; 慢尾(p90 见运维)多是期刊/registry回填日期或慢RSS=换源待办。替换了原先误导的 event_latency(8.7h, 基于LLM猜测的T0+取两侧min的小样本)。"
+    },
+    {
+      "id": 60,
+      "title": "护栏·错丢真损率(门)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "targets": [
+        {
+          "expr": "pgc_discard_false_loss_rate",
+          "refId": "A",
+          "legendFormat": "错丢真损%",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 8
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "实质门错丢真信号率(真·覆盖护栏): 抽样审计被丢弃的 benchmark 条目里, 有多少是'无任何已发条目覆盖'的真实事件被门错杀(排除噪声+排除被同事件他文覆盖的重复)。这是诚实的'过度丢弃'数字。低=好。当前 19.2% 偏高=门在杀真信号→Cycle2 调门。配套: 丢弃占比/捕获召回。"
+    },
+    {
+      "id": 53,
+      "title": "各域捕获召回率 (低=该域付费墙/抓取坏)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_coverage_recall_by_domain",
+          "legendFormat": "{{domain}}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        }
+      },
+      "description": "各 benchmark 域的捕获召回。低的域=该域源抓取/解析失败多(付费墙/JS)。law 低=National Law Review 全失败。"
+    },
+    {
+      "id": 59,
+      "title": "信源可信度构成 (按标签占比)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 12,
+        "y": 14
+      },
+      "targets": [
+        {
+          "expr": "pgc_broadcast_reliability_share_pct",
+          "refId": "A",
+          "legendFormat": "{{reliability}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        }
+      },
+      "description": "24h 广播按可信度标签的占比构成。high=一手官方记录, standard=专业媒体/分析, unverified=社区/未知, low=已知不可靠(仅人工覆盖). unverified+low 上升=信任风险。"
+    },
+    {
+      "id": 58,
+      "title": "护栏·低可信占比",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 14
+      },
+      "targets": [
+        {
+          "expr": "pgc_broadcast_low_trust_pct",
+          "refId": "A",
+          "legendFormat": "低可信%",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "信源可信度(决策#3): 来自 unverified+low 信源的广播占比。低=好。可信度标签按 source_class 推导(官方/监管=high, 社区/未知=unverified), 写入 EF 收到的 evidence, 让接收方据此加权。不做抑制。"
+    },
+    {
+      "id": 57,
+      "title": "首发判定准确率 (诚实)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_win_precision",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "诚实信任数: 我们声称的首发里, 经内容模型确认是真同事件的比例(确认赢/所有声称赢, 未判定算否)。远低于左边的'对决胜率'——后者已假设对决为真, 是自我打分。"
+    },
+    {
+      "id": 17,
+      "title": "对决胜率 (速度条件·诊断)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_real_win_rate",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 70
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "诊断, 非信任指标: 在已确认的真实同事件对决里我们更快的比例。它假设对决已经是真的, 所以这个比例高 ≠ '我们声称的赢都是真的'——真正的信任指标是 win_precision(确认的赢/所有声称的赢), 远低于此。"
+    },
+    {
+      "id": 5,
+      "title": "真实对决（模型验证）",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 10,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_meaningful_races",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "模型确认速度对比有意义的配对数。旧系统 76 对 → 模型过滤后仅留真正可比的。"
+    },
+    {
+      "id": 19,
+      "title": "赢 / 输",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 15,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_real_wins",
+          "instant": true,
+          "legendFormat": "赢"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_real_losses",
+          "instant": true,
+          "legendFormat": "输"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "赢"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "输"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "description": "真实对决中，我们抢先的次数（赢）和对照媒体更快的次数（输）。"
+    },
+    {
+      "id": 7,
+      "title": "判定数据年龄",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 23
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_verdicts_age_seconds / 3600",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1,
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 6
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "距上次模型判定运行的时间。每小时 systemd timer 自动执行。超过 2h 说明 timer 可能卡了。"
+    },
+    {
+      "id": 9,
+      "title": "首发: 准确率 · 抢先率 · 延迟走势",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_latency_median_hours",
+          "legendFormat": "可追延迟(h)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_latency_structural_median_hours",
+          "legendFormat": "结构延迟(h)"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_real_win_rate",
+          "legendFormat": "胜率(%)"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_first_source_speed_win_share",
+          "legendFormat": "抢先率(%)"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_event_win_precision",
+          "legendFormat": "准确率(%)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "description": "事件延迟（越低越好）和真实胜率走势。模型每 ~30 分钟重算。"
+    },
+    {
+      "id": 21,
+      "title": "近 24h 发布数",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 36
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_items_24h{status=\"published\"}",
+          "instant": true,
+          "legendFormat": "近24h发布"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 200
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "过去 24 小时推送到 EigenFlux 的内容数。为 0 说明管道挂了。 [reset-safe: pgc_items_24h, was increase(pgc_published_total) = same spike bug]"
+    },
+    {
+      "id": 22,
+      "title": "队列积压",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 36
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "sum(pgc_queue_fetched + pgc_queue_extracting + pgc_queue_extracted + pgc_queue_processing + pgc_queue_done) or vector(0)",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "当前未完成处理的内容总数。持续增长说明某阶段卡住。"
+    },
+    {
+      "id": 23,
+      "title": "Worker 最大空闲",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 36
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "max(pgc_worker_last_run_age_seconds)",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "最慢的 worker 距上次运行多久。超过 600s 可能卡住。"
+    },
+    {
+      "id": 36,
+      "type": "stat",
+      "title": "Twitter runway",
+      "description": "Estimated days until twitterapi.io credits run out at current burn.",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_twitterapi_credits_days_to_empty",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 39,
+      "type": "stat",
+      "title": "NewsAPI 用量",
+      "description": "本月 NewsAPI token 已用比例。接近 100% 会影响 NewsAPI 补源。",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_newsapi_tokens_pct",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 0,
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 40,
+      "type": "stat",
+      "title": "ScraperAPI 用量",
+      "description": "本月 ScraperAPI credits 已用比例。用于 IP 被封的信源代理抓取。",
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_scraperapi_credits_pct",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 0,
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 33,
+      "type": "stat",
+      "title": "我方管线延迟",
+      "description": "近 3h 内属于我方管线的 T0/T1 抓取超时（source_latency：我们抓到晚了，要修代码）。不含‘慢源 feed’（源自己 RSS 发得慢，是换源问题，见下方 Active source drilldown）。0 = 管线健康。",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 41
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 34,
+      "type": "stat",
+      "title": "Canary 失败",
+      "description": "Must-have source checks currently failing.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 41
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_canaries_failed",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 35,
+      "type": "stat",
+      "title": "源 SLA 关注",
+      "description": "Registry-defined source-health SLA breaches from the latest report.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 41
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_sla_attention",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 32,
+      "type": "stat",
+      "title": "首发关注",
+      "description": "Benchmark/secondary items needing primary-source coverage review.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 41
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_first_source_audit_attention",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 24,
+      "title": "发布量趋势 (条/小时)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_items_24h{status=\"published\"} / 24",
+          "legendFormat": "24h均值(条/小时)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_items_1h{status=\"published\"}",
+          "legendFormat": "实时(条/小时)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "lineInterpolation": "smooth"
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "description": "每小时发布量。24h均值线(pgc_items_24h/24)即时有历史; 实时线(pgc_items_1h, 1h滑窗)随时间累积出真实逐时趋势。两者都重置安全——已弃用 increase(pgc_published_total) 那个会因DB瞬时读0爆出~74万假尖峰的查询。"
+    },
+    {
+      "id": 38,
+      "type": "table",
+      "title": "各源延迟明细 (我方延迟 + 慢源feed)",
+      "description": "近 3h 谁在拖延迟, 按源+类型拆。kind=source_latency=我方抓晚了(修管线); kind=source_feed_lag=源自己 RSS 发得慢(换更快的源, 即‘慢源即坏源’)。慢源 feed 在这里复核, 不进上面的‘立即要处理’。",
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "sort_desc(pgc_signal_latency_active_source_breaches_3h{kind=~\"source_latency|source_feed_lag\"})",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 37,
+      "type": "timeseries",
+      "title": "运维行动项走势 (各自独立)",
+      "description": "各运维行动项随时间的独立走势(首发关注 / T0·T1 抓取超时 / Canary / 关键源 / 源SLA)。按北极星约定不再合成单一'总行动数'——每项独立看, 上升的那条就是要处理的。",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_first_source_audit_attention",
+          "instant": false,
+          "range": true,
+          "legendFormat": "首发关注"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
+          "instant": false,
+          "range": true,
+          "legendFormat": "T0/T1 active latency"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_canaries_failed",
+          "instant": false,
+          "range": true,
+          "legendFormat": "Canary"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_critical_attention",
+          "instant": false,
+          "range": true,
+          "legendFormat": "关键源关注"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_sla_attention",
+          "instant": false,
+          "range": true,
+          "legendFormat": "源 SLA"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "title": "Pipeline 日志",
+      "type": "logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{service=\"pgc-pipeline\"}",
+          "maxLines": 200
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      }
     }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "h",
-     "decimals": 1,
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 2
-       },
-       {
-        "color": "red",
-        "value": 6
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "距上次模型判定运行的时间。每小时 systemd timer 自动执行。超过 2h 说明 timer 可能卡了。"
-  },
-  {
-   "id": 9,
-   "title": "首发: 准确率 · 抢先率 · 延迟走势",
-   "type": "timeseries",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 17,
-    "w": 12,
-    "h": 8
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_latency_median_hours",
-     "legendFormat": "可追延迟(h)"
-    },
-    {
-     "refId": "B",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_latency_structural_median_hours",
-     "legendFormat": "结构延迟(h)"
-    },
-    {
-     "refId": "C",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_real_win_rate",
-     "legendFormat": "胜率(%)"
-    },
-    {
-     "refId": "D",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_first_source_speed_win_share",
-     "legendFormat": "抢先率(%)"
-    },
-    {
-     "refId": "E",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_win_precision",
-     "legendFormat": "准确率(%)"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 8,
-      "showPoints": "never",
-      "spanNulls": true
-     },
-     "color": {
-      "mode": "palette-classic"
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom"
-    },
-    "tooltip": {
-     "mode": "multi"
-    }
-   },
-   "description": "事件延迟（越低越好）和真实胜率走势。模型每 ~30 分钟重算。"
-  },
-  {
-   "id": 53,
-   "title": "各域捕获召回率 (低=该域付费墙/抓取坏)",
-   "type": "timeseries",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 12,
-    "y": 17,
-    "w": 12,
-    "h": 8
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_coverage_recall_by_domain",
-     "legendFormat": "{{domain}}",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "bars",
-      "fillOpacity": 80,
-      "lineWidth": 1
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "right"
-    },
-    "tooltip": {
-     "mode": "single"
-    },
-    "orientation": "horizontal",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": true
-    }
-   },
-   "description": "各 benchmark 域的捕获召回。低的域=该域源抓取/解析失败多(付费墙/JS)。law 低=National Law Review 全失败。"
-  },
-  {
-   "id": 20,
-   "type": "row",
-   "title": "🔧 运维 — 系统健康",
-   "collapsed": false,
-   "gridPos": {
-    "x": 0,
-    "y": 21,
-    "w": 24,
-    "h": 1
-   },
-   "panels": []
-  },
-  {
-   "id": 21,
-   "title": "近 24h 发布数",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 22,
-    "w": 4,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_items_24h{status=\"published\"}",
-     "instant": true,
-     "legendFormat": "近24h发布"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 50
-       },
-       {
-        "color": "green",
-        "value": 200
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "过去 24 小时推送到 EigenFlux 的内容数。为 0 说明管道挂了。 [reset-safe: pgc_items_24h, was increase(pgc_published_total) = same spike bug]"
-  },
-  {
-   "id": 22,
-   "title": "队列积压",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 4,
-    "y": 22,
-    "w": 4,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "sum(pgc_queue_fetched + pgc_queue_extracting + pgc_queue_extracted + pgc_queue_processing + pgc_queue_done) or vector(0)",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 100
-       },
-       {
-        "color": "red",
-        "value": 500
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "当前未完成处理的内容总数。持续增长说明某阶段卡住。"
-  },
-  {
-   "id": 23,
-   "title": "Worker 最大空闲",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 8,
-    "y": 22,
-    "w": 4,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "max(pgc_worker_last_run_age_seconds)",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "s",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 600
-       },
-       {
-        "color": "red",
-        "value": 1800
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "最慢的 worker 距上次运行多久。超过 600s 可能卡住。"
-  },
-  {
-   "id": 36,
-   "type": "stat",
-   "title": "Twitter runway",
-   "description": "Estimated days until twitterapi.io credits run out at current burn.",
-   "gridPos": {
-    "x": 12,
-    "y": 22,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_twitterapi_credits_days_to_empty",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "d",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 14
-       },
-       {
-        "color": "green",
-        "value": 30
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 39,
-   "type": "stat",
-   "title": "NewsAPI 用量",
-   "description": "本月 NewsAPI token 已用比例。接近 100% 会影响 NewsAPI 补源。",
-   "gridPos": {
-    "x": 16,
-    "y": 22,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_newsapi_tokens_pct",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "decimals": 0,
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 70
-       },
-       {
-        "color": "red",
-        "value": 90
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 40,
-   "type": "stat",
-   "title": "ScraperAPI 用量",
-   "description": "本月 ScraperAPI credits 已用比例。用于 IP 被封的信源代理抓取。",
-   "gridPos": {
-    "x": 20,
-    "y": 22,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_scraperapi_credits_pct",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "decimals": 0,
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 70
-       },
-       {
-        "color": "red",
-        "value": 90
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 24,
-   "title": "发布量趋势 (条/小时)",
-   "type": "timeseries",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 27,
-    "w": 12,
-    "h": 7
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_items_24h{status=\"published\"} / 24",
-     "legendFormat": "24h均值(条/小时)"
-    },
-    {
-     "refId": "B",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_items_1h{status=\"published\"}",
-     "legendFormat": "实时(条/小时)"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 10,
-      "showPoints": "never",
-      "spanNulls": true,
-      "lineInterpolation": "smooth"
-     },
-     "color": {
-      "mode": "palette-classic"
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom"
-    },
-    "tooltip": {
-     "mode": "multi"
-    }
-   },
-   "description": "每小时发布量。24h均值线(pgc_items_24h/24)即时有历史; 实时线(pgc_items_1h, 1h滑窗)随时间累积出真实逐时趋势。两者都重置安全——已弃用 increase(pgc_published_total) 那个会因DB瞬时读0爆出~74万假尖峰的查询。"
-  },
-  {
-   "id": 38,
-   "type": "table",
-   "title": "各源延迟明细 (我方延迟 + 慢源feed)",
-   "description": "近 3h 谁在拖延迟, 按源+类型拆。kind=source_latency=我方抓晚了(修管线); kind=source_feed_lag=源自己 RSS 发得慢(换更快的源, 即‘慢源即坏源’)。慢源 feed 在这里复核, 不进上面的‘立即要处理’。",
-   "gridPos": {
-    "x": 12,
-    "y": 27,
-    "w": 12,
-    "h": 7
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "sort_desc(pgc_signal_latency_active_source_breaches_3h{kind=~\"source_latency|source_feed_lag\"})",
-     "instant": true,
-     "format": "table"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short"
-    },
-    "overrides": []
-   },
-   "options": {
-    "showHeader": true,
-    "cellHeight": "sm",
-    "footer": {
-     "show": false,
-     "reducer": [
-      "sum"
-     ],
-     "countRows": false,
-     "fields": ""
-    }
-   }
-  },
-  {
-   "id": 25,
-   "title": "Pipeline 日志",
-   "type": "logs",
-   "datasource": {
-    "type": "loki",
-    "uid": "loki"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 34,
-    "w": 24,
-    "h": 8
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "loki",
-      "uid": "loki"
-     },
-     "expr": "{service=\"pgc-pipeline\"}",
-     "maxLines": 200
-    }
-   ],
-   "options": {
-    "showTime": true,
-    "showLabels": false,
-    "showCommonLabels": false,
-    "wrapLogMessage": true,
-    "prettifyLogMessage": true,
-    "enableLogDetails": true,
-    "sortOrder": "Descending",
-    "dedupStrategy": "none"
-   }
-  },
-  {
-   "id": 30,
-   "type": "row",
-   "title": "📉 诊断 / Deep dive",
-   "gridPos": {
-    "x": 0,
-    "y": 42,
-    "w": 24,
-    "h": 1
-   },
-   "collapsed": false
-  },
-  {
-   "id": 17,
-   "title": "对决胜率 (速度条件·诊断)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 43,
-    "w": 4,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_real_win_rate",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 50
-       },
-       {
-        "color": "green",
-        "value": 70
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "诊断, 非信任指标: 在已确认的真实同事件对决里我们更快的比例。它假设对决已经是真的, 所以这个比例高 ≠ '我们声称的赢都是真的'——真正的信任指标是 win_precision(确认的赢/所有声称的赢), 远低于此。"
-  },
-  {
-   "id": 57,
-   "title": "首发判定准确率 (诚实)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 20,
-    "y": 43,
-    "w": 4,
-    "h": 5
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_event_win_precision",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "red",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 50
-       },
-       {
-        "color": "green",
-        "value": 70
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "诚实信任数: 我们声称的首发里, 经内容模型确认是真同事件的比例(确认赢/所有声称赢, 未判定算否)。远低于左边的'对决胜率'——后者已假设对决为真, 是自我打分。"
-  },
-  {
-   "id": 32,
-   "type": "stat",
-   "title": "首发关注",
-   "description": "Benchmark/secondary items needing primary-source coverage review.",
-   "gridPos": {
-    "x": 4,
-    "y": 43,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_first_source_audit_attention",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 1
-       },
-       {
-        "color": "red",
-        "value": 5
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 33,
-   "type": "stat",
-   "title": "我方管线延迟",
-   "description": "近 3h 内属于我方管线的 T0/T1 抓取超时（source_latency：我们抓到晚了，要修代码）。不含‘慢源 feed’（源自己 RSS 发得慢，是换源问题，见下方 Active source drilldown）。0 = 管线健康。",
-   "gridPos": {
-    "x": 8,
-    "y": 43,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 1
-       },
-       {
-        "color": "red",
-        "value": 5
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 34,
-   "type": "stat",
-   "title": "Canary 失败",
-   "description": "Must-have source checks currently failing.",
-   "gridPos": {
-    "x": 12,
-    "y": 43,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_source_health_canaries_failed",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 1
-       },
-       {
-        "color": "red",
-        "value": 5
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 35,
-   "type": "stat",
-   "title": "源 SLA 关注",
-   "description": "Registry-defined source-health SLA breaches from the latest report.",
-   "gridPos": {
-    "x": 16,
-    "y": 43,
-    "w": 4,
-    "h": 5
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_source_health_sla_attention",
-     "instant": true
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 1
-       },
-       {
-        "color": "red",
-        "value": 5
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "background",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   }
-  },
-  {
-   "id": 37,
-   "type": "timeseries",
-   "title": "风险趋势",
-   "description": "Owner action count and its components over time.",
-   "gridPos": {
-    "x": 0,
-    "y": 48,
-    "w": 24,
-    "h": 7
-   },
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "targets": [
-    {
-     "refId": "A",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "(sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_critical_attention) or vector(0)) + (sum(pgc_source_health_canaries_failed) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0)) + (sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0))",
-     "instant": false,
-     "range": true,
-     "legendFormat": "总行动数"
-    },
-    {
-     "refId": "B",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_first_source_audit_attention",
-     "instant": false,
-     "range": true,
-     "legendFormat": "首发关注"
-    },
-    {
-     "refId": "C",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
-     "instant": false,
-     "range": true,
-     "legendFormat": "T0/T1 active latency"
-    },
-    {
-     "refId": "D",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_source_health_canaries_failed",
-     "instant": false,
-     "range": true,
-     "legendFormat": "Canary"
-    },
-    {
-     "refId": "E",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_source_health_critical_attention",
-     "instant": false,
-     "range": true,
-     "legendFormat": "关键源关注"
-    },
-    {
-     "refId": "F",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     },
-     "expr": "pgc_source_health_sla_attention",
-     "instant": false,
-     "range": true,
-     "legendFormat": "源 SLA"
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "short",
-     "custom": {
-      "drawStyle": "line",
-      "lineWidth": 2,
-      "fillOpacity": 8,
-      "showPoints": "never",
-      "spanNulls": true
-     },
-     "color": {
-      "mode": "palette-classic"
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom"
-    },
-    "tooltip": {
-     "mode": "multi"
-    }
-   }
-  },
-  {
-   "id": 58,
-   "title": "护栏·低可信占比",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 16,
-    "y": 9,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "expr": "pgc_broadcast_low_trust_pct",
-     "refId": "A",
-     "legendFormat": "低可信%",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     }
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 10
-       },
-       {
-        "color": "red",
-        "value": 25
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "信源可信度(决策#3): 来自 unverified+low 信源的广播占比。低=好。可信度标签按 source_class 推导(官方/监管=high, 社区/未知=unverified), 写入 EF 收到的 evidence, 让接收方据此加权。不做抑制。"
-  },
-  {
-   "id": 59,
-   "title": "信源可信度构成 (按标签占比)",
-   "type": "timeseries",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 0,
-    "y": 55,
-    "w": 12,
-    "h": 8
-   },
-   "targets": [
-    {
-     "expr": "pgc_broadcast_reliability_share_pct",
-     "refId": "A",
-     "legendFormat": "{{reliability}}",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     }
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "custom": {
-      "drawStyle": "bars",
-      "fillOpacity": 80,
-      "lineWidth": 1
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "legend": {
-     "displayMode": "list",
-     "placement": "right"
-    },
-    "tooltip": {
-     "mode": "single"
-    },
-    "orientation": "horizontal",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": true
-    }
-   },
-   "description": "24h 广播按可信度标签的占比构成。high=一手官方记录, standard=专业媒体/分析, unverified=社区/未知, low=已知不可靠(仅人工覆盖). unverified+low 上升=信任风险。"
-  },
-  {
-   "id": 60,
-   "title": "护栏·错丢真损率(门)",
-   "type": "stat",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "pgc-prometheus"
-   },
-   "gridPos": {
-    "x": 16,
-    "y": 13,
-    "w": 8,
-    "h": 4
-   },
-   "targets": [
-    {
-     "expr": "pgc_discard_false_loss_rate",
-     "refId": "A",
-     "legendFormat": "错丢真损%",
-     "datasource": {
-      "type": "prometheus",
-      "uid": "pgc-prometheus"
-     }
-    }
-   ],
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percent",
-     "mappings": [],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 8
-       },
-       {
-        "color": "red",
-        "value": 15
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "fields": "",
-     "values": false
-    },
-    "orientation": "auto",
-    "textMode": "auto",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto"
-   },
-   "description": "实质门错丢真信号率(真·覆盖护栏): 抽样审计被丢弃的 benchmark 条目里, 有多少是'无任何已发条目覆盖'的真实事件被门错杀(排除噪声+排除被同事件他文覆盖的重复)。这是诚实的'过度丢弃'数字。低=好。当前 19.2% 偏高=门在杀真信号→Cycle2 调门。配套: 丢弃占比/捕获召回。"
-  }
- ],
- "description": "北极星：事件延迟中位数 — 从事件发生到我们抓到，中间隔了多久。模型验证每对文章的真实关系。"
+  ],
+  "description": "北极星：事件延迟中位数 — 从事件发生到我们抓到，中间隔了多久。模型验证每对文章的真实关系。"
 }


### PR DESCRIPTION
Reorganizes the PGC Grafana dashboard to mirror `docs/NORTH_STAR.md` (eigenflux-pgc) four-axis shape and corrects a stale design doc.

## What
- **Layout → 4 sections**: 🎯价值(信号) apex → 🛡️护栏(覆盖·准确·速度) → 📉诊断(demoted) → 🔧运维(each standalone). Previously diagnostics interleaved into the apex row, operator tiles sat under diagnostics, and the source-reliability pair (panels 58/59) was split across the board.
- **Drop the summed "总行动数" line** in 风险趋势 — violates NORTH_STAR §OPERATOR's settled "never re-sum into one 'things to do' number". Keep the 5 independent component lines.
- **DESIGN.md**: rewritten panel table, fixed evolution log, and corrected two false claims — the leaderboard timer is enabled+active on prod (verified `systemctl list-timers`), and panel 32's audit is fed by the daily source-health embed (not orphaned). Panel budget 25→~35.

## Verification
Every panel's metric cross-checked against live `/metrics` on aliap; no dead refs, all setters wired, no panel overlaps, JSON validates.

## Deploy
After merge: `ssh aliapmo 'cd /data/git/eigenflux && git pull && docker compose -f docker-compose.monitor.yml restart grafana'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)