### PR TITLE
fix(grafana): correct 各域丢弃占比 panel type (timeseries -> barchart)

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -838,7 +838,7 @@
   {
    "id": 53,
    "title": "各域丢弃占比 (高=该域多被门丢弃)",
-   "type": "timeseries",
+   "type": "barchart",
    "datasource": {
     "type": "prometheus",
     "uid": "pgc-prometheus"
@@ -865,7 +865,6 @@
     "defaults": {
      "unit": "short",
      "custom": {
-      "drawStyle": "bars",
       "fillOpacity": 80,
       "lineWidth": 1
      }


### PR DESCRIPTION
## Summary
- Panel 53 (各域丢弃占比/discard-share-by-domain) uses an instant query with `reduceOptions` + `orientation: horizontal` — those are `barchart` panel options, not understood by `timeseries` panels.
- It's the only panel in this dashboard combining an instant per-label query with `reduceOptions`, and its `type` didn't match its own `options` schema — this is the render error Pascal flagged live.
- Fix: `type: timeseries` -> `type: barchart`; dropped the now-inert `drawStyle` custom field.

## Test plan
- [x] JSON validated (`python3 -c "import json; json.load(open(...))"`)
- [ ] Pascal to review/merge, then deploy via `aliapmo` git pull + `docker compose -f docker-compose.monitor.yml restart grafana` and visually confirm the panel renders as a horizontal bar-per-domain chart