### PR TITLE
fix(grafana): NewsAPI quota panel shows each key, not the pool average

### DIFF
--- a/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
+++ b/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
@@ -77,7 +77,7 @@ eigenflux-pgc `docs/plans/2026-07-01-llm-verdict-authority.md`。
 | 队列积压 (22) | queue depth | 持续增长 = 某阶段卡住 |
 | Worker 最大空闲 (23) | worker idle | 超时 = worker 可能死了 |
 | Twitter 还能撑几天 (36) | credits runway | 付费额度预警 |
-| NewsAPI 用量 (39) / ScraperAPI 用量 (40) | api usage | 付费额度预警 |
+| NewsAPI 用量·每把 key (39) / ScraperAPI 用量 (40) | api usage | 付费额度预警。NewsAPI 按 key 分开显示(`pgc_newsapi_key_tokens_pct`,1号=主):合计口径会把单把用光的 key 平均掉(7/4 主 key 烧干时合计仍 ~40% 绿) |
 | 发布量趋势 (24) | published/h | 吞吐节奏 |
 | Pipeline 日志 (25) | Loki | 排障 |
 

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1179,8 +1179,8 @@
   {
    "id": 39,
    "type": "stat",
-   "title": "NewsAPI 用量",
-   "description": "本月 NewsAPI token 已用比例。接近 100% 会影响 NewsAPI 补源。",
+   "title": "NewsAPI 用量(每把 key)",
+   "description": "每把 NewsAPI key 本月已用比例(1号=主 key)。任何一把用光都会单独变红。以前只看全部 key 的合计,主 key 用光时面板还是绿的,这次拆开看。",
    "gridPos": {
     "x": 16,
     "y": 26,
@@ -1198,7 +1198,8 @@
       "type": "prometheus",
       "uid": "pgc-prometheus"
      },
-     "expr": "pgc_newsapi_tokens_pct",
+     "expr": "pgc_newsapi_key_tokens_pct",
+     "legendFormat": "{{key}}号key",
      "instant": true
     }
    ],
@@ -1239,7 +1240,7 @@
      "values": false
     },
     "orientation": "auto",
-    "textMode": "auto",
+    "textMode": "value_and_name",
     "colorMode": "background",
     "graphMode": "area",
     "justifyMode": "auto"


### PR DESCRIPTION
## 问题
「NewsAPI 用量」面板读 `pgc_newsapi_tokens_pct`(所有 key 合计)。合计口径永远看不见单把 key 用光:7/4 当时的主 key(免费档)烧到 2000/2000 时,面板仍显示 ~40% 绿。

## 改动
- 面板 39 改读 `pgc_newsapi_key_tokens_pct`(per-key,1号=主 key),每把 key 一个色块,任何一把用光单独变红(阈值不变 70/90)
- 标题/描述同步说人话;设计文档同步

## 现状(7/5 下午已按 Pascal 指示收口)
- 指标端 phronesis-io/eigenflux-pgc#55 已合并部署
- 不充钱的免费 key 已从生产 key 池摘除(.env 备份 aliap:/tmp/.env.bak.20260705-2),现在池子=付费主 key 一把,额度 5000,已用 21.78%
- 所以合并后面板就显示一个色块「1号key 22%」绿;以后再加 key 会自动多出一个色块,谁用光谁变红

合并本 PR 后我去 aliapmo `git pull` + restart grafana 即生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)