### PR TITLE
feat(skills): CLI heartbeat skills auto-refresh (once/day)

### DIFF
--- a/cli/cmd/doctor.go
+++ b/cli/cmd/doctor.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
+	"cli.eigenflux.ai/internal/config"
 	"cli.eigenflux.ai/internal/output"
 	"cli.eigenflux.ai/internal/skills"
 	"github.com/spf13/cobra"
@@ -18,7 +20,16 @@ type doctorReport struct {
 	Writable      bool                `json:"writable"`
 	Stale         bool                `json:"stale"`
 	Skills        []skills.LocalSkill `json:"skills"`
+	AutoSync      autoSyncStatus      `json:"auto_sync"`
 	Hint          string              `json:"hint,omitempty"`
+}
+
+// autoSyncStatus surfaces the last background (heartbeat) skills refresh so ops
+// can confirm the once/day auto-sync is actually firing.
+type autoSyncStatus struct {
+	LastAttemptUnix int64  `json:"last_attempt_unix"`
+	LastResult      string `json:"last_result,omitempty"`
+	LastRevision    string `json:"last_revision,omitempty"`
 }
 
 var doctorCmd = &cobra.Command{
@@ -45,6 +56,13 @@ silently corrupted or hand-modified.`,
 		rep.Writable = isWritableDir(dir)
 		if err == nil {
 			rep.Stale = skillsStale(dir)
+		}
+		if st := skills.LoadAutoSyncState(config.HomeDir()); st.LastAttemptUnix > 0 {
+			rep.AutoSync = autoSyncStatus{
+				LastAttemptUnix: st.LastAttemptUnix,
+				LastResult:      st.LastResult,
+				LastRevision:    st.LastRevision,
+			}
 		}
 		if rep.Outdated {
 			rep.Hint = "the CLI binary is out of date — upgrade it: curl -fsSL https://www.eigenflux.ai/install.sh | sh (skills update independently via 'eigenflux skills sync')"
@@ -84,6 +102,12 @@ func printDoctorTable(rep doctorReport) {
 	}
 	fmt.Println()
 	fmt.Printf("Skills dir: %s (host=%s, writable=%t, stale=%t)\n", rep.SkillsDir, rep.HostDetected, rep.Writable, rep.Stale)
+	if rep.AutoSync.LastAttemptUnix > 0 {
+		fmt.Printf("Auto-sync:  last %s (result=%s)\n",
+			time.Unix(rep.AutoSync.LastAttemptUnix, 0).Format(time.RFC3339), rep.AutoSync.LastResult)
+	} else {
+		fmt.Println("Auto-sync:  never run yet (fires on the feed-poll heartbeat, ~once/day)")
+	}
 	if len(rep.Skills) == 0 {
 		fmt.Println("  (no skills installed — run 'eigenflux skills sync')")
 	}

--- a/cli/cmd/feed.go
+++ b/cli/cmd/feed.go
@@ -78,6 +78,9 @@ Examples:
 		// Best-effort: a sync failure must never break the poll itself.
 		if cfg, err := config.Load(); err == nil {
 			_ = SyncSettings(cfg)
+			// Same heartbeat, same best-effort contract: keep skills fresh for
+			// bare-CLI / heartbeat users (throttled to once/day, offline-safe).
+			maybeSyncSkills(cfg)
 		}
 		return nil
 	},

--- a/cli/cmd/settings.go
+++ b/cli/cmd/settings.go
@@ -133,7 +133,14 @@ func SyncSettings(cfg *config.Config) error {
 	if err := json.Unmarshal(resp.Data, &remote); err != nil {
 		return err
 	}
-	skip := map[string]bool{"mode": true, "updated_at": true}
+	// mode/updated_at are meta. auto_skill_sync / skill_sync_interval_hours are
+	// client-local safety controls (throttle + kill switch for the background
+	// skill refresh) and must NOT be settable by the backend — otherwise a
+	// compromised backend could disable updates or overflow the throttle.
+	skip := map[string]bool{
+		"mode": true, "updated_at": true,
+		autoSkillSyncKey: true, skillSyncIntervalKey: true,
+	}
 	for k, v := range remote {
 		if skip[k] {
 			continue

--- a/cli/cmd/skills_autosync.go
+++ b/cli/cmd/skills_autosync.go
@@ -17,20 +17,27 @@ const (
 	skillSyncIntervalKey = "skill_sync_interval_hours"
 
 	defaultSkillSyncTTL = 24 * time.Hour
-	// autoSkillSyncTimeout bounds the one-per-TTL blocking sync so a slow CDN
-	// can never stall the heartbeat for long. `--if-stale` means the common
-	// case is a single small manifest GET; only a real revision change downloads
-	// the (tiny) skills tarball.
-	autoSkillSyncTimeout = 10 * time.Second
+	// maxSkillSyncHours clamps a user- or backend-supplied interval to [1h, 1y].
+	// The clamp is applied to the raw hour count BEFORE multiplying by
+	// time.Hour, so an absurd value (e.g. pushed by a compromised backend) can
+	// never overflow time.Duration into a negative TTL — which would flip the
+	// throttle gate permanently open and hammer the CDN every heartbeat.
+	minSkillSyncHours = 1
+	maxSkillSyncHours = 365 * 24
+	// autoSkillSyncTimeout bounds a SINGLE CDN request. A due heartbeat does a
+	// few small GETs (manifest, then a tiny tarball only on a real change), so
+	// worst-case blocking is a small multiple of this — not a hard per-sync cap.
+	autoSkillSyncTimeout = 5 * time.Second
 )
 
 // maybeSyncSkills is a best-effort, throttled background skill refresh meant to
-// hang off the feed-poll heartbeat. It NEVER returns an error and blocks for at
-// most autoSkillSyncTimeout, and only once per TTL (default 24h) — the rest of
-// the heartbeats just read a small local state file and return. It writes to
-// the host's autodetected skill-load dir (terminal => ~/.agents/skills);
-// plugin hosts that load their own bundle are refreshed by the plugin's own
-// periodic sync, not this hook.
+// hang off the feed-poll heartbeat. It NEVER returns an error and does real work
+// at most once per TTL (default 24h) — the rest of the heartbeats just read a
+// small local state file and return. When it does run, network is bounded per
+// request (autoSkillSyncTimeout); the disk swap is not, so on the ~once/day
+// update it can block a few seconds. It writes to the host's autodetected
+// skill-load dir (terminal => ~/.agents/skills); plugin hosts that load their
+// own bundle are refreshed by the plugin's own periodic sync, not this hook.
 func maybeSyncSkills(cfg *config.Config) {
 	if cfg == nil || cfg.GetKV(autoSkillSyncKey) == "false" {
 		return
@@ -38,7 +45,9 @@ func maybeSyncSkills(cfg *config.Config) {
 
 	ttl := defaultSkillSyncTTL
 	if v := cfg.GetKV(skillSyncIntervalKey); v != "" {
-		if h, err := strconv.Atoi(v); err == nil && h > 0 {
+		// Clamp the hour count before multiplying (overflow-safe); out-of-range
+		// or non-numeric falls back to the default TTL.
+		if h, err := strconv.Atoi(v); err == nil && h >= minSkillSyncHours && h <= maxSkillSyncHours {
 			ttl = time.Duration(h) * time.Hour
 		}
 	}

--- a/cli/cmd/skills_autosync.go
+++ b/cli/cmd/skills_autosync.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/skills"
+)
+
+const (
+	// autoSkillSyncKey disables the background refresh when set to "false".
+	// Absent/any-other value => enabled (this is on by default).
+	autoSkillSyncKey = "auto_skill_sync"
+	// skillSyncIntervalKey overrides the throttle TTL, in whole hours.
+	skillSyncIntervalKey = "skill_sync_interval_hours"
+
+	defaultSkillSyncTTL = 24 * time.Hour
+	// autoSkillSyncTimeout bounds the one-per-TTL blocking sync so a slow CDN
+	// can never stall the heartbeat for long. `--if-stale` means the common
+	// case is a single small manifest GET; only a real revision change downloads
+	// the (tiny) skills tarball.
+	autoSkillSyncTimeout = 10 * time.Second
+)
+
+// maybeSyncSkills is a best-effort, throttled background skill refresh meant to
+// hang off the feed-poll heartbeat. It NEVER returns an error and blocks for at
+// most autoSkillSyncTimeout, and only once per TTL (default 24h) — the rest of
+// the heartbeats just read a small local state file and return. It writes to
+// the host's autodetected skill-load dir (terminal => ~/.agents/skills);
+// plugin hosts that load their own bundle are refreshed by the plugin's own
+// periodic sync, not this hook.
+func maybeSyncSkills(cfg *config.Config) {
+	if cfg == nil || cfg.GetKV(autoSkillSyncKey) == "false" {
+		return
+	}
+
+	ttl := defaultSkillSyncTTL
+	if v := cfg.GetKV(skillSyncIntervalKey); v != "" {
+		if h, err := strconv.Atoi(v); err == nil && h > 0 {
+			ttl = time.Duration(h) * time.Hour
+		}
+	}
+
+	home := config.HomeDir()
+	state := skills.LoadAutoSyncState(home)
+	if !skills.DueForAutoSync(state, ttl, time.Now()) {
+		return
+	}
+
+	// Stamp the attempt BEFORE calling out, so an offline/slow stretch can't
+	// re-punch the TTL gate on every subsequent heartbeat.
+	state.LastAttemptUnix = time.Now().Unix()
+
+	res, err := skills.Sync(skills.SyncOptions{
+		IfStale:    true,
+		Quiet:      true,
+		CLIVersion: version,
+		CDNBase:    cdnBase(),
+		HTTPClient: &http.Client{Timeout: autoSkillSyncTimeout},
+	})
+	state.LastResult = classifyAutoSync(res, err)
+	if res != nil {
+		if m, mErr := skills.ReadLocalManifest(res.SkillsDir); mErr == nil && m != nil {
+			state.LastRevision = m.Revision
+		}
+	}
+	_ = skills.SaveAutoSyncState(home, state)
+}
+
+// classifyAutoSync maps a Sync outcome to a short state label for `doctor`.
+func classifyAutoSync(res *skills.SyncResult, err error) string {
+	switch {
+	case err != nil || res == nil:
+		return "error"
+	case res.NoNetwork:
+		return "offline"
+	case res.Source == "local":
+		// revision matched (or lock held) => nothing changed
+		return "nochange"
+	default:
+		return "ok"
+	}
+}

--- a/cli/cmd/skills_autosync_test.go
+++ b/cli/cmd/skills_autosync_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/skills"
+)
+
+// tempHome points config.HomeDir() at a throwaway dir and returns the resolved
+// home (EIGENFLUX_HOME gets a ".eigenflux" suffix appended).
+func tempHome(t *testing.T) string {
+	t.Helper()
+	t.Setenv("EIGENFLUX_HOME", t.TempDir())
+	return config.HomeDir()
+}
+
+func TestMaybeSyncSkills_DisabledByConfig(t *testing.T) {
+	home := tempHome(t)
+	maybeSyncSkills(&config.Config{KV: map[string]string{autoSkillSyncKey: "false"}})
+	if _, err := os.Stat(filepath.Join(home, skills.AutoSyncStateFile)); !os.IsNotExist(err) {
+		t.Fatalf("disabled: expected no state file to be written, stat err=%v", err)
+	}
+}
+
+func TestMaybeSyncSkills_ThrottledNotDue(t *testing.T) {
+	home := tempHome(t)
+	// A fresh attempt timestamp => not due => must NOT re-attempt (and must not
+	// touch the network).
+	fresh := skills.AutoSyncState{LastAttemptUnix: time.Now().Unix(), LastResult: "ok"}
+	if err := skills.SaveAutoSyncState(home, fresh); err != nil {
+		t.Fatal(err)
+	}
+	// Point the CDN at a dead addr: if the throttle leaks, classifyAutoSync
+	// would overwrite LastResult with offline/error and we'd catch it.
+	t.Setenv("EIGENFLUX_CDN_URL", "http://127.0.0.1:1")
+
+	maybeSyncSkills(&config.Config{})
+
+	got := skills.LoadAutoSyncState(home)
+	if got.LastAttemptUnix != fresh.LastAttemptUnix || got.LastResult != "ok" {
+		t.Fatalf("not-due: state should be untouched, got %+v", got)
+	}
+}
+
+func TestMaybeSyncSkills_DueOfflineStampsAttempt(t *testing.T) {
+	home := tempHome(t)
+	t.Setenv("EIGENFLUX_CDN_URL", "http://127.0.0.1:1")                // connection refused (fast)
+	t.Setenv("EIGENFLUX_SKILLS_DIR", filepath.Join(t.TempDir(), "sk")) // keep the real dir untouched
+
+	// No prior state => due. Offline sync must not panic, must stamp the
+	// attempt (so it won't re-punch the gate next heartbeat), and must not
+	// record success.
+	maybeSyncSkills(&config.Config{})
+
+	got := skills.LoadAutoSyncState(home)
+	if got.LastAttemptUnix == 0 {
+		t.Fatal("offline+due: expected the attempt to be stamped in state")
+	}
+	if got.LastResult == "ok" {
+		t.Fatalf("offline+due: result must not be ok, got %q", got.LastResult)
+	}
+}

--- a/cli/cmd/skills_autosync_test.go
+++ b/cli/cmd/skills_autosync_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,29 @@ import (
 	"cli.eigenflux.ai/internal/config"
 	"cli.eigenflux.ai/internal/skills"
 )
+
+func TestClassifyAutoSync(t *testing.T) {
+	cases := []struct {
+		name string
+		res  *skills.SyncResult
+		err  error
+		want string
+	}{
+		{"error from err", nil, errors.New("boom"), "error"},
+		{"error on nil result", nil, nil, "error"},
+		{"offline", &skills.SyncResult{NoNetwork: true}, nil, "offline"},
+		{"offline wins over source", &skills.SyncResult{NoNetwork: true, Source: "local"}, nil, "offline"},
+		{"nochange (local source)", &skills.SyncResult{Source: "local"}, nil, "nochange"},
+		{"ok (real update)", &skills.SyncResult{Source: "cli/latest"}, nil, "ok"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyAutoSync(c.res, c.err); got != c.want {
+				t.Fatalf("classifyAutoSync = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
 
 // tempHome points config.HomeDir() at a throwaway dir and returns the resolved
 // home (EIGENFLUX_HOME gets a ".eigenflux" suffix appended).

--- a/cli/internal/skills/autosync.go
+++ b/cli/internal/skills/autosync.go
@@ -1,0 +1,82 @@
+package skills
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// AutoSyncStateFile is the small sidecar that records the last background
+// auto-sync attempt so a heartbeat can throttle to at most once per TTL without
+// re-hitting R2 on every poll. It lives in the eigenflux home dir (NOT the
+// skills dir), so it is decoupled from the atomic skills-dir swap and the CLI
+// version.
+const AutoSyncStateFile = "skills-autosync.json"
+
+// AutoSyncState is persisted between heartbeats.
+type AutoSyncState struct {
+	// LastAttemptUnix is when the last sync was *attempted* (success or not).
+	// Recording attempt (not success) means an offline stretch can't punch
+	// through the TTL gate on every heartbeat.
+	LastAttemptUnix int64 `json:"last_attempt_unix"`
+	// LastRevision / LastResult are informational (surfaced by `doctor`).
+	LastRevision string `json:"last_revision,omitempty"`
+	LastResult   string `json:"last_result,omitempty"` // ok|nochange|offline|error|disabled
+}
+
+// LoadAutoSyncState reads the state file from homeDir. A missing or corrupt file
+// yields a zero state (treated as "never attempted") — never an error, so a bad
+// file can only cost one extra sync attempt, never wedge the gate.
+func LoadAutoSyncState(homeDir string) AutoSyncState {
+	b, err := os.ReadFile(filepath.Join(homeDir, AutoSyncStateFile))
+	if err != nil {
+		return AutoSyncState{}
+	}
+	var s AutoSyncState
+	if json.Unmarshal(b, &s) != nil {
+		return AutoSyncState{}
+	}
+	return s
+}
+
+// SaveAutoSyncState writes the state file atomically (temp + rename) so a
+// concurrent reader never sees a half-written file.
+func SaveAutoSyncState(homeDir string, s AutoSyncState) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(homeDir, ".skills-autosync-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, filepath.Join(homeDir, AutoSyncStateFile))
+}
+
+// DueForAutoSync reports whether a background sync should be attempted now.
+// True when: never attempted (zero); now-last >= ttl; or last is in the future
+// (clock rewind / corruption) so a bad timestamp can never wedge auto-sync off.
+func DueForAutoSync(s AutoSyncState, ttl time.Duration, now time.Time) bool {
+	if s.LastAttemptUnix <= 0 {
+		return true
+	}
+	last := time.Unix(s.LastAttemptUnix, 0)
+	if last.After(now) {
+		return true
+	}
+	return now.Sub(last) >= ttl
+}

--- a/cli/internal/skills/autosync.go
+++ b/cli/internal/skills/autosync.go
@@ -22,7 +22,7 @@ type AutoSyncState struct {
 	LastAttemptUnix int64 `json:"last_attempt_unix"`
 	// LastRevision / LastResult are informational (surfaced by `doctor`).
 	LastRevision string `json:"last_revision,omitempty"`
-	LastResult   string `json:"last_result,omitempty"` // ok|nochange|offline|error|disabled
+	LastResult   string `json:"last_result,omitempty"` // ok|nochange|offline|error
 }
 
 // LoadAutoSyncState reads the state file from homeDir. A missing or corrupt file
@@ -47,7 +47,10 @@ func SaveAutoSyncState(homeDir string, s AutoSyncState) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+	// 0o700 mirrors the rest of the eigenflux home (config.json, credentials);
+	// this MkdirAll can run before config's own first write on a fresh install,
+	// so it must not create the home dir with looser perms.
+	if err := os.MkdirAll(homeDir, 0o700); err != nil {
 		return err
 	}
 	tmp, err := os.CreateTemp(homeDir, ".skills-autosync-*.tmp")
@@ -64,7 +67,11 @@ func SaveAutoSyncState(homeDir string, s AutoSyncState) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, filepath.Join(homeDir, AutoSyncStateFile))
+	if err := os.Rename(tmpPath, filepath.Join(homeDir, AutoSyncStateFile)); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }
 
 // DueForAutoSync reports whether a background sync should be attempted now.

--- a/cli/internal/skills/autosync_test.go
+++ b/cli/internal/skills/autosync_test.go
@@ -1,0 +1,59 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDueForAutoSync(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	ttl := 24 * time.Hour
+	cases := []struct {
+		name string
+		last int64
+		want bool
+	}{
+		{"never attempted", 0, true},
+		{"negative/garbage", -5, true},
+		{"just now", now.Unix(), false},
+		{"within ttl", now.Add(-1 * time.Hour).Unix(), false},
+		{"exactly at ttl", now.Add(-24 * time.Hour).Unix(), true},
+		{"past ttl", now.Add(-25 * time.Hour).Unix(), true},
+		{"future (clock rewind)", now.Add(1 * time.Hour).Unix(), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DueForAutoSync(AutoSyncState{LastAttemptUnix: c.last}, ttl, now)
+			if got != c.want {
+				t.Fatalf("DueForAutoSync(last=%d) = %v, want %v", c.last, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAutoSyncStateRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing file => zero state, no error.
+	if s := LoadAutoSyncState(dir); s != (AutoSyncState{}) {
+		t.Fatalf("missing file: want zero, got %+v", s)
+	}
+
+	want := AutoSyncState{LastAttemptUnix: 12345, LastRevision: "rev-abc", LastResult: "ok"}
+	if err := SaveAutoSyncState(dir, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if got := LoadAutoSyncState(dir); got != want {
+		t.Fatalf("roundtrip: want %+v, got %+v", want, got)
+	}
+
+	// Corrupt file => zero state, never an error (can only cost one extra sync).
+	if err := os.WriteFile(filepath.Join(dir, AutoSyncStateFile), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if s := LoadAutoSyncState(dir); s != (AutoSyncState{}) {
+		t.Fatalf("corrupt file: want zero, got %+v", s)
+	}
+}


### PR DESCRIPTION
给裸 CLI / 心跳包用户加 skills 自动刷新：挂在 `feed poll` 心跳里，24h TTL 节流、`--if-stale`、离线安全、不阻塞 poll。写到 host 自动解析的 skill 目录（terminal→~/.agents/skills）；插件用户由插件自身周期同步负责。

含专家评审必修项：interval 溢出钳制、后端不可覆盖本地安全键、home 0o700、per-request 超时如实、classifyAutoSync 测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)