### PR TITLE
chore(cli): bump CLI_VERSION to 0.0.21

### DIFF
--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,7 +3,7 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.20
+CLI_VERSION=0.0.21
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients


### PR DESCRIPTION
Release the five-part onboarding bio format in the daily refresh prompt (PR #70, buildRefreshPrompt) as CLI 0.0.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)