### PR TITLE
feat: X Ads token/copy funnel conversion callbacks

### DIFF
--- a/api/install/handlers.go
+++ b/api/install/handlers.go
@@ -123,6 +123,9 @@ func mintRef(_ context.Context, c *app.RequestContext) {
 	}
 	event("install_ref_new", t.Token, "channel", t.Channel,
 		"paid", t.ClickID != "" || t.Twclid != "", "invite_code", t.InviteCode)
+	// The token is now durably created; report this server-confirmed funnel
+	// stage to X when it came from an X ad click.
+	fireXAdsTokenCreatedCallback(t.Token)
 	reply(c, http.StatusOK, 0, "success", map[string]interface{}{
 		"ref":     t.Token,
 		"command": installCommand(t.Token),
@@ -223,6 +226,8 @@ func reportCopy(_ context.Context, c *app.RequestContext) {
 	if t != nil {
 		event("install_copy", t.Token, "channel", t.Channel)
 		fireXHSCallback(t.Token, EventCopy) // shallow conversion (101)
+		// Copy was confirmed by the server and is idempotent per ref.
+		fireXAdsCopyCommandCallback(t.Token)
 	}
 	reply(c, http.StatusOK, 0, "success", map[string]interface{}{"ref": body.Ref})
 }

--- a/api/install/models.go
+++ b/api/install/models.go
@@ -43,12 +43,18 @@ type Token struct {
 	// cb101 = copy click (event_type 101), cb102 = install success (event_type
 	// 102). Code: -1 not attempted, 0 accepted (terminal), >0 platform error,
 	// -2 transport error. Non-zero is re-claimable by a later trigger.
-	Cb101Code    int   `gorm:"column:cb101_code;not null;default:-1"`
-	Cb101SentAt  int64 `gorm:"column:cb101_sent_at;not null;default:0"`
-	Cb102Code    int   `gorm:"column:cb102_code;not null;default:-1"`
-	Cb102SentAt  int64 `gorm:"column:cb102_sent_at;not null;default:0"`
-	XCb102Code   int   `gorm:"column:x_cb102_code;not null;default:-1"`
-	XCb102SentAt int64 `gorm:"column:x_cb102_sent_at;not null;default:0"`
+	Cb101Code   int   `gorm:"column:cb101_code;not null;default:-1"`
+	Cb101SentAt int64 `gorm:"column:cb101_sent_at;not null;default:0"`
+	Cb102Code   int   `gorm:"column:cb102_code;not null;default:-1"`
+	Cb102SentAt int64 `gorm:"column:cb102_sent_at;not null;default:0"`
+	// X Ads CAPI callbacks are tracked independently for the server-confirmed
+	// token-created, command-copied, and install-complete funnel stages.
+	XCbTokenCode   int   `gorm:"column:x_cb_token_code;not null;default:-1"`
+	XCbTokenSentAt int64 `gorm:"column:x_cb_token_sent_at;not null;default:0"`
+	XCbCopyCode    int   `gorm:"column:x_cb_copy_code;not null;default:-1"`
+	XCbCopySentAt  int64 `gorm:"column:x_cb_copy_sent_at;not null;default:0"`
+	XCb102Code     int   `gorm:"column:x_cb102_code;not null;default:-1"`
+	XCb102SentAt   int64 `gorm:"column:x_cb102_sent_at;not null;default:0"`
 	// CallbackSentAt / CallbackCode are the legacy single-event callback columns,
 	// superseded by the cb101/cb102 pair above; kept for backward compatibility.
 	CallbackSentAt int64 `gorm:"column:callback_sent_at;not null;default:0"`

--- a/api/install/store.go
+++ b/api/install/store.go
@@ -160,12 +160,12 @@ func xInstallCallbackClaimable(sentAt, now int64) bool {
 	return sentAt == 0 || sentAt < now-xInstallCallbackLease.Milliseconds()
 }
 
-func ClaimXInstallCallback(db *gorm.DB, ref string) (won bool, t *Token, err error) {
+func ClaimXAdsCallback(db *gorm.DB, ref string, event xAdsFunnelEvent) (won bool, t *Token, err error) {
 	now := time.Now().UnixMilli()
 	leaseCutoff := now - xInstallCallbackLease.Milliseconds()
 	res := db.Model(&Token{}).
-		Where("token = ? AND x_cb102_code <> 0 AND twclid <> '' AND (x_cb102_sent_at = 0 OR x_cb102_sent_at < ?)", ref, leaseCutoff).
-		Update("x_cb102_sent_at", now)
+		Where(fmt.Sprintf("token = ? AND %s <> 0 AND twclid <> '' AND (%s = 0 OR %s < ?)", event.codeCol, event.sentCol, event.sentCol), ref, leaseCutoff).
+		Update(event.sentCol, now)
 	if res.Error != nil {
 		return false, nil, res.Error
 	}
@@ -179,6 +179,14 @@ func ClaimXInstallCallback(db *gorm.DB, ref string) (won bool, t *Token, err err
 	return true, &tok, nil
 }
 
+func SetXAdsCallbackCode(db *gorm.DB, ref string, event xAdsFunnelEvent, code int) error {
+	return db.Model(&Token{}).Where("token = ?", ref).Update(event.codeCol, code).Error
+}
+
+func ClaimXInstallCallback(db *gorm.DB, ref string) (won bool, t *Token, err error) {
+	return ClaimXAdsCallback(db, ref, xAdsInstall)
+}
+
 func SetXInstallCallbackCode(db *gorm.DB, ref string, code int) error {
-	return db.Model(&Token{}).Where("token = ?", ref).Update("x_cb102_code", code).Error
+	return SetXAdsCallbackCode(db, ref, xAdsInstall, code)
 }

--- a/api/install/store.go
+++ b/api/install/store.go
@@ -150,10 +150,22 @@ func ReportInstall(db *gorm.DB, token string) (converted bool, t *Token, err err
 	return converted, t, nil
 }
 
+const xInstallCallbackLease = time.Minute
+
+// xInstallCallbackClaimable reports whether a previous callback attempt has
+// either never been claimed or its in-flight lease has expired. The database
+// UPDATE in ClaimXInstallCallback applies this predicate atomically, so several
+// duplicate install reports cannot concurrently send the same conversion.
+func xInstallCallbackClaimable(sentAt, now int64) bool {
+	return sentAt == 0 || sentAt < now-xInstallCallbackLease.Milliseconds()
+}
+
 func ClaimXInstallCallback(db *gorm.DB, ref string) (won bool, t *Token, err error) {
+	now := time.Now().UnixMilli()
+	leaseCutoff := now - xInstallCallbackLease.Milliseconds()
 	res := db.Model(&Token{}).
-		Where("token = ? AND x_cb102_code <> 0 AND twclid <> ''", ref).
-		Update("x_cb102_sent_at", time.Now().UnixMilli())
+		Where("token = ? AND x_cb102_code <> 0 AND twclid <> '' AND (x_cb102_sent_at = 0 OR x_cb102_sent_at < ?)", ref, leaseCutoff).
+		Update("x_cb102_sent_at", now)
 	if res.Error != nil {
 		return false, nil, res.Error
 	}

--- a/api/install/x_ads_callback.go
+++ b/api/install/x_ads_callback.go
@@ -28,6 +28,8 @@ var (
 	xAdsAPIVersion     string
 	xAdsAccountID      string
 	xPixelID           string
+	xTokenEventID      string
+	xCopyEventID       string
 	xInstallEventID    string
 	xConsumerKey       string
 	xConsumerSecret    string
@@ -43,7 +45,9 @@ func initXAdsConfig() {
 	xAdsAPIVersion = strings.Trim(envStr("X_ADS_API_VERSION", "12"), "/")
 	xAdsAccountID = envStr("X_ADS_ACCOUNT_ID", "")
 	xPixelID = envStr("X_PIXEL_ID", "rcmcb")
-	xInstallEventID = envStr("X_INSTALL_EVENT_ID", "tw-rcmcb-rdiwm")
+	xTokenEventID = envStr("X_TOKEN_CREATED_EVENT_ID", "tw-rcmcb-rdiw5")
+	xCopyEventID = envStr("X_COPY_COMMAND_EVENT_ID", "tw-rcmcb-rdiw6")
+	xInstallEventID = envStr("X_INSTALL_EVENT_ID", "tw-rcmcb-rdiw7")
 	xConsumerKey = envStr("X_CONSUMER_KEY", "")
 	xConsumerSecret = envStr("X_CONSUMER_SECRET", "")
 	xAccessToken = envStr("X_ACCESS_TOKEN", "")
@@ -54,36 +58,70 @@ func initXAdsConfig() {
 }
 
 func xAdsConfigured() bool {
-	return xAdsAccountID != "" && xPixelID != "" && xInstallEventID != "" && xConsumerKey != "" && xConsumerSecret != "" && xAccessToken != "" && xAccessTokenSecret != ""
+	return xAdsAccountID != "" && xPixelID != "" && xTokenEventID != "" && xCopyEventID != "" && xInstallEventID != "" && xConsumerKey != "" && xConsumerSecret != "" && xAccessToken != "" && xAccessTokenSecret != ""
 }
 
-func fireXAdsInstallCallback(ref string) {
+type xAdsFunnelEvent struct {
+	name    string
+	eventID string
+	codeCol string
+	sentCol string
+}
+
+var (
+	xAdsTokenCreated = xAdsFunnelEvent{name: "token_created", codeCol: "x_cb_token_code", sentCol: "x_cb_token_sent_at"}
+	xAdsCopyCommand  = xAdsFunnelEvent{name: "copy_command", codeCol: "x_cb_copy_code", sentCol: "x_cb_copy_sent_at"}
+	xAdsInstall      = xAdsFunnelEvent{name: "install_complete", codeCol: "x_cb102_code", sentCol: "x_cb102_sent_at"}
+)
+
+func configuredXAdsEvent(event xAdsFunnelEvent) xAdsFunnelEvent {
+	switch event.name {
+	case "token_created":
+		event.eventID = xTokenEventID
+	case "copy_command":
+		event.eventID = xCopyEventID
+	case "install_complete":
+		event.eventID = xInstallEventID
+	}
+	return event
+}
+
+func fireXAdsTokenCreatedCallback(ref string) { fireXAdsCallback(ref, xAdsTokenCreated) }
+func fireXAdsCopyCommandCallback(ref string)  { fireXAdsCallback(ref, xAdsCopyCommand) }
+func fireXAdsInstallCallback(ref string)      { fireXAdsCallback(ref, xAdsInstall) }
+
+func fireXAdsCallback(ref string, funnel xAdsFunnelEvent) {
 	if !xCallbackEnabled || !xAdsConfigured() {
 		return
 	}
+	funnel = configuredXAdsEvent(funnel)
 	go func() {
-		won, t, err := ClaimXInstallCallback(db.DB, ref)
+		won, t, err := ClaimXAdsCallback(db.DB, ref, funnel)
 		if err != nil {
-			logger.Default().Error("install x ads callback claim failed", "ref", ref, "err", err)
+			logger.Default().Error("X Ads callback claim failed", "ref", ref, "event", funnel.name, "err", err)
 			return
 		}
 		if !won || t.Twclid == "" {
 			return
 		}
-		code, err := reportXAdsInstallConversion(t.Token, t.Twclid, t.ReportedAt)
+		code, err := reportXAdsConversion(t.Token, t.Twclid, t.ReportedAt, funnel.eventID, funnel.name)
 		if err != nil {
-			logger.Default().Error("install x ads callback failed", "ref", ref, "code", code, "err", err)
+			logger.Default().Error("X Ads callback failed", "ref", ref, "event", funnel.name, "code", code, "err", err)
 		}
-		if e := SetXInstallCallbackCode(db.DB, ref, code); e != nil {
-			logger.Default().Error("install x ads callback set code failed", "ref", ref, "err", e)
+		if e := SetXAdsCallbackCode(db.DB, ref, funnel, code); e != nil {
+			logger.Default().Error("X Ads callback set code failed", "ref", ref, "event", funnel.name, "err", e)
 		}
 		if code == 0 {
-			event("install_callback_x_ads", ref, "channel", t.Channel, "event_id", xInstallEventID)
+			event("install_callback_x_ads", ref, "channel", t.Channel, "funnel_event", funnel.name, "event_id", funnel.eventID)
 		}
 	}()
 }
 
 func reportXAdsInstallConversion(ref, twclid string, reportedAt int64) (int, error) {
+	return reportXAdsConversion(ref, twclid, reportedAt, xInstallEventID, "install_complete")
+}
+
+func reportXAdsConversion(ref, twclid string, reportedAt int64, eventID, funnelEvent string) (int, error) {
 	conversionTime := time.Now().UTC()
 	if reportedAt > 0 {
 		conversionTime = time.UnixMilli(reportedAt).UTC()
@@ -92,12 +130,10 @@ func reportXAdsInstallConversion(ref, twclid string, reportedAt int64) (int, err
 		"conversions": []map[string]interface{}{
 			{
 				"conversion_time": conversionTime.Format(time.RFC3339Nano),
-				"event_id":        xInstallEventID,
-				"identifiers": []map[string]string{
-					{"twclid": twclid},
-				},
-				"conversion_id": ref,
-				"description":   "EigenFlux install complete",
+				"event_id":        eventID,
+				"identifiers":     []map[string]string{{"twclid": twclid}},
+				"conversion_id":   fmt.Sprintf("%s:%s", funnelEvent, ref),
+				"description":     "EigenFlux " + strings.ReplaceAll(funnelEvent, "_", " "),
 			},
 		},
 	}

--- a/api/install/xhs_callback_test.go
+++ b/api/install/xhs_callback_test.go
@@ -117,3 +117,24 @@ func TestCallbackCols(t *testing.T) {
 		t.Fatalf("unknown event should default to cb101, got %s", c)
 	}
 }
+
+func TestXInstallCallbackClaimable(t *testing.T) {
+	now := int64(10 * 60 * 1000)
+	tests := []struct {
+		name   string
+		sentAt int64
+		want   bool
+	}{
+		{name: "never claimed", sentAt: 0, want: true},
+		{name: "active lease", sentAt: now - xInstallCallbackLease.Milliseconds() + 1, want: false},
+		{name: "lease boundary", sentAt: now - xInstallCallbackLease.Milliseconds(), want: false},
+		{name: "expired lease", sentAt: now - xInstallCallbackLease.Milliseconds() - 1, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := xInstallCallbackClaimable(tt.sentAt, now); got != tt.want {
+				t.Fatalf("xInstallCallbackClaimable(%d, %d) = %v, want %v", tt.sentAt, now, got, tt.want)
+			}
+		})
+	}
+}

--- a/migrations/000048_install_x_ads_funnel_callbacks.sql
+++ b/migrations/000048_install_x_ads_funnel_callbacks.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Per-event X Ads CAPI callback state for the server-confirmed token-minted
+-- and command-copied funnel stages. Codes: -1 not attempted, 0 accepted,
+-- >0 X HTTP error, -2 transport/signing error.
+ALTER TABLE install_tokens ADD COLUMN x_cb_token_code INT NOT NULL DEFAULT -1;
+ALTER TABLE install_tokens ADD COLUMN x_cb_token_sent_at BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE install_tokens ADD COLUMN x_cb_copy_code INT NOT NULL DEFAULT -1;
+ALTER TABLE install_tokens ADD COLUMN x_cb_copy_sent_at BIGINT NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE install_tokens DROP COLUMN x_cb_copy_sent_at;
+ALTER TABLE install_tokens DROP COLUMN x_cb_copy_code;
+ALTER TABLE install_tokens DROP COLUMN x_cb_token_sent_at;
+ALTER TABLE install_tokens DROP COLUMN x_cb_token_code;
+-- +goose StatementEnd


### PR DESCRIPTION
把两个**已在 prod 运行、但从未推到 origin** 的提交补进 main（原作者 aliecs，直接在 prod 服务器提交/部署，无评审记录、GitHub 无备份）。cherry-pick 到当前 origin/main，无冲突，`go build ./api` 通过。

## 改动
- **feat: report X Ads token and copy funnel conversions** (`f296c85`)
  - X Ads 转化回传从「仅安装完成」扩为三级漏斗：`token_created`（token 落库）→ `copy_command`（复制安装命令，按 ref 幂等）→ `install_complete`。
  - 每级独立 X 事件 ID（env 可覆盖 `X_TOKEN_CREATED_EVENT_ID` / `X_COPY_COMMAND_EVENT_ID` / `X_INSTALL_EVENT_ID`）与独立回传状态列。
  - 迁移 `000048_install_x_ads_funnel_callbacks.sql`：`install_tokens` 加 `x_cb_token_code/sent_at`、`x_cb_copy_code/sent_at`（**prod RDS 已应用**）。
  - 单一 install 回传重构为通用 `fireXAdsCallback(ref, funnel)` + `ClaimXAdsCallback`。
- **fix: serialize X Ads install conversion callbacks** (`c9919b9`)
  - 1 分钟租约锁 + 原子 UPDATE 判定，防止重复安装上报并发重发同一转化污染广告数据。附测试。

## 部署状态
prod 已在跑（DB 列已建、二进制含代码、`X_CALLBACK_ENABLED=true` 正在回传）。合并后 origin/main 与 prod 对齐。

## ⚠️ 待确认
`.env` 未设 `X_TOKEN_CREATED_EVENT_ID` / `X_COPY_COMMAND_EVENT_ID`，代码走默认值 `tw-rcmcb-rdiw5` / `rdiw6`——需确认这两个是否为 X 后台真实事件 ID。

🤖 Generated with [Claude Code](https://claude.com/claude-code)