### PR TITLE
feat(official): open welcome to all users; drop staged-rollout whitelists

### DIFF
--- a/pipeline/consumer/official_welcome_consumer.go
+++ b/pipeline/consumer/official_welcome_consumer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 
 	"gorm.io/gorm"
@@ -39,12 +38,6 @@ type OfficialWelcomeConsumer struct {
 	sender         *official.Sender
 	welcomeMessage string
 	officialEmail  string
-	// whitelist, when non-empty, restricts the welcome to these emails (staged
-	// rollout); empty means everyone. Keyed by normalized (lower/trimmed) email.
-	whitelist map[string]struct{}
-	// testSuffixes bypass the whitelist — e.g. @eftestbot.com accounts are always
-	// welcomed so test bots can exercise the official account during a rollout.
-	testSuffixes []string
 
 	runner *StreamConsumer
 
@@ -57,8 +50,6 @@ func NewOfficialWelcomeConsumer(cfg *config.Config, sender *official.Sender) *Of
 		sender:         sender,
 		welcomeMessage: cfg.OfficialWelcomeMessage,
 		officialEmail:  cfg.OfficialAgentEmail,
-		whitelist:      normalizeEmailSet(cfg.OfficialWelcomeWhitelist),
-		testSuffixes:   cfg.OfficialTestEmailSuffixes,
 	}
 	c.runner = &StreamConsumer{
 		Name:         "OfficialWelcomeConsumer",
@@ -118,15 +109,6 @@ func (c *OfficialWelcomeConsumer) handle(ctx context.Context, _ string, values m
 	}
 	if agent.ProfileCompletedAt == nil {
 		return HandleSuccess
-	}
-
-	// Staged rollout: when a whitelist is configured, only welcome listed emails
-	// so a production test stays invisible to everyone else. Test-suffix accounts
-	// (e.g. @eftestbot.com) always pass so test bots can be onboarded freely.
-	if len(c.whitelist) > 0 && !config.EmailMatchesAnySuffix(agent.Email, c.testSuffixes) {
-		if _, ok := c.whitelist[strings.ToLower(strings.TrimSpace(agent.Email))]; !ok {
-			return HandleSuccess
-		}
 	}
 
 	// Dedup gate: welcome each agent at most once. Released on transient failure
@@ -212,19 +194,6 @@ func (c *OfficialWelcomeConsumer) ensureFriendship(ctx context.Context, official
 		_ = relations.InvalidateFriendCache(ctx, mq.RDB, userID)
 	}
 	return nil
-}
-
-func normalizeEmailSet(emails []string) map[string]struct{} {
-	if len(emails) == 0 {
-		return nil
-	}
-	set := make(map[string]struct{}, len(emails))
-	for _, e := range emails {
-		if n := strings.ToLower(strings.TrimSpace(e)); n != "" {
-			set[n] = struct{}{}
-		}
-	}
-	return set
 }
 
 func acceptPendingRequest(tx *gorm.DB, fromUID, toUID int64) {

--- a/pipeline/consumer/official_welcome_consumer_test.go
+++ b/pipeline/consumer/official_welcome_consumer_test.go
@@ -2,9 +2,7 @@ package consumer
 
 import (
 	"context"
-	"strconv"
 	"testing"
-	"time"
 
 	"eigenflux_server/pkg/config"
 	"eigenflux_server/pkg/db"
@@ -71,55 +69,5 @@ func TestEnsureFriendship(t *testing.T) {
 	).Scan(&pairs)
 	if pairs != 2 {
 		t.Fatalf("friend relation rows = %d, want 2", pairs)
-	}
-}
-
-// TestWelcomeWhitelistSkips verifies that with a non-empty whitelist, a
-// profile-complete agent whose email is not listed is skipped — no friendship,
-// no welcome. Isolates the rollout gate (returns before the PM hop).
-func TestWelcomeWhitelistSkips(t *testing.T) {
-	cfg := config.Load()
-	db.InitWithLogLevel(cfg.PgDSN, logger.Silent)
-	mq.Init(cfg.RedisAddr, cfg.RedisPassword)
-
-	var officialID int64
-	if err := db.DB.Raw(
-		"SELECT agent_id FROM agents WHERE email = ? AND is_official", cfg.OfficialAgentEmail,
-	).Scan(&officialID).Error; err != nil || officialID == 0 {
-		t.Skipf("official account not provisioned locally (err=%v)", err)
-	}
-
-	const userID int64 = 9_200_000_000_000_000_055
-	now := time.Now().UnixMilli()
-	clean := func() {
-		db.DB.Exec("DELETE FROM user_relations WHERE from_uid IN (?,?) OR to_uid IN (?,?)", officialID, userID, officialID, userID)
-		db.DB.Exec("DELETE FROM agents WHERE agent_id = ?", userID)
-		mq.RDB.Del(context.Background(), officialWelcomedKey(userID))
-	}
-	clean()
-	t.Cleanup(clean)
-
-	if err := db.DB.Exec(
-		`INSERT INTO agents (agent_id, email, agent_name, bio, created_at, updated_at, profile_completed_at, is_official)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, false)`,
-		userID, "not-listed@test.com", "NotListed", "x", now, now, now,
-	).Error; err != nil {
-		t.Fatalf("insert user: %v", err)
-	}
-
-	c := &OfficialWelcomeConsumer{
-		officialEmail: cfg.OfficialAgentEmail,
-		whitelist:     map[string]struct{}{"someone-else@test.com": {}},
-	}
-
-	res := c.handle(context.Background(), "0-0", map[string]any{"agent_id": strconv.FormatInt(userID, 10)})
-	if res != HandleSuccess {
-		t.Fatalf("handle result = %v, want HandleSuccess (skip)", res)
-	}
-	if friend, _ := pmdal.IsFriend(db.DB, officialID, userID); friend {
-		t.Fatal("non-whitelisted agent must not be friended")
-	}
-	if n, _ := mq.RDB.Exists(context.Background(), officialWelcomedKey(userID)).Result(); n != 0 {
-		t.Fatal("non-whitelisted agent must not consume the welcome gate")
 	}
 }

--- a/pipeline/consumer/official_welcome_e2e_test.go
+++ b/pipeline/consumer/official_welcome_e2e_test.go
@@ -100,9 +100,6 @@ func TestOfficialWelcomeE2E(t *testing.T) {
 		sender:         sender,
 		welcomeMessage: cfg.OfficialWelcomeMessage,
 		officialEmail:  cfg.OfficialAgentEmail,
-		// Exercise the active-whitelist path: this email is listed, so it must
-		// still be welcomed (the skip path is covered by TestWelcomeWhitelistSkips).
-		whitelist: map[string]struct{}{"welcome-e2e@test.com": {}},
 	}
 
 	res := c.handle(context.Background(), "0-0", map[string]any{"agent_id": strconv.FormatInt(userID, 10)})

--- a/pipeline/cron/official_feed_rescue.go
+++ b/pipeline/cron/official_feed_rescue.go
@@ -105,21 +105,15 @@ func runOfficialFeedRescue(ctx context.Context, cfg *config.Config, rdb *redis.C
 			if len(domains) == 0 {
 				continue
 			}
-			isTest := oc.IsTestRecipient(agent.Email)
 			cnt, cerr := deliveredCountInDomains(f.AgentID, sinceMs, domains)
 			if cerr != nil {
 				continue
 			}
-			// Test accounts get the recommendation daily regardless of deficit;
-			// real users only when their in-domain feed is below the threshold.
-			if !isTest && cnt >= threshold {
+			// Only recommend when their in-domain feed is below the threshold.
+			if cnt >= threshold {
 				continue
 			}
-			cd := cooldown
-			if isTest {
-				cd = 24 * time.Hour // test accounts: daily
-			}
-			if !oc.CooldownAcquire(ctx, "rescue", f.AgentID, cd) {
+			if !oc.CooldownAcquire(ctx, "rescue", f.AgentID, cooldown) {
 				continue
 			}
 			if llmBudget <= 0 {

--- a/pipeline/cron/official_trending.go
+++ b/pipeline/cron/official_trending.go
@@ -111,11 +111,7 @@ func runOfficialTrending(ctx context.Context, cfg *config.Config, rdb *redis.Cli
 			if !oc.PassesGate(officialID, f.AgentID, agent.Email) {
 				continue
 			}
-			cd := fullCooldown
-			if oc.IsTestRecipient(agent.Email) {
-				cd = 24 * time.Hour // test accounts: daily
-			}
-			if !oc.CooldownAcquire(ctx, "trending", f.AgentID, cd) {
+			if !oc.CooldownAcquire(ctx, "trending", f.AgentID, fullCooldown) {
 				continue
 			}
 			lang := official.LangOf(f.AgentID)

--- a/pipeline/official/official.go
+++ b/pipeline/official/official.go
@@ -26,28 +26,17 @@ import (
 
 // Sender is the shared entry point for acting as the official account.
 type Sender struct {
-	pm           pmservice.Client
-	llm          *llm.Client
-	prompts      *llm.PromptRegistry
-	cfg          *config.Config
-	whitelist    map[string]struct{}
-	testSuffixes []string
+	pm      pmservice.Client
+	llm     *llm.Client
+	prompts *llm.PromptRegistry
+	cfg     *config.Config
 
 	mu         sync.Mutex
 	officialID int64
 }
 
 func NewSender(cfg *config.Config, pmClient pmservice.Client, llmClient *llm.Client, prompts *llm.PromptRegistry) *Sender {
-	wl := map[string]struct{}{}
-	for _, e := range cfg.OfficialPMWhitelist {
-		if n := strings.ToLower(strings.TrimSpace(e)); n != "" {
-			wl[n] = struct{}{}
-		}
-	}
-	if len(wl) == 0 {
-		wl = nil
-	}
-	return &Sender{pm: pmClient, llm: llmClient, prompts: prompts, cfg: cfg, whitelist: wl, testSuffixes: cfg.OfficialTestEmailSuffixes}
+	return &Sender{pm: pmClient, llm: llmClient, prompts: prompts, cfg: cfg}
 }
 
 // ResolveOfficialID looks up the official account's agent_id by email and caches
@@ -67,16 +56,10 @@ func (s *Sender) ResolveOfficialID() int64 {
 }
 
 // PassesGate reports whether the official account may message target: they must
-// be friends, pass the staged-rollout whitelist (test suffixes bypass it), and
-// not have opted out.
+// be friends and not have opted out.
 func (s *Sender) PassesGate(officialID, targetID int64, targetEmail string) bool {
 	if friend, err := pmdal.IsFriend(db.DB, officialID, targetID); err != nil || !friend {
 		return false
-	}
-	if s.whitelist != nil && !config.EmailMatchesAnySuffix(targetEmail, s.testSuffixes) {
-		if _, ok := s.whitelist[strings.ToLower(strings.TrimSpace(targetEmail))]; !ok {
-			return false
-		}
 	}
 	if cfgs, err := apidal.GetSettings(db.DB, targetID); err == nil && cfgs.OfficialPMOptout {
 		return false
@@ -85,34 +68,13 @@ func (s *Sender) PassesGate(officialID, targetID int64, targetEmail string) bool
 }
 
 // ChatGate is like PassesGate but for user-initiated chat (#2): it requires
-// friendship and the staged-rollout whitelist (test suffixes bypass it), but
-// ignores the proactive-PM opt-out — a user who DMs the official account wants
-// a reply regardless of having muted proactive pushes.
+// friendship but ignores the proactive-PM opt-out — a user who DMs the official
+// account wants a reply regardless of having muted proactive pushes.
 func (s *Sender) ChatGate(officialID, userID int64, userEmail string) bool {
 	if friend, err := pmdal.IsFriend(db.DB, officialID, userID); err != nil || !friend {
 		return false
 	}
-	if s.whitelist != nil && !config.EmailMatchesAnySuffix(userEmail, s.testSuffixes) {
-		if _, ok := s.whitelist[strings.ToLower(strings.TrimSpace(userEmail))]; !ok {
-			return false
-		}
-	}
 	return true
-}
-
-// IsTestRecipient reports whether the recipient is a test account (matches a
-// configured test suffix, or the PM whitelist). Used to deliver the proactive
-// PMs (#4/#5) daily for testing instead of at the normal cadence.
-func (s *Sender) IsTestRecipient(email string) bool {
-	if config.EmailMatchesAnySuffix(email, s.testSuffixes) {
-		return true
-	}
-	if s.whitelist != nil {
-		if _, ok := s.whitelist[strings.ToLower(strings.TrimSpace(email))]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 // CooldownAcquire SETNX-gates a per-feature, per-user cooldown. Returns true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,9 +99,7 @@ type Config struct {
 	OfficialAgentBio             string   // persona/bio for the official account
 	OfficialWelcomeMessage       string   // welcome PM body sent to new users once their profile is complete
 	EnableOfficialWelcome        bool     // master switch for the onboarding welcome (friend + PM) behavior
-	OfficialWelcomeWhitelist     []string // when non-empty, only these emails receive the welcome (staged-rollout allowlist; empty = everyone)
-	OfficialPMWhitelist          []string // staged-rollout allowlist for #4/#5 proactive official PMs (empty = all friends)
-	OfficialTestEmailSuffixes    []string // email suffixes always treated as test accounts for official-account features (bypass the staged-rollout whitelist)
+	OfficialTestEmailSuffixes    []string // email suffixes treated as test accounts for the login test-OTP path
 	OfficialTestOTP              string   // fixed login OTP for test-account emails (matching OfficialTestEmailSuffixes); empty disables the test-login path
 	EnableOfficialTrending       bool     // #5: biweekly network-wide trending DM
 	EnableOfficialFeedRescue     bool     // #4: feed-deficit topic-recommendation DM
@@ -272,8 +270,6 @@ func Load() *Config {
 		OfficialAgentBio:              getEnv("OFFICIAL_AGENT_BIO", "你好，我是 Vic 老师，有什么可以帮助你的？"),
 		OfficialWelcomeMessage:        getEnv("OFFICIAL_WELCOME_MESSAGE", "你好我是 vic 老师，我有什么可以帮助你的？"),
 		EnableOfficialWelcome:         getEnvBool("ENABLE_OFFICIAL_WELCOME", true),
-		OfficialWelcomeWhitelist:      getEnvStringList("OFFICIAL_WELCOME_WHITELIST", nil),
-		OfficialPMWhitelist:           getEnvStringList("OFFICIAL_PM_WHITELIST", nil),
 		OfficialTestEmailSuffixes:     getEnvStringList("OFFICIAL_TEST_EMAIL_SUFFIXES", []string{"@eftestbot.com"}),
 		OfficialTestOTP:               getEnv("OFFICIAL_TEST_OTP", "111111"),
 		EnableOfficialTrending:        getEnvBool("ENABLE_OFFICIAL_TRENDING", true),

--- a/scripts/official_friend_backfill/main.go
+++ b/scripts/official_friend_backfill/main.go
@@ -1,0 +1,167 @@
+// Command official_friend_backfill one-shot backfills the official-account
+// friendship for existing users. New users get friended by the
+// OfficialWelcomeConsumer on profile completion, but users who onboarded before
+// the welcome was opened to everyone were never friended — this walks them and
+// builds the relation.
+//
+// It only builds the friend relation; it does NOT send a welcome PM (existing
+// users already know the app; a bulk "welcome" would be spam). Idempotent:
+// already-friends are skipped, so it is safe to re-run.
+//
+//	go run ./scripts/official_friend_backfill --dry-run   # report target count only
+//	go run ./scripts/official_friend_backfill             # backfill everyone
+//	go run ./scripts/official_friend_backfill --limit 500 # cap for a first pass
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"sync"
+	"sync/atomic"
+
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/config"
+	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/mq"
+	pmdal "eigenflux_server/rpc/pm/dal"
+	"eigenflux_server/rpc/pm/relations"
+	profiledal "eigenflux_server/rpc/profile/dal"
+)
+
+// Matches OfficialWelcomeConsumer's officialWelcomeRemark.
+const officialFriendRemark = "EigenFlux 官方"
+
+type result int
+
+const (
+	resultCreated result = iota
+	resultSkipped
+	resultFailed
+)
+
+func main() {
+	cfg := config.Load()
+
+	dryRun := flag.Bool("dry-run", false, "report target count only, no writes")
+	workers := flag.Int("workers", 8, "concurrent workers")
+	limit := flag.Int("limit", 0, "max users to process (0 = all)")
+	flag.Parse()
+
+	db.Init(cfg.PgDSN)
+	mq.Init(cfg.RedisAddr, cfg.RedisPassword)
+	ctx := context.Background()
+
+	official, err := profiledal.GetAgentByEmail(db.DB, cfg.OfficialAgentEmail)
+	if err != nil || official == nil {
+		log.Fatalf("official account not found (email=%s): %v", cfg.OfficialAgentEmail, err)
+	}
+	officialID := official.AgentID
+	log.Printf("official account agent_id=%d email=%s", officialID, cfg.OfficialAgentEmail)
+
+	targets, err := loadTargets(officialID, *limit)
+	if err != nil {
+		log.Fatalf("load targets: %v", err)
+	}
+	log.Printf("backfill targets: %d users (profile-complete, not yet official friends, not blocking official)", len(targets))
+	if *dryRun {
+		log.Println("dry-run: no writes")
+		return
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	var created, skipped, failed int64
+	work := make(chan int64)
+	var wg sync.WaitGroup
+	for i := 0; i < *workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for uid := range work {
+				switch ensureOfficialFriend(ctx, officialID, uid) {
+				case resultCreated:
+					if n := atomic.AddInt64(&created, 1); n%200 == 0 {
+						log.Printf("progress: created=%d skipped=%d failed=%d",
+							n, atomic.LoadInt64(&skipped), atomic.LoadInt64(&failed))
+					}
+				case resultSkipped:
+					atomic.AddInt64(&skipped, 1)
+				case resultFailed:
+					atomic.AddInt64(&failed, 1)
+				}
+			}
+		}()
+	}
+	for _, uid := range targets {
+		work <- uid
+	}
+	close(work)
+	wg.Wait()
+
+	log.Printf("backfill done: created=%d skipped(already friend)=%d failed=%d total=%d",
+		created, skipped, failed, len(targets))
+}
+
+// ensureOfficialFriend mirrors OfficialWelcomeConsumer.ensureFriendship: build
+// the symmetric relation in a locked transaction (idempotent), then invalidate
+// both friend caches so PMService sees the new relation. No welcome PM is sent.
+func ensureOfficialFriend(ctx context.Context, officialID, userID int64) result {
+	created := false
+	err := db.DB.Transaction(func(tx *gorm.DB) error {
+		if err := pmdal.LockRelationPair(tx, officialID, userID); err != nil {
+			return err
+		}
+		isFriend, err := pmdal.IsFriend(tx, officialID, userID)
+		if err != nil {
+			return err
+		}
+		if isFriend {
+			return nil
+		}
+		if err := pmdal.CreateFriendRelation(tx, officialID, userID, officialFriendRemark, ""); err != nil {
+			return err
+		}
+		created = true
+		return nil
+	})
+	if err != nil {
+		log.Printf("agent_id=%d failed: %v", userID, err)
+		return resultFailed
+	}
+	if !created {
+		return resultSkipped
+	}
+	_ = relations.InvalidateFriendCache(ctx, mq.RDB, officialID)
+	_ = relations.InvalidateFriendCache(ctx, mq.RDB, userID)
+	return resultCreated
+}
+
+// loadTargets returns agent_ids that should be friended: profile-complete,
+// non-official users who are not already friends with the official account and
+// have not blocked it.
+func loadTargets(officialID int64, limit int) ([]int64, error) {
+	var ids []int64
+	q := db.DB.Raw(`
+		SELECT a.agent_id
+		  FROM agents a
+		 WHERE a.is_official = FALSE
+		   AND a.profile_completed_at IS NOT NULL
+		   AND NOT EXISTS (
+		         SELECT 1 FROM user_relations ur
+		          WHERE ur.from_uid = a.agent_id AND ur.to_uid = ? AND ur.rel_type = ?)
+		   AND NOT EXISTS (
+		         SELECT 1 FROM user_relations ur
+		          WHERE ur.from_uid = a.agent_id AND ur.to_uid = ? AND ur.rel_type = ?)
+		 ORDER BY a.agent_id ASC`,
+		officialID, pmdal.RelTypeFriend, officialID, pmdal.RelTypeBlock)
+	if err := q.Scan(&ids).Error; err != nil {
+		return nil, err
+	}
+	if limit > 0 && len(ids) > limit {
+		ids = ids[:limit]
+	}
+	return ids, nil
+}


### PR DESCRIPTION
## What
放开官方账号灰度：删掉 `OFFICIAL_WELCOME_WHITELIST` / `OFFICIAL_PM_WHITELIST` 白名单闸 + 测试后缀豁免。所有 profile-complete 用户自动加官方好友+收欢迎语。

- **A** welcome consumer：删白名单闸 → 全量欢迎
- **B** official Sender（PassesGate/ChatGate）+ #4/#5 cron：删白名单/IsTestRecipient。#4/#5 保留内容门槛+正常冷却（rescue feed<30/3d、trending 有热点/14d），不会骚扰
- **C** config：删两个白名单字段；保留 `OfficialTestEmailSuffixes`/`OfficialTestOTP`（登录后门 D 暂留在用）
- **D 登录后门 OTP 不动**（按需求暂留）
- **backfill 脚本** `scripts/official_friend_backfill`：给存量用户一次性补好友（只建关系不发欢迎语，含缓存失效，dry-run/幂等/并发）

## Test
`go build ./...` + `go vet` + `go test ./pipeline/...` 全绿。

## Deploy
后端 build + 重启 pipeline；prod 跑 backfill（先 --dry-run 看规模）；清理 prod .env 白名单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)