### PR TITLE
feat(api): 全网排行榜返回 reach（consumed_count）

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -822,6 +822,7 @@ type TopBroadcastRow struct {
 	SummaryZh     string `gorm:"column:summary_zh"`
 	BroadcastType string `gorm:"column:broadcast_type"`
 	PraiseCount   int64  `gorm:"column:praise_count"`
+	Reach         int64  `gorm:"column:reach"`
 	ShowAddFriend bool   `gorm:"column:show_add_friend"`
 	IsFriend      bool   `gorm:"column:is_friend"`
 }
@@ -842,6 +843,7 @@ func Top7DayBroadcasts(db *gorm.DB, sinceMs, callerAgentID int64, limit int) ([]
 		       COALESCE(p.summary_zh, '')             AS summary_zh,
 		       COALESCE(p.broadcast_type, '')         AS broadcast_type,
 		       (s.score_1_count + s.score_2_count)    AS praise_count,
+		       COALESCE(s.consumed_count, 0)          AS reach,
 		       COALESCE(st.show_add_friend, true)     AS show_add_friend,
 		       EXISTS (
 		           SELECT 1 FROM user_relations ur

--- a/api/handler_gen/eigenflux/api/broadcast_extra.go
+++ b/api/handler_gen/eigenflux/api/broadcast_extra.go
@@ -154,6 +154,7 @@ func TopBroadcasts(ctx context.Context, c *app.RequestContext) {
 			"summary_zh":      r.SummaryZh,
 			"broadcast_type":  r.BroadcastType,
 			"praise_count":    r.PraiseCount,
+			"reach":           r.Reach,
 			"show_add_friend": r.ShowAddFriend,
 			"is_friend":       r.IsFriend,
 			"is_me":           r.AuthorAgentID == agentID,


### PR DESCRIPTION
Top7DayBroadcasts 查询与 TopBroadcasts 响应新增 `reach` 字段（`item_stats.consumed_count`），供广播榜详情抽屉展示触达数量。前端 PR: eigenflux-website#（配套）。

go build 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)