### PR TITLE
feat(grafana): PGC external alerting — 5 provisioned rules → Lark relay

### DIFF
--- a/configs/grafana/alerting/contactpoints.yml
+++ b/configs/grafana/alerting/contactpoints.yml
@@ -1,0 +1,22 @@
+# Grafana → PGC viewer relay → Lark ops group.
+#
+# Grafana 11.6 webhook contact points send a FIXED JSON schema that a Lark
+# custom-bot webhook rejects (silent-drop channel). The viewer on the app
+# host exposes POST /grafana-alert (eigenflux-pgc rsspipe/grafana_relay.py,
+# deployed 2026-07-15) which reformats to a plain-Chinese Lark card and
+# reuses the pipeline's delivery bookkeeping / dead-man alerting.
+#
+# $METRICS_HOST and $GRAFANA_ALERT_TOKEN come from the monitor host's .env
+# via the grafana service environment (docker-compose.monitor.yml) — the
+# internal IP and the shared secret stay out of the repo.
+apiVersion: 1
+contactPoints:
+  - orgId: 1
+    name: pgc-lark-relay
+    receivers:
+      - uid: pgc-lark-relay
+        type: webhook
+        settings:
+          url: http://$METRICS_HOST:9090/grafana-alert?token=$GRAFANA_ALERT_TOKEN
+          httpMethod: POST
+        disableResolveMessage: false

--- a/configs/grafana/alerting/pgc-rules.yml
+++ b/configs/grafana/alerting/pgc-rules.yml
@@ -1,0 +1,155 @@
+# PGC 链路告警规则（2026-07-15 首批，来源=7/12 巡检遗留的"外部告警为零"账）。
+#
+# 措辞规则：annotations.summary 是最终出现在 Lark 卡片上的句子——说人话、
+# 无黑话、一句话说清"什么坏了 + 多久了/差多少"。中继端(grafana_relay)只排版
+# 不改写。阈值备注了 2026-07-15 的观测基线，改阈值前先看当天真实值。
+#
+# noDataState 取向：链路可见性规则(停摆/刷新/火警)在 NoData 时也告警——
+# 抓不到指标本身就是事故(6/20 日志文档 17 天静默失败的教训)；额度类规则
+# NoData 不告警，避免抓取抖动引发狼来了。
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: pgc-alerts
+    folder: PGC 告警
+    interval: 1m
+    rules:
+      - uid: pgc-pipeline-dead
+        title: PGC 管道停摆
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        annotations:
+          summary: 抓取/处理/发布至少一个工序超过 30 分钟没有运行（正常最慢的抓取工序约 4 分钟一轮），或者监控完全抓不到管道指标了。
+        labels:
+          service: pgc
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: pgc-prometheus
+            model:
+              expr: max(pgc_worker_last_run_age_seconds)
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [1800] }
+
+      - uid: pgc-metrics-stale
+        title: PGC 指标刷新停滞
+        condition: C
+        for: 10m
+        noDataState: Alerting
+        execErrState: Alerting
+        annotations:
+          summary: 看板背后的指标已经超过 1 小时没有刷新成功——面板上的数字可能是旧的，别据此判断链路健康。
+        labels:
+          service: pgc
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: pgc-prometheus
+            model:
+              expr: time() - min(pgc_metrics_last_refresh_success_timestamp)
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [3600] }
+
+      - uid: pgc-source-fire
+        title: PGC 信源体检火警
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        annotations:
+          summary: 信源体检发现"火警"级问题——某个重点信源族可能整体熄火了（对照 2026-06 那次静默 50 小时的教训，这条必须当天处理）。
+        labels:
+          service: pgc
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: pgc-prometheus
+            model:
+              expr: pgc_source_health_critical_fire
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: pgc-newsapi-budget
+        title: NewsAPI 月额度告急
+        condition: C
+        for: 30m
+        noDataState: OK
+        execErrState: OK
+        annotations:
+          summary: NewsAPI 本月额度已用超过 90%——再不管，月底前 NewsAPI 各簇会集体熄火（基线：7/15 月中用量 53%）。
+        labels:
+          service: pgc
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: pgc-prometheus
+            model:
+              expr: pgc_newsapi_tokens_pct
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [90] }
+
+      - uid: pgc-scraperapi-credits
+        title: ScraperAPI 额度告急
+        condition: C
+        for: 30m
+        noDataState: OK
+        execErrState: OK
+        annotations:
+          summary: ScraperAPI 本月 credits 已用超过 90%——Reddit 全量 42 个源和多个代理源都靠它，烧干会一起断（基线：7/15 用量 31%）。
+        labels:
+          service: pgc
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: pgc-prometheus
+            model:
+              expr: pgc_scraperapi_credits_pct
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [90] }

--- a/configs/grafana/alerting/policies.yml
+++ b/configs/grafana/alerting/policies.yml
@@ -1,0 +1,11 @@
+# Route every alert to the Lark relay. group_by alertname so one flapping
+# rule batches into one card instead of spamming the group; repeat every 4h
+# while still firing (the boss-group rule: don't cry wolf, don't go silent).
+apiVersion: 1
+policies:
+  - orgId: 1
+    receiver: pgc-lark-relay
+    group_by: ["alertname"]
+    group_wait: 1m
+    group_interval: 10m
+    repeat_interval: 4h

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -84,6 +84,11 @@ services:
       - GRAFANA_PG_USER=${GRAFANA_PG_USER:-eigenflux}
       - GRAFANA_PG_PASSWORD=${GRAFANA_PG_PASSWORD:-eigenflux123}
       - GRAFANA_PG_DATABASE=${GRAFANA_PG_DATABASE:-eigenflux}
+      # Alerting contact point (configs/grafana/alerting/contactpoints.yml)
+      # interpolates these: the PGC viewer's internal address and the shared
+      # relay token both live in .env, never in the repo.
+      - METRICS_HOST=${METRICS_HOST:-host.docker.internal}
+      - GRAFANA_ALERT_TOKEN=${GRAFANA_ALERT_TOKEN:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -93,6 +98,7 @@ services:
       - ./configs/grafana/datasources.yml:/etc/grafana/provisioning/datasources/ds.yml
       - ./configs/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
       - ./configs/grafana/dashboards:/var/lib/grafana/dashboards
+      - ./configs/grafana/alerting:/etc/grafana/provisioning/alerting
     depends_on:
       jaeger:
         condition: service_healthy


### PR DESCRIPTION
## What

First external alerting for the PGC chain — closes the "外部告警为零" item open since the 7/12 ops review.

**5 alert rules** (folder `PGC 告警`, summaries in plain Chinese per the boss-group wording rules):

| Rule | Fires when | NoData |
|---|---|---|
| PGC 管道停摆 | any worker idle > 30 min (baseline: slowest ~4 min/cycle) | Alerting |
| PGC 指标刷新停滞 | metrics refresh stale > 1 h | Alerting |
| PGC 信源体检火警 | `critical_fire > 0` | Alerting |
| NewsAPI 月额度告急 | > 90% monthly (7/15 baseline: 53%) | OK |
| ScraperAPI 额度告急 | > 90% credits (7/15 baseline: 31%) | OK |

Visibility-critical rules alert on NoData too — losing the metrics scrape is itself an incident (the 6/20 17-day-silent-failure lesson). Budget rules don't, to avoid scrape-flap wolf-crying.

## Why a relay

Grafana 11.6 webhook contact points send a **fixed JSON schema** — pointed straight at a Lark custom-bot webhook, Lark 400s every post and Grafana shrugs: a silently-dead channel (the 7/7 "假主通道" failure shape). The contact point instead posts to the PGC viewer's token-gated `/grafana-alert` relay (eigenflux-pgc `5dd0f41`, **already deployed and e2e-verified**: 403/404/429 paths + a labeled test card delivered to the group), which renders a short Chinese card and reuses the pipeline's delivery bookkeeping + dead-man alerting.

`$METRICS_HOST` / `$GRAFANA_ALERT_TOKEN` interpolate from the monitor host `.env` (already pre-staged on aliapmo) — no internal IP or secret enters the repo.

## Verification

- Throwaway `grafana:11.6.0` container with these files mounted: all 5 rules + contact point provision cleanly, env interpolation confirmed against the API, zero provisioning errors.
- Relay side: 8 unit tests + prod e2e (bad token 403, wrong path 404, real push 200 → card arrived).

## Deploy after merge

```
ssh aliapmo 'cd /data/git/eigenflux && git pull && docker compose -f docker-compose.monitor.yml up -d grafana'
```

Then the "告警链路自检" card in the group can be re-triggered from Grafana UI (or wait for the first real incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)