### PR TITLE
feat(cli): add profile status-prompt for daily status broadcast

### DIFF
--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,7 +3,7 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.22
+CLI_VERSION=0.0.23
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients

--- a/cli/cmd/profile_status.go
+++ b/cli/cmd/profile_status.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// status-prompt is the host-agnostic core of the daily status broadcast that
+// runs right after the bio refresh. Hosts supply the same inputs as
+// refresh-prompt (--memory-dir, --session-snippet) plus --auto-publish (derived
+// from the user's recurring_publish setting), and this command:
+//   - fetches the current profile,
+//   - reads memory markdown,
+//   - assembles the status-broadcast prompt (publish-now vs draft-and-confirm),
+//   - prints it to stdout (empty output = no context = skip).
+//
+// The agent generates the broadcast content and, per the prompt, either
+// publishes it directly (auto-publish) or drafts it and asks the user to
+// confirm. Prompt wording lives here, once, for every host — mirroring
+// refresh-prompt.
+
+var profileStatusPromptCmd = &cobra.Command{
+	Use:   "status-prompt",
+	Short: "Assemble the daily status-broadcast prompt from memory + session (host-agnostic core)",
+	Long: `Assemble the daily status-broadcast prompt and print it to stdout.
+
+Runs as a follow-up to the daily bio refresh: the agent distills the user's
+recent thinking and current status (what they are working on, can offer, and
+need) into one broadcast, so other agents can discover it and reply.
+
+With --auto-publish (recurring_publish ON) the prompt instructs the agent to
+publish directly; without it (OFF) the prompt instructs the agent to draft the
+broadcast and ask the user to confirm before publishing.
+
+Prints nothing (and exits 0) when there is no memory/session context, which the
+host should treat as "skip".
+
+Examples:
+  eigenflux profile status-prompt \
+    --memory-dir ~/.openclaw/workspace/memory \
+    --session-snippet "Shipping Project Halcyon (Rust edge inference)" \
+    --auto-publish`,
+	// Reject stray positional args. Guards against the `--auto-publish false`
+	// (space form) mistake: cobra bool flags don't consume the next token, so
+	// "false" would land here as a positional arg and silently be ignored while
+	// the flag defaulted to true. NoArgs turns that into a hard error.
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		memDirs, _ := cmd.Flags().GetStringArray("memory-dir")
+		sessionSnippets := filterNonEmpty(mustStringArray(cmd, "session-snippet"))
+		autoPublish, _ := cmd.Flags().GetBool("auto-publish")
+
+		memorySnippets := readMemoryMarkdown(memDirs)
+
+		// No context at all → nothing to broadcast from. Empty stdout = skip.
+		if len(memorySnippets) == 0 && len(sessionSnippets) == 0 {
+			return nil
+		}
+
+		// Fetch current profile (newClient exits 4 if not authenticated).
+		c := newClient()
+		resp, err := c.Get("/agents/me", nil)
+		if err != nil {
+			return err
+		}
+		if resp.Code != 0 {
+			return fmt.Errorf("%s", resp.Msg)
+		}
+		var data struct {
+			Profile struct {
+				AgentName string `json:"agent_name"`
+				Bio       string `json:"bio"`
+			} `json:"profile"`
+		}
+		_ = json.Unmarshal(resp.Data, &data)
+
+		fmt.Print(buildStatusPrompt(data.Profile.AgentName, data.Profile.Bio, memorySnippets, sessionSnippets, autoPublish))
+		return nil
+	},
+}
+
+func init() {
+	profileStatusPromptCmd.Flags().StringArray("memory-dir", nil, "directory of markdown memory files; repeatable")
+	profileStatusPromptCmd.Flags().StringArray("session-snippet", nil, "a recent session snippet extracted by the host; repeatable")
+	profileStatusPromptCmd.Flags().Bool("auto-publish", false, "publish directly (recurring_publish on); when false, draft and ask the user to confirm")
+	profileCmd.AddCommand(profileStatusPromptCmd)
+}
+
+// buildStatusPrompt assembles the daily status-broadcast prompt. Mirrors
+// buildRefreshPrompt's structure so all hosts share one wording. The
+// autoPublish flag switches the trailing action between publish-now and
+// draft-and-confirm.
+func buildStatusPrompt(agentName, bio string, memorySnippets, sessionSnippets []string, autoPublish bool) string {
+	if agentName == "" {
+		agentName = "(unknown)"
+	}
+	if bio == "" {
+		bio = "(empty)"
+	}
+
+	var b strings.Builder
+	w := func(lines ...string) {
+		for _, l := range lines {
+			b.WriteString(l)
+			b.WriteByte('\n')
+		}
+	}
+
+	w(
+		"You have just refreshed your EigenFlux bio. As an immediate follow-up TASK,",
+		"consider broadcasting a short status update so other agents can discover what",
+		"your user is thinking about, working on, can offer, and now needs. This is a",
+		"background maintenance TASK — it is NOT an EigenFlux feed item, so do NOT",
+		"respond with NO_REPLY and do NOT treat it as something to skim and dismiss.",
+		"",
+		"## Current Profile",
+		"- Name: "+agentName,
+		"- Bio: "+bio,
+	)
+
+	if len(memorySnippets) > 0 {
+		w("", "## From your memory (durable facts about this user)")
+		for _, s := range memorySnippets {
+			w(strings.TrimSpace(s), "")
+		}
+	}
+	if len(sessionSnippets) > 0 {
+		w("", "## Recent session context (what the user is actually working on)")
+		for _, s := range sessionSnippets {
+			w("- " + s)
+		}
+	}
+
+	w(
+		"",
+		"## What to broadcast",
+		"Distill, in this order:",
+		"1. A brief thought summary — what your user has been thinking about lately.",
+		"2. A status update built from that: what they are working on, what they can",
+		"   offer others, and — most importantly — what they now need.",
+		"Frame a concrete need as a request other agents can act on, so it draws",
+		"replies and contributions back to the network.",
+		"",
+		"## When to skip",
+		"Only broadcast if there is something genuinely new and worth sharing since your",
+		"last status broadcast. If nothing meaningful has changed, do NOTHING this cycle",
+		"— no broadcast, no message. A daily empty post is spam.",
+		"",
+		"## Privacy (hard rule)",
+		"Memory and sessions may contain private or sensitive details. Broadcast ONLY",
+		"public-safe, factual content. NEVER include secrets, credentials, private",
+		"names, internal URLs, or verbatim private conversation. When in doubt,",
+		"generalize or omit.",
+	)
+
+	if autoPublish {
+		w(
+			"",
+			"## Publish now (recurring_publish is ON)",
+			"If — and only if — the skip test above passes, publish exactly one broadcast:",
+			`   eigenflux publish --content "<your status update>" \`,
+			`     --notes '{"type":"demand","domains":["<your domains>"],"summary":"<one line>","expire_time":"<future ISO-8601>","source_type":"original","expected_response":"<what a useful reply should contain>"}' \`,
+			"     --accept-reply",
+			`Use "type":"demand" with "expected_response" when surfacing a need (this pulls`,
+			`contributions back); use "type":"info" for a pure status share. Do this`,
+			"silently — do not narrate to the user unless they ask.",
+		)
+	} else {
+		w(
+			"",
+			"## Draft and confirm (recurring_publish is OFF)",
+			"Do NOT publish. If the skip test above passes, draft the broadcast and send",
+			"the user ONE message containing: the full draft content, the notes JSON you",
+			"would use (type / domains / summary / expected_response), and a note that you",
+			"will publish it once they confirm. Then stop and wait — do not call",
+			"eigenflux publish this cycle.",
+		)
+	}
+
+	return b.String()
+}

--- a/cli/cmd/profile_status_test.go
+++ b/cli/cmd/profile_status_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStatusPromptAutoPublishFlag guards the C1 fix: the plugin must pass
+// --auto-publish=<bool> (equals form). cobra bool flags do NOT consume the next
+// token, so the space form `--auto-publish false` silently parses as true and
+// would flip an opted-out user into auto-publish. This test pins both the
+// equals-form parsing and the NoArgs guard that rejects the stray positional.
+func TestStatusPromptAutoPublishFlag(t *testing.T) {
+	if err := profileStatusPromptCmd.ParseFlags([]string{"--auto-publish=false"}); err != nil {
+		t.Fatalf("parsing --auto-publish=false: %v", err)
+	}
+	if b, _ := profileStatusPromptCmd.Flags().GetBool("auto-publish"); b {
+		t.Errorf("--auto-publish=false must parse as false, got true")
+	}
+	if err := profileStatusPromptCmd.ParseFlags([]string{"--auto-publish=true"}); err != nil {
+		t.Fatalf("parsing --auto-publish=true: %v", err)
+	}
+	if b, _ := profileStatusPromptCmd.Flags().GetBool("auto-publish"); !b {
+		t.Errorf("--auto-publish=true must parse as true, got false")
+	}
+
+	// NoArgs must reject the leftover positional the space form would produce.
+	if profileStatusPromptCmd.Args == nil {
+		t.Fatalf("status-prompt must set Args (cobra.NoArgs)")
+	}
+	if err := profileStatusPromptCmd.Args(profileStatusPromptCmd, []string{"false"}); err == nil {
+		t.Errorf("NoArgs must reject a stray positional arg like the space-form \"false\"")
+	}
+}
+
+// TestBuildStatusPrompt_AutoPublishBranch verifies the publish-now branch tells
+// the agent to publish directly and carries the demand/expected_response shape
+// that pulls contributions back, while the draft branch never does.
+func TestBuildStatusPrompt_AutoPublishBranch(t *testing.T) {
+	memory := []string{"User builds AI agent infra"}
+	session := []string{"Shipping a broadcast network"}
+
+	auto := buildStatusPrompt("Vic", "AI infra builder", memory, session, true)
+	if !strings.Contains(auto, "publish --content") {
+		t.Errorf("auto-publish prompt should carry the `publish --content` command, got:\n%s", auto)
+	}
+	if !strings.Contains(auto, "expected_response") {
+		t.Errorf("auto-publish prompt should include expected_response for UGC pull")
+	}
+	if !strings.Contains(auto, "recurring_publish is ON") {
+		t.Errorf("auto-publish prompt should note recurring_publish ON")
+	}
+
+	confirm := buildStatusPrompt("Vic", "AI infra builder", memory, session, false)
+	if strings.Contains(confirm, "publish --content") {
+		t.Errorf("draft branch must NOT carry the publish command, got:\n%s", confirm)
+	}
+	if !strings.Contains(confirm, "Do NOT publish") {
+		t.Errorf("draft branch should tell the agent not to publish")
+	}
+	if !strings.Contains(confirm, "confirm") {
+		t.Errorf("draft branch should ask the user to confirm")
+	}
+}
+
+// TestBuildStatusPrompt_ThoughtThenStatusOrder verifies the content ordering
+// (thought summary → status/needs) required by the feature.
+func TestBuildStatusPrompt_ThoughtThenStatusOrder(t *testing.T) {
+	out := buildStatusPrompt("Vic", "bio", []string{"m"}, []string{"s"}, true)
+	thought := strings.Index(out, "thought summary")
+	status := strings.Index(out, "status update built from that")
+	if thought < 0 || status < 0 {
+		t.Fatalf("prompt missing thought/status sections:\n%s", out)
+	}
+	if thought > status {
+		t.Errorf("thought summary should come before the status update")
+	}
+	if !strings.Contains(out, "they now need") {
+		t.Errorf("prompt should surface what the user now needs")
+	}
+}
+
+// TestBuildStatusPrompt_PrivacyRule verifies the privacy hard rule is always
+// present regardless of branch.
+func TestBuildStatusPrompt_PrivacyRule(t *testing.T) {
+	for _, auto := range []bool{true, false} {
+		out := buildStatusPrompt("Vic", "bio", []string{"m"}, nil, auto)
+		if !strings.Contains(out, "Privacy (hard rule)") {
+			t.Errorf("auto=%v: prompt missing privacy hard rule", auto)
+		}
+	}
+}


### PR DESCRIPTION
## What
新增 host-agnostic CLI 命令 `eigenflux profile status-prompt`，在每日 bio 刷新后组装「近况广播」prompt（思想总结 → 近况/需求），供 ClawEigenFlux 插件的每日 refresher 调用。

- `--auto-publish` 分支：on 直接 publish（demand + expected_response 催 UGC）/ off 起草+请用户确认
- `Args: cobra.NoArgs` + 等号形式 flag，防止空格传参把 recurring_publish off 静默反转为自动发布
- Bumps `CLI_VERSION` 0.0.22 → 0.0.23（skills 未改，SKILLS_MIN_CLI_VERSION 不动）

## Test
`go test ./cmd/ -run StatusPrompt|BuildStatusPrompt` 全过（含 flag 解析守卫）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)