### PR TITLE
fix(tagnorm): fold separators to a space instead of stripping them

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -533,7 +533,8 @@ func GetTodayBroadcastAgg(db *gorm.DB, agentID int64, todayStartMs int64) (*Toda
 // set is its keywords ∪ domains. Beat matching is separator-agnostic (via
 // NormTagSet / tagnorm), but the readable TagSet is kept intact because the same
 // GetNetworkSignalAgg aggregate feeds user-facing surfaces (trending / feed
-// rescue DMs) that must show "ai agents", not the normalized "aiagents".
+// rescue DMs) that must show the tag as written (e.g. "ai-agents"), not its
+// match-only normalized form ("ai agents").
 
 // BeatItemTags is one item's topic tags (comma-separated columns).
 type BeatItemTags struct {

--- a/pkg/tagnorm/tagnorm.go
+++ b/pkg/tagnorm/tagnorm.go
@@ -5,30 +5,35 @@
 // terms: the item tagger emits space-separated phrases ("ai agents", "market
 // data") while the profile keyword extractor emits hyphenated compounds
 // ("ai-agents", "market-data"). Both sides are also internally inconsistent
-// (e.g. items carry "open-source" and "a-share" hyphenated). A plain
-// lowercase exact match therefore only ever fires on single-word tags, which
-// is why most multi-word beats score zero on the Coverage view.
+// (items carry "open-source" and "a-share" hyphenated). A plain lowercase exact
+// match therefore only fires on single-word tags, so most multi-word beats
+// score zero on the Coverage view.
 //
-// Stripping separators before comparing folds the ASCII separator conventions
-// (space, hyphen, underscore) onto one canonical form ("ai agents",
-// "ai-agents", "aiagents" -> "aiagents"), which maximizes recall without losing
-// the hyphenated-on-both-sides terms. It does NOT fold lexical synonyms or
-// non-ASCII separators (en-dash, NBSP, tab); those remain distinct. See the
-// beat/Coverage matching in api/dal/console.go and the ranking keyword-overlap
-// signal in rpc/sort/ranker/signals.go.
+// Normalize folds the separator conventions — hyphen, underscore and runs of
+// whitespace all collapse to a single space — so "ai agents", "ai-agents" and
+// "ai_agents" compare equal. It deliberately does NOT remove word boundaries:
+// "co op" stays distinct from "coop", and "ai infrastructure" stays distinct
+// from "infrastructure". This is the minimal folding needed to bridge the two
+// separator conventions; it does not fold lexical synonyms, abbreviations, or
+// non-ASCII separators (en-dash, NBSP). See the beat/Coverage matching in
+// api/dal/console.go and the ranking keyword-overlap signal in
+// rpc/sort/ranker/signals.go.
 package tagnorm
 
 import "strings"
 
-// sepStripper removes the separators that differ between the two vocabularies
-// (space, hyphen, underscore). A Replacer is safe for concurrent use, so the
-// per-item ranking hot path can share this single package-level instance.
-var sepStripper = strings.NewReplacer(" ", "", "-", "", "_", "")
+// sepFolder rewrites the ASCII separator characters that differ between the two
+// vocabularies (hyphen, underscore) to a plain space. A Replacer is safe for
+// concurrent use, so the per-item ranking hot path can share this single
+// package-level instance.
+var sepFolder = strings.NewReplacer("-", " ", "_", " ")
 
 // Normalize returns the canonical form of a tag for separator-agnostic
-// exact-overlap matching: lowercased, whitespace-trimmed, with spaces,
-// hyphens and underscores removed. "AI Agents", "ai-agents" and "ai_agents"
-// all normalize to "aiagents". An empty or separator-only input yields "".
+// exact-overlap matching: lowercased, with hyphens/underscores folded to spaces
+// and any run of whitespace collapsed to a single space (leading/trailing
+// removed). "AI-Agents", "ai agents" and "ai_agents" all normalize to
+// "ai agents". Word boundaries are preserved, so "co op" != "coop". An empty or
+// separator-only input yields "".
 func Normalize(s string) string {
-	return sepStripper.Replace(strings.ToLower(strings.TrimSpace(s)))
+	return strings.Join(strings.Fields(sepFolder.Replace(strings.ToLower(s))), " ")
 }

--- a/pkg/tagnorm/tagnorm_test.go
+++ b/pkg/tagnorm/tagnorm_test.go
@@ -7,15 +7,16 @@ func TestNormalize(t *testing.T) {
 		in   string
 		want string
 	}{
-		// separator convention folds onto one canonical form
-		{"ai agents", "aiagents"},
-		{"ai-agents", "aiagents"},
-		{"ai_agents", "aiagents"},
-		{"AI Agents", "aiagents"},
-		// hyphenated-on-both-sides terms still collapse consistently
-		{"e-commerce", "ecommerce"},
-		{"E-Commerce", "ecommerce"},
-		{"a-share", "ashare"},
+		// separator convention folds onto one canonical form (single space)
+		{"ai agents", "ai agents"},
+		{"ai-agents", "ai agents"},
+		{"ai_agents", "ai agents"},
+		{"AI Agents", "ai agents"},
+		{"ai   agents", "ai agents"}, // whitespace runs collapse
+		// hyphenated-on-both-sides terms fold consistently
+		{"e-commerce", "e commerce"},
+		{"E-Commerce", "e commerce"},
+		{"a-share", "a share"},
 		// single-word and edge cases
 		{"defi", "defi"},
 		{"  MCP  ", "mcp"},
@@ -31,9 +32,8 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
-// TestNormalizeFoldsConventions is the property the whole change relies on:
-// the extractor's hyphenated form and the item tagger's spaced form must land
-// on the same key.
+// The property the whole change relies on: the extractor's hyphenated form and
+// the item tagger's spaced form must land on the same key.
 func TestNormalizeFoldsConventions(t *testing.T) {
 	pairs := [][2]string{
 		{"ai-agents", "ai agents"},
@@ -44,6 +44,22 @@ func TestNormalizeFoldsConventions(t *testing.T) {
 	for _, p := range pairs {
 		if Normalize(p[0]) != Normalize(p[1]) {
 			t.Errorf("Normalize(%q)=%q != Normalize(%q)=%q", p[0], Normalize(p[0]), p[1], Normalize(p[1]))
+		}
+	}
+}
+
+// Folding is minimal: it must NOT merge across word boundaries, so genuinely
+// different concepts that differ only by the presence/absence of a boundary
+// stay distinct.
+func TestNormalizePreservesWordBoundaries(t *testing.T) {
+	distinct := [][2]string{
+		{"co op", "coop"},
+		{"ai infrastructure", "infrastructure"},
+		{"e commerce", "ecommerce"},
+	}
+	for _, p := range distinct {
+		if Normalize(p[0]) == Normalize(p[1]) {
+			t.Errorf("Normalize(%q) and Normalize(%q) should differ, both=%q", p[0], p[1], Normalize(p[0]))
 		}
 	}
 }

--- a/rpc/sort/ranker/signals_test.go
+++ b/rpc/sort/ranker/signals_test.go
@@ -124,8 +124,8 @@ func TestKeywordOverlap_SeparatorAgnostic(t *testing.T) {
 }
 
 // An item carrying both separator variants of the same tag ("ai agents" and
-// "ai-agents" both normalize to "aiagents") must count once, not twice, so the
-// overlap ratio stays 1/2 (aiagents, blockchain) rather than being skewed.
+// "ai-agents" both normalize to "ai agents") must count once, not twice, so the
+// overlap ratio stays 1/2 ("ai agents", blockchain) rather than being skewed.
 func TestKeywordOverlap_DedupsItemVariants(t *testing.T) {
 	ps := buildProfileSets(&UserProfile{Keywords: []string{"ai-agents"}})
 	score := keywordOverlap(ps, []string{"ai agents", "ai-agents", "blockchain"}, nil)


### PR DESCRIPTION
## 背景

`tagnorm.Normalize` 之前**去掉所有分隔符**(空格/连字符/下划线),这也把「有无词边界」抹平了:`co op`==`coop`、`e commerce`==`ecommerce`、`ai infrastructure` 仍安全但 `co op`/`coop` 这类会误并。原始问题只是「空格 vs 连字符」,全删是过度归一。

## 改动

`Normalize` 改为**最小折叠**:hyphen/underscore/连续空白 → 单个空格。
- `ai-agents` 仍匹配 `ai agents` ✅
- `co op` 与 `coop` 保持不同 ✅、`ai infrastructure` 与 `infrastructure` 保持不同 ✅

## 数据佐证(7天 prod)

| 规则 | 命中(共2666) |
|---|---|
| 精确 | 608 (23%) |
| **最小(本PR)** | **1331 (50.0%)** |
| 全删(改前) | 1345 (50.5%) |

只差 14 词(0.5%),却换来语义安全。彻底消除评审 ISSUE-12(过度合并)。

## 影响
- 只改 `Normalize` 实现 + 其单测;上层 beat/排序/去重逻辑与测试不变(断言的是 hyphen↔space 等价,仍成立)。
- `go build ./...` ✅、`go test ./pkg/tagnorm/... ./rpc/sort/ranker/...` ✅、集成测试编译 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)