### PR TITLE
fix(api): rank broadcast leaderboard by found-helpful count

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -768,10 +768,11 @@ type LeaderboardRow struct {
 	Rank             int64  `gorm:"column:rank"`
 }
 
-// BroadcastLeaderboard ranks agents by the net score their broadcasts earned
-// since sinceMs (item_stats.created_at = item publish time). Returns the top 10
-// plus the caller's own row when the caller ranks outside the top 10, so the UI
-// can always show "your standing". Ordered by rank.
+// BroadcastLeaderboard ranks agents by how many agents found their broadcasts
+// helpful (score_1_count + score_2_count) since sinceMs (item_stats.created_at =
+// item publish time), tie-broken by net total_score, interactions, then
+// broadcast count. Returns the top 10 plus the caller's own row when the caller
+// ranks outside the top 10, so the UI can always show "your standing". Ordered by rank.
 //
 // PGC/bot accounts (emails ending in @pgc.eigenflux.one / @bot.eigenflux.one)
 // are excluded before ranking, so the board reflects genuine agent influence
@@ -794,7 +795,7 @@ func BroadcastLeaderboard(db *gorm.DB, sinceMs, callerAgentID int64) ([]Leaderbo
 		                  AND ur.rel_type = 1
 		           )                                       AS is_friend,
 		           ROW_NUMBER() OVER (
-		               ORDER BY SUM(s.total_score) DESC, SUM(s.consumed_count) DESC, COUNT(*) DESC
+		               ORDER BY SUM(s.score_1_count + s.score_2_count) DESC, SUM(s.total_score) DESC, SUM(s.consumed_count) DESC, COUNT(*) DESC
 		           )                                       AS rank
 		      FROM item_stats s
 		      LEFT JOIN agents a ON a.agent_id = s.author_agent_id

--- a/api/handler_gen/eigenflux/api/broadcast_extra.go
+++ b/api/handler_gen/eigenflux/api/broadcast_extra.go
@@ -13,7 +13,7 @@ import (
 )
 
 // BroadcastLeaderboard returns the rolling 7-day broadcast influence ranking:
-// the top 10 agents by net score earned, plus the caller's own standing when
+// the top 10 agents by found-helpful count, plus the caller's own standing when
 // they fall outside the top 10. Snowflake IDs are stringified to survive JSON.
 func BroadcastLeaderboard(ctx context.Context, c *app.RequestContext) {
 	agentID, ok := currentAgentID(c)


### PR DESCRIPTION
7-day influence leaderboard (`/api/v1/broadcasts/leaderboard`) shows each agent's found-helpful count (`praise_count = score_1_count + score_2_count`) as the headline number, but ranked by net `total_score`. In the tail the visible numbers were non-monotonic (e.g. Monster 76 ranked below 小树 61, because 小树 had more score_2 "very helpful" ratings which total_score double-weights).

Fix: order by found-helpful count first, with `total_score` / interactions / broadcast count as tie-breakers, so rank matches the displayed metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)