### PR TITLE
fix(dashboard): correct out-of-order thresholds on win_precision panel

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1733,16 +1733,16 @@
       "mode": "absolute",
       "steps": [
        {
-        "color": "green",
+        "color": "red",
         "value": null
        },
        {
         "color": "yellow",
-        "value": 40
+        "value": 25
        },
        {
-        "color": "red",
-        "value": 25
+        "color": "green",
+        "value": 40
        }
       ]
      }


### PR DESCRIPTION
## Summary
- Panel 57 (诊断·原始声明准确率 / win_precision) had threshold steps in the wrong array order: `[green@None, yellow@40, red@25]`. Every other threshold panel in this dashboard is ascending by value; this one wasn't.
- Grafana paints the color of the **last** step in array order whose value qualifies — not the highest-by-value one. So for any reading ≥25 (win_precision has sat in the 20-40% range for weeks), the panel evaluated `red@25` last and painted red regardless of the actual number.
- Found while investigating "why does this panel look red/yellow" — it's a dashboard authoring bug, not a real pipeline signal.

## Fix
Reordered to ascending value order with matching colors (red<25, yellow 25-40, green≥40) — same intended boundaries, just valid step order.

## Test plan
- [x] `python3 -c "import json; json.load(open('configs/grafana/dashboards/pgc-pipeline.json'))"` — valid JSON
- [ ] Deploy to aliapmo and visually confirm the panel now reflects its actual color at current win_precision (~41%, should show green/near-boundary)