### PR TITLE
fix(grafana): NewsAPI alert on per-key pct + brace env syntax (follow-up to #86)

### DIFF
--- a/configs/grafana/alerting/contactpoints.yml
+++ b/configs/grafana/alerting/contactpoints.yml
@@ -17,6 +17,6 @@ contactPoints:
       - uid: pgc-lark-relay
         type: webhook
         settings:
-          url: http://$METRICS_HOST:9090/grafana-alert?token=$GRAFANA_ALERT_TOKEN
+          url: http://${METRICS_HOST}:9090/grafana-alert?token=${GRAFANA_ALERT_TOKEN}
           httpMethod: POST
         disableResolveMessage: false

--- a/configs/grafana/alerting/pgc-rules.yml
+++ b/configs/grafana/alerting/pgc-rules.yml
@@ -105,7 +105,7 @@ groups:
         noDataState: OK
         execErrState: OK
         annotations:
-          summary: NewsAPI key {{ $labels.key }} 本月额度已用超过 90%——再不管，月底前用这个 key 的 NewsAPI 簇会熄火（基线：7/15 月中用量 53%；按 key 告警是因为合计口径会藏住单个耗尽的 key，2026-07-05 教训）。
+          summary: NewsAPI 本月额度已用超过 90%——再不管，月底前 NewsAPI 各簇会集体熄火（基线：7/15 月中用量 53%；2026-07-15 起只用单 key，指标仍按 key 导出故用 per-key 序列）。
         labels:
           service: pgc
         data:

--- a/configs/grafana/alerting/pgc-rules.yml
+++ b/configs/grafana/alerting/pgc-rules.yml
@@ -105,7 +105,7 @@ groups:
         noDataState: OK
         execErrState: OK
         annotations:
-          summary: 至少一个 NewsAPI key 本月额度已用超过 90%——再不管，月底前对应的 NewsAPI 簇会熄火（基线：7/15 月中用量 53%；按 key 看是因为合计口径会藏住单个耗尽的 key，2026-07-05 教训）。
+          summary: NewsAPI key {{ $labels.key }} 本月额度已用超过 90%——再不管，月底前用这个 key 的 NewsAPI 簇会熄火（基线：7/15 月中用量 53%；按 key 告警是因为合计口径会藏住单个耗尽的 key，2026-07-05 教训）。
         labels:
           service: pgc
         data:
@@ -113,7 +113,7 @@ groups:
             relativeTimeRange: { from: 600, to: 0 }
             datasourceUid: pgc-prometheus
             model:
-              expr: max(pgc_newsapi_key_tokens_pct)
+              expr: pgc_newsapi_key_tokens_pct
               instant: true
               refId: A
           - refId: C

--- a/configs/grafana/alerting/pgc-rules.yml
+++ b/configs/grafana/alerting/pgc-rules.yml
@@ -105,7 +105,7 @@ groups:
         noDataState: OK
         execErrState: OK
         annotations:
-          summary: NewsAPI 本月额度已用超过 90%——再不管，月底前 NewsAPI 各簇会集体熄火（基线：7/15 月中用量 53%）。
+          summary: 至少一个 NewsAPI key 本月额度已用超过 90%——再不管，月底前对应的 NewsAPI 簇会熄火（基线：7/15 月中用量 53%；按 key 看是因为合计口径会藏住单个耗尽的 key，2026-07-05 教训）。
         labels:
           service: pgc
         data:
@@ -113,7 +113,7 @@ groups:
             relativeTimeRange: { from: 600, to: 0 }
             datasourceUid: pgc-prometheus
             model:
-              expr: pgc_newsapi_tokens_pct
+              expr: max(pgc_newsapi_key_tokens_pct)
               instant: true
               refId: A
           - refId: C


### PR DESCRIPTION
Two-line follow-up addressing the #86 review comments — see the commit message for full reasoning.

1. **NewsAPI rule → `max(pgc_newsapi_key_tokens_pct)`**. The review bot's premise was factually wrong (`pgc_newsapi_tokens_pct` does exist on prod — 53.34% observed today; both metrics are exported), so there was never a silent-NoData failure. But per-key max is strictly better anyway: the aggregate hides a single exhausted key — the exact 2026-07-05 lesson that split the dashboard panel per-key (pgc#55).
2. **`${VAR}` brace syntax** in the contact point URL. `$VAR` was already empirically verified on grafana:11.6.0, braces are just unambiguous for free.

Revalidated on a throwaway grafana:11.6.0 container: 5 rules load, new expr provisioned, brace interpolation confirmed, per-key metric live on prod.

Deploy after merge: same one-liner as #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)