### PR TITLE
feat(grafana): NewsAPI per-cluster daily burn vs enforced cap panel

### DIFF
--- a/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
+++ b/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
@@ -162,7 +162,14 @@ Datasource uid `pgc-prometheus` 指向 `pgc-prometheus` Docker 容器（端口 9
 - `pgc_broadcast_reliability_share_pct` — 原"信源可信度构成"
 - `pgc_source_health_sla_attention_source` — 原"哪些源违反 SLA"明细表
 
-`pgc_signal_latency_active_source_breaches_3h`、`pgc_source_health_sla_attention`、`pgc_source_health_canaries_failed` 仍被保留面板（风险趋势 / 信源更新是否及时 / 关键源现在挂了吗）消费，未退役。
+`pgc_signal_latency_active_source_breaches_3h`、`pgc_source_health_sla_attention`、`pgc_source_health_canaries_failed` 仍被保留面板（风险趋势 / 信源更新是否及时 / 关键源现在挂了吗）消费，未退役。`活跃高优先延迟` 和风险趋势里的同名序列统计 `source_latency` 与 `source_feed_lag`，避免上游 feed 晚到的 T0/T1 active breach 只出现在明细表、首屏 stat 却为 0。
+
+## 2026-07-07 口径修正：低延迟 owner 视图必须看见 feed-lag
+
+日检发现 7/6 收窄后，`活跃高优先延迟` 只看 `source_latency`，会把 `source_feed_lag`
+这类同样 actionable 的 T0/T1 慢源从首屏 stat 和风险趋势中藏掉。修正：面板 33 和风险
+趋势里的“高优先级延迟”序列恢复为 `source_latency|source_feed_lag`；面板 17
+`需要动手吗(火情)` 仍只看我方契约侧故障，避免把上游潮汐误报为生产事故。
 
 ## 2026-07-06 口径修正：行动类面板只数"我们的错"
 

--- a/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
+++ b/configs/grafana/dashboards/PGC_DASHBOARD_DESIGN.md
@@ -78,7 +78,8 @@ eigenflux-pgc `docs/plans/2026-07-01-llm-verdict-authority.md`。
 | Worker 最大空闲 (23) | worker idle | 超时 = worker 可能死了 |
 | Twitter 还能撑几天 (36) | credits runway | 付费额度预警 |
 | NewsAPI 用量·每把 key (39) / ScraperAPI 用量 (40) | api usage | 付费额度预警。NewsAPI 按 key 分开显示(`pgc_newsapi_key_tokens_pct`,1号=主):合计口径会把单把用光的 key 平均掉(7/4 主 key 烧干时合计仍 ~40% 绿) |
-| 发布量趋势 (24) | published/h | 吞吐节奏 |
+| NewsAPI 今天各组用了多少 (64) | `pgc_newsapi_daily_tokens` / `pgc_newsapi_daily_token_cap` | 日上限执行情况(2026-07-07 起代码强制,八组上限总和=146=月配额日均线)。顶到 100% 走平=设计行为;要行动的形态只有"某组连续多天 100%"(上限长期压量,该调上限或收窄范围) |
+| 发布量趋势 (24) | published/h | 吞吐节奏(与 64 并排,w12) |
 | Pipeline 日志 (25) | Loki | 排障 |
 
 ### Row 🏁 首发榜单 — 对外口径 · 诊断

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1640,7 +1640,7 @@
       "id": 33,
       "type": "stat",
       "title": "活跃高优先延迟",
-      "description": "只统计【我们自己造成】的活跃延迟(source_latency, 3h窗, T0/T1)。平时=0, 非0就查管线。上游feed迟到(别人家慢)不计入——那是随新闻潮汐呼吸的背景(午后/开盘冲到几十是常态), 看下方明细表; 慢源要不要换快通道由每周迟到画像决定(例:Bloomberg Bluesky快车道)。2026-07-06收窄:宽口径的8→63潮汐反复被误读为事故。",
+      "description": "统计 T0/T1 在 3h 窗口内仍活跃的 actionable 延迟(source_latency + source_feed_lag)。source_latency=我方管线慢, source_feed_lag=上游 feed 晚到但需要评估换快通道/补源。看下方明细表定位具体来源和原因。",
       "gridPos": {
         "x": 8,
         "y": 47,
@@ -1658,7 +1658,7 @@
             "type": "prometheus",
             "uid": "pgc-prometheus"
           },
-          "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
+          "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"}) or vector(0)",
           "instant": true
         }
       ],
@@ -1816,7 +1816,7 @@
             "type": "prometheus",
             "uid": "pgc-prometheus"
           },
-          "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"}) or vector(0)",
+          "expr": "sum(pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"}) or vector(0)",
           "instant": false,
           "range": true,
           "legendFormat": "高优先级延迟"

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1333,7 +1333,7 @@
       },
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "pgc-prometheus"
       },
       "targets": [
         {

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1321,6 +1321,71 @@
       }
     },
     {
+      "id": 64,
+      "type": "bargauge",
+      "title": "NewsAPI 今天各组用了多少(有硬上限)",
+      "description": "每组新闻主题今天用掉的 NewsAPI 配额,分母是这组的每日上限(2026-07-07 起代码强制:到顶当天停抓,第二天自动补上积压,所以顶到 100% 走平是设计行为,不是坏了)。八组上限加起来正好等于月度配额的日均线。组名: A央行公司事件 B科技巨头 C亚太地缘 C2全球地缘军事 D能源宏观 E医药 F创投并购 G网络安全。要担心的形态只有一种: 某组连续多天 100% —— 说明这组的量被上限长期压着,积压在滚,该给它调上限或收窄这组的抓取范围。",
+      "gridPos": {
+        "x": 0,
+        "y": 31,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "100 * pgc_newsapi_daily_tokens / (pgc_newsapi_daily_token_cap > 0)",
+          "legendFormat": "{{cluster}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 85
+              },
+              {
+                "color": "orange",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      }
+    },
+    {
       "id": 24,
       "title": "发布量趋势 (条/小时)",
       "type": "timeseries",
@@ -1329,9 +1394,9 @@
         "uid": "pgc-prometheus"
       },
       "gridPos": {
-        "x": 0,
+        "x": 12,
         "y": 31,
-        "w": 24,
+        "w": 12,
         "h": 7
       },
       "targets": [

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -134,6 +134,10 @@ def static_validate(dashboard: dict) -> list[str]:
         exprs = [target.get("expr", "") for target in panel.get("targets", []) or []]
         if not any("pgc_signal_latency_active_source_breaches_3h" in expr for expr in exprs):
             errors.append(f"panel {panel_id} must use active source latency breaches")
+        if not any("source_latency" in expr and "source_feed_lag" in expr for expr in exprs):
+            errors.append(
+                f"panel {panel_id} must count actionable source_latency/source_feed_lag rows"
+            )
 
     for panel_id in ACTIVE_SOURCE_LATENCY_PANEL_IDS:
         panel = panels_by_id.get(panel_id)


### PR DESCRIPTION
daily_token_cap is enforced in eigenflux-pgc since 2026-07-07 (caps sum
146 = the monthly budget's daily line): per-cluster burn now flat-tops at
the cap BY DESIGN. Without the cap next to the burn that flat-top is a
reading a human has to explain — 同一个数字解释第二遍=面板缺陷.

One horizontal bargauge (panel 64) in the ops row: today's burn as % of
each cluster's cap, plain-language cluster names in the description, and
the only action-worthy shape spelled out (a cluster pinned at 100% for
days = its cap is throttling real volume — retune cap or narrow the
cluster). 发布量趋势 (24) shrinks to w12 to share the row.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
