### PR TITLE
feat(api/auth): deny-list agent emails at the auth gate (block spam account fmw)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,10 @@ RESEND_FROM_EMAIL="EigenFlux <noreply@yourdomain.com>"
 # Both conditions must be satisfied simultaneously
 MOCK_OTP_EMAIL_SUFFIXES=@test.com
 MOCK_OTP_IP_WHITELIST=127.0.0.1,::1,[::1]
+# Comma-separated agent emails denied at the API auth gate (spam/abuse). Rejected
+# with HTTP 403 on every authenticated route, including broadcast publish. Keyed
+# by email so a re-login keeps the block. Defaults to the known spam account.
+BLOCKED_AGENT_EMAILS=fmw19990718@gmail.com
 # Universal OTP code for whitelist-matched requests (can include letters and numbers)
 MOCK_UNIVERSAL_OTP=123456
 

--- a/api/main.go
+++ b/api/main.go
@@ -50,6 +50,7 @@ import (
 
 func main() {
 	cfg := config.Load()
+	middleware.SetBlockedAgentEmails(cfg.BlockedAgentEmails)
 	logFlush := logger.Init("api-gateway", cfg.EffectiveLokiURL(), cfg.LogLevel)
 	defer logFlush()
 

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -14,6 +14,24 @@ import (
 	"eigenflux_server/pkg/reqinfo"
 )
 
+// blockedAgentEmails holds normalized (lowercased) agent emails that are denied
+// at the auth gate. Populated once at startup via SetBlockedAgentEmails and
+// treated as read-only afterwards, so concurrent request reads need no lock.
+var blockedAgentEmails map[string]struct{}
+
+// SetBlockedAgentEmails installs the deny-list of agent emails. Call once at
+// startup, before the server starts serving requests. Emails are matched
+// case-insensitively; blank entries are ignored.
+func SetBlockedAgentEmails(emails []string) {
+	m := make(map[string]struct{}, len(emails))
+	for _, e := range emails {
+		if e = strings.ToLower(strings.TrimSpace(e)); e != "" {
+			m[e] = struct{}{}
+		}
+	}
+	blockedAgentEmails = m
+}
+
 func AuthMiddleware() app.HandlerFunc {
 	return func(ctx context.Context, c *app.RequestContext) {
 		header := string(c.GetHeader("Authorization"))
@@ -45,6 +63,20 @@ func AuthMiddleware() app.HandlerFunc {
 			})
 			c.Abort()
 			return
+		}
+
+		// Deny-listed accounts (e.g. spam ingestion identities) are rejected here,
+		// blocking every authenticated route including broadcast publish. Keyed by
+		// email so a re-login keeps the block even if the agent row changes.
+		if resp.Email != nil && len(blockedAgentEmails) > 0 {
+			if _, blocked := blockedAgentEmails[strings.ToLower(*resp.Email)]; blocked {
+				c.JSON(http.StatusForbidden, map[string]interface{}{
+					"code": 403,
+					"msg":  "account suspended",
+				})
+				c.Abort()
+				return
+			}
 		}
 
 		c.Set("agent_id", resp.AgentId)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,16 +155,17 @@ type Config struct {
 	EnableKNNRecall          bool
 	KNNRecallK               int
 	KNNRecallCandidates      int
-	EnableHotRecall          bool   // Enable hot_recall from Redis (default: true)
-	EnableNewRecall          bool   // Enable new_recall from Redis (default: true)
-	EnableTwoTowerRecall     bool   // Enable precomputed two_tower recall from Redis (default: false)
+	EnableHotRecall          bool     // Enable hot_recall from Redis (default: true)
+	EnableNewRecall          bool     // Enable new_recall from Redis (default: true)
+	EnableTwoTowerRecall     bool     // Enable precomputed two_tower recall from Redis (default: false)
 	PGCEmailSuffixes         []string // author email suffixes classifying a broadcast as PGC (official bots); everything else is UGC. Drives the sort UGC boost and category metrics
+	BlockedAgentEmails       []string // agent emails denied at the API auth gate (spam/abuse); blocks every authenticated route including broadcast publish
 	EnableServiceMix         bool     // Mix trading services into the SortItems feed (default: false)
-	ServiceMixRecallSize     int    // Max service candidates to recall before rerank (default: 50)
-	RecallRedisNamespace     string // Redis key namespace for recall indices (default: "rec")
-	TwoTowerRecallRedisKey   string // Redis recall output key for two_tower candidates (default: "two_tower_recall")
-	TwoTowerRecallK          int    // Top-K for two-tower Redis candidates (default: 50)
-	TwoTowerRecallCandidates int    // Deprecated; retained for env compatibility
+	ServiceMixRecallSize     int      // Max service candidates to recall before rerank (default: 50)
+	RecallRedisNamespace     string   // Redis key namespace for recall indices (default: "rec")
+	TwoTowerRecallRedisKey   string   // Redis recall output key for two_tower candidates (default: "two_tower_recall")
+	TwoTowerRecallK          int      // Top-K for two-tower Redis candidates (default: 50)
+	TwoTowerRecallCandidates int      // Deprecated; retained for env compatibility
 
 	// Per-type freshness decay
 	FreshnessAlertOffset  string
@@ -323,6 +324,7 @@ func Load() *Config {
 		EnableHotRecall:               getEnvBool("ENABLE_HOT_RECALL", true),
 		EnableNewRecall:               getEnvBool("ENABLE_NEW_RECALL", true),
 		PGCEmailSuffixes:              getEnvStringList("PGC_EMAIL_SUFFIXES", []string{"@bot.eigenflux.one", "@pgc.eigenflux.one"}),
+		BlockedAgentEmails:            getEnvStringList("BLOCKED_AGENT_EMAILS", []string{"fmw19990718@gmail.com"}),
 		EnableServiceMix:              getEnvBool("ENABLE_SERVICE_MIX", false),
 		ServiceMixRecallSize:          getEnvInt("SERVICE_MIX_RECALL_SIZE", 50),
 		EnableTwoTowerRecall:          getEnvBool("ENABLE_TWO_TOWER_RECALL", false),


### PR DESCRIPTION
## 背景
`fmw19990718@gmail.com`（agent_id 290801134694563840）是一个 spam ingestion 账号，用一个 curl 脚本 + 长效 token，约 **1400 条/天** 灌广播，污染候选池（占全平台内容 12%，真实 UGC 仅 0.8%）。团队此前已在 `70b3dc4` 把它标为 spam 并从各 UGC 统计里排除。

## 为什么在 auth 中间件按 email 封
- 运营后台**没有封号 API**；`agents` 表**没有 status/deleted 字段**；发布链路鉴权**只查 session token**（`GetSessionByTokenHash` 只看 token_hash+status+expire，从不读 agents 行）。
- 所以「软删除账号」对发广播**完全无效**，硬删除又会 `ON DELETE CASCADE` 连带删掉它 4 万+条 `item_stats` 历史。代码级闸口是唯一稳妥、永久的封法。
- **按 email 而非 agent_id**：即使账号被重建换了 agent_id，重新登录后 email 不变，封禁依然生效。

## 改动
- `pkg/config`: 新增 `BlockedAgentEmails`，由 `BLOCKED_AGENT_EMAILS`（逗号分隔）驱动，默认含 `fmw19990718@gmail.com`。
- `api/middleware/auth.go`: `AuthMiddleware` 在校验通过后按 email 命中即返回 **403 `account suspended`**，`c.Abort()`——覆盖所有需鉴权路由（含发布）。包级 set 在启动时注入一次，请求期只读、无锁。
- `api/main.go`: `config.Load()` 后调用 `middleware.SetBlockedAgentEmails(...)`。
- `.env.example`: 补文档。

## 部署
合并后需在 `aliap` 上 `git pull → ./scripts/common/build.sh → sudo ./scripts/cloud/restart.sh api`。默认值已含 fmw，无需改 `.env`（如需扩展再设 `BLOCKED_AGENT_EMAILS`）。

## 现状
fmw 的 live session token **已在生产先行吊销止血**（`agent_sessions.status 0→2` + 清 Redis 缓存，已确认停发）；本 PR 是防它重新登录的**永久方案**。

## 验证
`go build ./api/... ./pkg/config/...` 通过，`go vet`/`gofmt` 干净。