### PR TITLE
feat(sort): friend-feed recall lane

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,10 @@ type Config struct {
 
 	// Recall & ranking
 	MinRelevanceScore        float64 // items below this total score are dropped from feed (default 0)
+	FriendFeedEnabled        bool    // inject friends' recent broadcasts into the feed, bypassing the relevance threshold (best-effort, not guaranteed)
+	FriendFeedWindowHours    int     // how far back to pull friends' broadcasts
+	FriendFeedMaxItems       int     // cap friend items injected per feed fetch
+	FriendFeedMaxAuthors     int     // cap friends queried per feed fetch
 	KeywordRecallSize        int     // number of keyword recall candidates from ES (default 200)
 	EnableKNNRecall          bool
 	KNNRecallK               int
@@ -307,6 +311,10 @@ func Load() *Config {
 		MMRLambda:                     getEnvFloat("MMR_LAMBDA", 0.7),
 		ExplorationSlots:              getEnvInt("EXPLORATION_SLOTS", 0),
 		MinRelevanceScore:             getEnvFloat("MIN_RELEVANCE_SCORE", 0.1),
+		FriendFeedEnabled:             getEnvBool("FRIEND_FEED_ENABLED", true),
+		FriendFeedWindowHours:         getEnvInt("FRIEND_FEED_WINDOW_HOURS", 168),
+		FriendFeedMaxItems:            getEnvInt("FRIEND_FEED_MAX_ITEMS", 20),
+		FriendFeedMaxAuthors:          getEnvInt("FRIEND_FEED_MAX_AUTHORS", 50),
 		KeywordRecallSize:             getEnvInt("KEYWORD_RECALL_SIZE", 200),
 		EnableKNNRecall:               getEnvBool("ENABLE_KNN_RECALL", true),
 		KNNRecallK:                    getEnvInt("KNN_RECALL_K", 80),

--- a/pkg/recallsource/source.go
+++ b/pkg/recallsource/source.go
@@ -6,11 +6,12 @@ import "context"
 type Source uint8
 
 const (
-	Keyword  Source = 1 << iota // 0x01
-	KNN                         // 0x02
-	TwoTower                    // 0x04
-	HotRecall                   // 0x08
-	NewRecall                   // 0x10
+	Keyword   Source = 1 << iota // 0x01
+	KNN                          // 0x02
+	TwoTower                     // 0x04
+	HotRecall                    // 0x08
+	NewRecall                    // 0x10
+	Friend                       // 0x20
 )
 
 func (s Source) Has(flag Source) bool    { return s&flag != 0 }
@@ -47,6 +48,9 @@ func Names(s Source) []string {
 	}
 	if s.Has(NewRecall) {
 		names = append(names, "new_recall")
+	}
+	if s.Has(Friend) {
+		names = append(names, "friend")
 	}
 	return names
 }

--- a/rpc/sort/dal/es.go
+++ b/rpc/sort/dal/es.go
@@ -253,6 +253,71 @@ func SearchByEmbedding(ctx context.Context, embedding []float32, filters []inter
 	return items, nil
 }
 
+// FetchRecentItemsByAuthors returns recent broadcasts authored by any of authorIDs,
+// within the last windowHours, newest first, capped at limit. Used by the friend-feed
+// recall lane to surface friends' broadcasts regardless of relevance affinity.
+func FetchRecentItemsByAuthors(ctx context.Context, authorIDs []int64, windowHours, limit int) ([]Item, error) {
+	if len(authorIDs) == 0 || limit <= 0 {
+		return nil, nil
+	}
+	if windowHours <= 0 {
+		windowHours = 168
+	}
+
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"filter": []interface{}{
+					map[string]interface{}{"terms": map[string]interface{}{"author_agent_id": authorIDs}},
+					map[string]interface{}{"range": map[string]interface{}{"created_at": map[string]interface{}{"gte": fmt.Sprintf("now-%dh", windowHours)}}},
+					map[string]interface{}{"exists": map[string]interface{}{"field": "group_id"}},
+				},
+			},
+		},
+		"sort": []interface{}{
+			map[string]interface{}{"created_at": map[string]interface{}{"order": "desc"}},
+		},
+		"size": limit,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(query); err != nil {
+		return nil, fmt.Errorf("encode authors query: %w", err)
+	}
+
+	res, err := es.Client.Search(
+		es.Client.Search.WithContext(ctx),
+		es.Client.Search.WithIndex(es.ReadIndexPattern),
+		es.Client.Search.WithBody(&buf),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("execute authors search: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		return nil, fmt.Errorf("ES authors search error: %s", res.String())
+	}
+
+	parsed, err := parseSearchResponse(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]Item, 0, len(parsed.Hits.Hits))
+	for _, hit := range parsed.Hits.Hits {
+		item := hit.Source
+		if hit.ID != "" {
+			if id, parseErr := strconv.ParseInt(hit.ID, 10, 64); parseErr == nil {
+				item.ID = id
+			}
+		}
+		item.Score = hit.Score
+		items = append(items, item)
+	}
+	return items, nil
+}
+
 // FetchItemsByIDs retrieves full item documents from ES using an ids query.
 func FetchItemsByIDs(ctx context.Context, ids []int64) ([]Item, error) {
 	if len(ids) == 0 {

--- a/rpc/sort/handler.go
+++ b/rpc/sort/handler.go
@@ -473,6 +473,40 @@ func (s *SortServiceESImpl) SortItems(ctx context.Context, req *sort.SortItemsRe
 
 	esItems = applyItemRerankPolicies(ctx, esItems, sourceMap)
 
+	// Friend-feed recall lane: surface friends' recent broadcasts in the requester's
+	// feed, bypassing the relevance threshold in the split below. Group-collapse and
+	// bloom dedup still apply (so a friend post shows at most once per group), and
+	// inactive friends who never fetch are not reached — best-effort, not guaranteed.
+	if cfg.FriendFeedEnabled {
+		var friendIDs []int64
+		if err := db.DB.Table("user_relations").
+			Where("from_uid = ? AND rel_type = ?", req.AgentId, 1).
+			Limit(cfg.FriendFeedMaxAuthors).
+			Pluck("to_uid", &friendIDs).Error; err != nil {
+			logger.Ctx(ctx).Warn("friend recall: list friends failed", "err", err)
+		} else if len(friendIDs) > 0 {
+			friendItems, ferr := sortDal.FetchRecentItemsByAuthors(ctx, friendIDs, cfg.FriendFeedWindowHours, cfg.FriendFeedMaxItems)
+			if ferr != nil {
+				logger.Ctx(ctx).Warn("friend recall: fetch items failed", "err", ferr)
+			} else {
+				existing := make(map[int64]bool, len(esItems))
+				for _, it := range esItems {
+					existing[it.ID] = true
+				}
+				added := 0
+				for _, it := range friendItems {
+					sourceMap[it.ID] |= recallsource.Friend
+					if !existing[it.ID] {
+						esItems = append(esItems, it)
+						existing[it.ID] = true
+						added++
+					}
+				}
+				logger.Ctx(ctx).Info("friend recall merge", "friends", len(friendIDs), "candidates", len(friendItems), "newItems", added)
+			}
+		}
+	}
+
 	// Record recall source feed composition
 	for _, item := range esItems {
 		for _, name := range recallsource.Names(sourceMap[item.ID]) {
@@ -498,7 +532,9 @@ func (s *SortServiceESImpl) SortItems(ctx context.Context, req *sort.SortItemsRe
 	ranked := make([]ranker.RankedItem, 0, len(allRanked))
 	filteredItems := make([]ranker.RankedItem, 0)
 	for _, ri := range allRanked {
-		if ri.Score >= rankerCfg.MinRelevanceScore {
+		// Friend-feed items bypass the relevance threshold; they still pass through
+		// group-collapse (above) and bloom dedup (below).
+		if ri.Score >= rankerCfg.MinRelevanceScore || sourceMap[ri.ItemID].Has(recallsource.Friend) {
 			ranked = append(ranked, ri)
 		} else {
 			filteredItems = append(filteredItems, ri)


### PR DESCRIPTION
Best-effort friend recall lane: on each feed fetch, pull the requester's friends (`user_relations from_uid=agent, rel_type=1`), fetch their recent broadcasts from ES, inject as candidates, and **bypass the `MinRelevanceScore` threshold** so a friend's post surfaces even at low relevance affinity.

**Intentionally left untouched** (per design "只做①"): group-collapse and bloom dedup. A friend post shows at most once per group (bloom = free de-dup, no new per-recipient state); a post sharing a group with a higher-ranked item can still be collapsed. Best-effort — inactive friends who never fetch are not reached.

Behind `FRIEND_FEED_ENABLED` (default on). Tunables: `FRIEND_FEED_WINDOW_HOURS`=168, `FRIEND_FEED_MAX_ITEMS`=20, `FRIEND_FEED_MAX_AUTHORS`=50.

Compile + `go test ./pkg/recallsource/... ./pkg/config/... ./rpc/sort/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)