### PR TITLE
fix(grafana): PGC action panels count OUR latency only — feed-lag tides misread as incidents

### DIFF
--- a/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
+++ b/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
@@ -162,3 +162,12 @@ Datasource uid `pgc-prometheus` 指向 `pgc-prometheus` Docker 容器（端口 9
 - `pgc_source_health_sla_attention_source` — 原"哪些源违反 SLA"明细表
 
 `pgc_signal_latency_active_source_breaches_3h`、`pgc_source_health_sla_attention`、`pgc_source_health_canaries_failed` 仍被保留面板（风险趋势 / 信源更新是否及时 / 关键源现在挂了吗）消费，未退役。
+
+## 2026-07-06 口径修正：行动类面板只数"我们的错"
+
+宽口径（kind 含 source_feed_lag）让 33/17/37 三个行动类面板跟着新闻潮汐呼吸
+（午后/开盘 8→63，Pascal 两天内三次误读为事故）。修正：**stat/趋势类行动面板一律
+kind="source_latency"（我们的错，平时=0，非0即查）**；上游 feed 迟到的观察留在
+明细表(62, 双口径保留)与每周迟到画像（换快通道的依据，例：Bluesky-Bloomberg）。
+教训回填设计原则："看了会做什么"不仅约束加面板，也约束改口径——一个让人反复问
+"这数对吗"的面板等于坏面板。

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1446,7 +1446,7 @@
       "type": "prometheus",
       "uid": "pgc-prometheus"
      },
-     "expr": "(sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_critical_attention) or vector(0)) + (sum(pgc_source_health_canaries_failed) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0)) + (sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"}) or vector(0))",
+     "expr": "(sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_critical_attention) or vector(0)) + (sum(pgc_source_health_canaries_failed) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0)) + (sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0))",
      "instant": true
     }
    ],
@@ -1565,7 +1565,7 @@
    "id": 33,
    "type": "stat",
    "title": "活跃高优先延迟",
-   "description": "近 3h 内 T0/T1 重要源的可行动延迟：source_latency=我们抓到晚了，source_feed_lag=上游 feed 发得慢或需要换更快源。0 = 当前无高优先延迟行动项。",
+   "description": "只统计【我们自己造成】的活跃延迟(source_latency, 3h窗, T0/T1)。平时=0, 非0就查管线。上游feed迟到(别人家慢)不计入——那是随新闻潮汐呼吸的背景(午后/开盘冲到几十是常态), 看下方明细表; 慢源要不要换快通道由每周迟到画像决定(例:Bloomberg Bluesky快车道)。2026-07-06收窄:宽口径的8→63潮汐反复被误读为事故。",
    "gridPos": {
     "x": 8,
     "y": 47,
@@ -1583,7 +1583,7 @@
       "type": "prometheus",
       "uid": "pgc-prometheus"
      },
-     "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"}) or vector(0)",
+     "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
      "instant": true
     }
    ],
@@ -1719,7 +1719,7 @@
       "type": "prometheus",
       "uid": "pgc-prometheus"
      },
-     "expr": "(sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_critical_attention) or vector(0)) + (sum(pgc_source_health_canaries_failed) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0)) + (sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"}) or vector(0))",
+     "expr": "(sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_critical_attention) or vector(0)) + (sum(pgc_source_health_canaries_failed) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0)) + (sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0))",
      "instant": false,
      "range": true,
      "legendFormat": "总行动数"
@@ -1741,7 +1741,7 @@
       "type": "prometheus",
       "uid": "pgc-prometheus"
      },
-     "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"}) or vector(0)",
+     "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
      "instant": false,
      "range": true,
      "legendFormat": "高优先级延迟"


### PR DESCRIPTION
Panels 33/17/37 (all *action* panels) currently include `source_feed_lag` — upstream feeds running late — so they swing 8→63 with news tides. Live decode of today's "48": **47 upstream entries, 2 ours (one transient HF item), 0 incidents**; the only actionable slice is invisible inside the noise.

This narrows the three action panels to `kind="source_latency"` (ours; normally 0, nonzero = act). The detail table (62) keeps both kinds for diagnosis; channel-replacement decisions stay with the weekly lateness profile (which produced the Bluesky-Bloomberg fast lane).

Deploy after merge: `ssh aliapmo 'cd /data/git/eigenflux && git pull && docker compose -f docker-compose.monitor.yml restart grafana'` — I'll handle it once you approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)