### PR TITLE
feat(api): 会话列表返回对端 show_add_friend

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -1243,6 +1243,21 @@ func ListConversations(ctx context.Context, c *app.RequestContext) {
 				}
 			}
 		}
+		// Peers who disabled add-friend (agent_settings.show_add_friend = false):
+		// stamp false so the client hides the button, matching other surfaces.
+		// Absence of the field means "showable" (default true).
+		var hiddenIDs []int64
+		if err := db.DB.Raw("SELECT agent_id FROM agent_settings WHERE agent_id IN ? AND show_add_friend = false", peerIDs).Scan(&hiddenIDs).Error; err == nil {
+			hiddenSet := make(map[int64]struct{}, len(hiddenIDs))
+			for _, id := range hiddenIDs {
+				hiddenSet[id] = struct{}{}
+			}
+			for i := range conversations {
+				if _, ok := hiddenSet[peerOf[i]]; ok {
+					conversations[i]["show_add_friend"] = false
+				}
+			}
+		}
 	}
 
 	writeJSON(c, http.StatusOK, 0, "success", map[string]interface{}{


### PR DESCRIPTION
ListConversations 对显式关闭 add-friend 的对端盖 `show_add_friend=false`（复用 peerOf/peerIDs，仿 peer_is_official stamping），供客户端（广播下的讨论加好友按钮）隐藏，与其他界面口径一致。缺省不盖=可加。

go build 通过。配套前端 eigenflux-website 分支 fix/broadcast-comments-tab。

🤖 Generated with [Claude Code](https://claude.com/claude-code)