### PR TITLE
ci: add Release Skills workflow (publish skills to R2)

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -1,0 +1,75 @@
+name: Release Skills
+
+# Publishes the EigenFlux skills bundle to Cloudflare R2 (skills/latest + cli/latest)
+# WITHOUT a CLI binary release — the CI equivalent of running
+# cli/scripts/release-skills.sh locally. Clients pick up the change on their next
+# `skills sync` by comparing the manifest content-hash `revision`.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions):
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY  (a scoped R2 API token, Object R/W on the bucket)
+#   R2_ENDPOINT, R2_BUCKET, R2_PUBLIC_URL   (non-secret account values; kept as secrets for simplicity)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'                    # the skills source of truth
+      - 'cli/internal/skills/types.go' # ProdAllowlist — which skills get packaged
+      - 'cli/.cli.config'              # SKILLS_MIN_CLI_VERSION / SKILLS_REVISION
+  workflow_dispatch:                   # manual "Run workflow" button
+
+permissions:
+  contents: read
+
+# One publish at a time — the job overwrites the same skills/latest objects.
+concurrency:
+  group: release-skills
+  cancel-in-progress: false
+
+jobs:
+  release-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      # release-skills.sh calls `gtar`; on Ubuntu the default `tar` IS GNU tar.
+      - name: Provide gtar
+        run: sudo ln -sf "$(command -v tar)" /usr/local/bin/gtar
+
+      - name: Verify toolchain (gtar / aws / shasum / go)
+        run: |
+          gtar --version | head -1
+          aws --version
+          shasum -a 256 /dev/null >/dev/null && echo "shasum: ok"
+          go version
+
+      - name: Publish skills to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+        run: bash cli/scripts/release-skills.sh
+
+      - name: Summarize published revision
+        if: always()
+        env:
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+        run: |
+          if [ -f build/cli/manifest.json ]; then
+            rev=$(grep -o '"revision"[^,]*' build/cli/manifest.json | head -1)
+            echo "### Skills published" >> "$GITHUB_STEP_SUMMARY"
+            echo "- built manifest: \`${rev}\`" >> "$GITHUB_STEP_SUMMARY"
+            live=$(curl -fsS "${R2_PUBLIC_URL}/skills/latest/manifest.json" | grep -o '"revision"[^,]*' | head -1 || echo "unavailable")
+            echo "- live on R2: \`${live}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No manifest built — publish step did not reach the build stage." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## 目的
让「只发 skills」不再依赖任何人本地持有 R2 凭证/工具链。合并到 main 触碰 `skills/**` 时(或手动 Run workflow),CI 跑 `cli/scripts/release-skills.sh` 把 skills bundle 传到 R2 `skills/latest/` + `cli/latest/`,客户端下次 `skills sync` 自动拉。

## 触发
- push 到 `main` 且改动 `skills/**` / `cli/internal/skills/types.go`(allowlist) / `cli/.cli.config`
- 手动 `workflow_dispatch`

## CI 环境如何复刻本地脚本
- Go 1.25(`go-version-file: cli/go.mod`)→ `go run ./cmd/manifestgen`
- `gtar`:软链 ubuntu 自带的 GNU `tar`
- `aws` / `shasum`:runner 自带
- 无 mise → 脚本回退用纯 `go`;`.cli.env` 缺席 → 用 env 注入 R2_* (脚本本就支持)

## 上线前你需要做(一次性)
1. **Cloudflare** 建一个 R2 API Token(Object Read & Write,作用域 `eigenflux-releases`)
2. **repo Settings → Secrets and variables → Actions** 加 5 个 secret:
   `R2_ACCESS_KEY_ID` `R2_SECRET_ACCESS_KEY` `R2_ENDPOINT` `R2_BUCKET` `R2_PUBLIC_URL`
3. 合并本 PR → 到 Actions 里手动 Run 一次验证(末尾会在 job summary 打印 revision + 线上 manifest 对比)

> 建议先加 secrets 再合并/触发,否则首次运行会因缺凭证失败(仅红叉,无副作用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)