### PR TITLE
feat(api): dashboard 两个只读接口（contacted / new-users）

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -887,6 +887,125 @@ func Top7DayBroadcasts(db *gorm.DB, sinceMs, callerAgentID int64, limit int) ([]
 	return rows, err
 }
 
+// NewUserBroadcasts lists broadcasts authored by newly-registered agents
+// (agents.created_at within the last `windowMs` milliseconds of `nowMs`),
+// newest broadcast first, capped at `limit`. Unlike Top7DayBroadcasts it does
+// NOT require any positive feedback (new users rarely have praise yet) and does
+// NOT rank by helpful count — it surfaces fresh voices ordered by publish time.
+// Reuses TopBroadcastRow. PGC/bot accounts are still excluded, and the author's
+// name, show_add_friend setting, and the caller's friendship are joined in.
+func NewUserBroadcasts(db *gorm.DB, nowMs, windowMs, callerAgentID int64, limit int) ([]TopBroadcastRow, error) {
+	var rows []TopBroadcastRow
+	err := db.Raw(`
+		SELECT s.item_id,
+		       s.author_agent_id,
+		       COALESCE(a.agent_name, '')             AS agent_name,
+		       COALESCE(p.summary, '')                AS summary,
+		       COALESCE(p.summary_zh, '')             AS summary_zh,
+		       COALESCE(p.broadcast_type, '')         AS broadcast_type,
+		       (s.score_1_count + s.score_2_count)    AS praise_count,
+		       COALESCE(s.consumed_count, 0)          AS reach,
+		       COALESCE(st.show_add_friend, true)     AS show_add_friend,
+		       EXISTS (
+		           SELECT 1 FROM user_relations ur
+		            WHERE ur.from_uid = ? AND ur.to_uid = s.author_agent_id
+		              AND ur.rel_type = 1
+		       )                                      AS is_friend
+		  FROM item_stats s
+		  LEFT JOIN agents a          ON a.agent_id = s.author_agent_id
+		  LEFT JOIN agent_settings st ON st.agent_id = s.author_agent_id
+		  LEFT JOIN processed_items p ON p.item_id = s.item_id
+		 WHERE a.created_at >= ?
+		   AND COALESCE(a.email, '') NOT LIKE '%@pgc.eigenflux.one'
+		   AND COALESCE(a.email, '') NOT LIKE '%@bot.eigenflux.one'
+		 ORDER BY s.created_at DESC, s.item_id DESC
+		 LIMIT ?`,
+		callerAgentID, nowMs-windowMs, limit,
+	).Scan(&rows).Error
+	return rows, err
+}
+
+// ContactedRow is one peer the caller has previously contacted but is NOT
+// currently friends with: a durable friend-request sender and/or a non-friend
+// broadcast-comment conversation counterparty.
+type ContactedRow struct {
+	AgentID          int64  `gorm:"column:agent_id"`
+	AgentName        string `gorm:"column:agent_name"`
+	IsOfficial       bool   `gorm:"column:is_official"`
+	ShowAddFriend    bool   `gorm:"column:show_add_friend"`
+	LastContactAt    int64  `gorm:"column:last_contact_at"`
+	PendingRequestID int64  `gorm:"column:pending_request_id"`
+	HasRequest       bool   `gorm:"column:has_request"`
+	HasPm            bool   `gorm:"column:has_pm"`
+}
+
+// ContactedNonFriends returns the caller's de-duplicated history of peers they
+// have contacted but are NOT currently friends with, most-recent contact first.
+//
+// The union of two durable contact sources:
+//
+//	(a) friend_requests where to_uid = caller (ALL statuses — a rejected or
+//	    cancelled request still proves prior contact); peer = from_uid, contact
+//	    time = updated_at. A still-pending row surfaces its id as
+//	    pending_request_id so the client can accept it directly.
+//	(b) conversations whose origin_type = 'broadcast' where the caller is a
+//	    participant; peer = the other participant, contact time = updated_at.
+//	    Combined with the friend-exclusion below this is exactly the
+//	    "non_friend" bucket (broadcast conversation + not currently friends).
+//
+// Current friends (user_relations rel_type=1), the caller itself, and PGC/bot
+// accounts (emails ending in @pgc.eigenflux.one / @bot.eigenflux.one) are
+// excluded after the union, so an accepted request / now-friend peer never
+// appears. Rows are grouped by peer, so a peer reached both ways collapses to
+// one entry with both sources flagged.
+func ContactedNonFriends(db *gorm.DB, callerAgentID int64) ([]ContactedRow, error) {
+	var rows []ContactedRow
+	err := db.Raw(`
+		WITH contacts AS (
+		    SELECT fr.from_uid                                       AS peer_id,
+		           fr.updated_at                                     AS contact_at,
+		           true                                              AS is_request,
+		           false                                             AS is_pm,
+		           CASE WHEN fr.status = 0 THEN fr.id ELSE 0 END     AS pending_req_id
+		      FROM friend_requests fr
+		     WHERE fr.to_uid = ?
+		    UNION ALL
+		    SELECT CASE WHEN c.participant_a = ? THEN c.participant_b
+		                ELSE c.participant_a END                     AS peer_id,
+		           c.updated_at                                      AS contact_at,
+		           false                                             AS is_request,
+		           true                                              AS is_pm,
+		           0                                                 AS pending_req_id
+		      FROM conversations c
+		     WHERE (c.participant_a = ? OR c.participant_b = ?)
+		       AND c.origin_type = 'broadcast'
+		)
+		SELECT ct.peer_id                          AS agent_id,
+		       COALESCE(a.agent_name, '')          AS agent_name,
+		       COALESCE(a.is_official, false)       AS is_official,
+		       COALESCE(st.show_add_friend, true)   AS show_add_friend,
+		       MAX(ct.contact_at)                   AS last_contact_at,
+		       COALESCE(MAX(ct.pending_req_id), 0)  AS pending_request_id,
+		       bool_or(ct.is_request)               AS has_request,
+		       bool_or(ct.is_pm)                    AS has_pm
+		  FROM contacts ct
+		  LEFT JOIN agents a          ON a.agent_id = ct.peer_id
+		  LEFT JOIN agent_settings st ON st.agent_id = ct.peer_id
+		 WHERE ct.peer_id <> ?
+		   AND COALESCE(a.email, '') NOT LIKE '%@pgc.eigenflux.one'
+		   AND COALESCE(a.email, '') NOT LIKE '%@bot.eigenflux.one'
+		   AND NOT EXISTS (
+		       SELECT 1 FROM user_relations ur
+		        WHERE ur.from_uid = ? AND ur.to_uid = ct.peer_id
+		          AND ur.rel_type = 1
+		   )
+		 GROUP BY ct.peer_id, a.agent_name, a.is_official, st.show_add_friend
+		 ORDER BY last_contact_at DESC`,
+		callerAgentID, callerAgentID, callerAgentID, callerAgentID, callerAgentID, callerAgentID,
+	).Scan(&rows).Error
+	return rows, err
+}
+
 // RatedItem is a broadcast the caller has scored, with the caller's own score
 // and enough item content to render a card.
 type RatedItem struct {

--- a/api/handler_gen/eigenflux/api/broadcast_extra.go
+++ b/api/handler_gen/eigenflux/api/broadcast_extra.go
@@ -166,3 +166,46 @@ func TopBroadcasts(ctx context.Context, c *app.RequestContext) {
 		"list":        list,
 	})
 }
+
+// newUserWindowMs is the registration-recency window for the new-user broadcast
+// board: broadcasts from agents who registered within the last 3 days.
+const newUserWindowMs int64 = 3 * 24 * 60 * 60 * 1000
+
+// NewUserBroadcasts returns up to 100 broadcasts authored by agents who
+// registered in the last 3 days, newest broadcast first. Unlike /broadcasts/top
+// it does not require any positive feedback, so freshly-joined agents surface
+// even before they earn praise. Response shape matches /broadcasts/top exactly.
+func NewUserBroadcasts(ctx context.Context, c *app.RequestContext) {
+	agentID, ok := currentAgentID(c)
+	if !ok {
+		return
+	}
+	nowMs := time.Now().UnixMilli()
+	rows, err := consoledal.NewUserBroadcasts(db.DB, nowMs, newUserWindowMs, agentID, 100)
+	if err != nil {
+		writeJSON(c, http.StatusInternalServerError, 1, "failed to load new-user broadcasts", nil)
+		return
+	}
+
+	list := make([]map[string]interface{}, 0, len(rows))
+	for i, r := range rows {
+		list = append(list, map[string]interface{}{
+			"rank":            i + 1,
+			"item_id":         strconv.FormatInt(r.ItemID, 10),
+			"agent_id":        strconv.FormatInt(r.AuthorAgentID, 10),
+			"agent_name":      r.AgentName,
+			"summary":         r.Summary,
+			"summary_zh":      r.SummaryZh,
+			"broadcast_type":  r.BroadcastType,
+			"praise_count":    r.PraiseCount,
+			"show_add_friend": r.ShowAddFriend,
+			"is_friend":       r.IsFriend,
+			"is_me":           r.AuthorAgentID == agentID,
+		})
+	}
+
+	writeJSON(c, http.StatusOK, 0, "success", map[string]interface{}{
+		"window_days": 3,
+		"list":        list,
+	})
+}

--- a/api/handler_gen/eigenflux/api/relations_extra.go
+++ b/api/handler_gen/eigenflux/api/relations_extra.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	consoledal "eigenflux_server/api/dal"
+	"eigenflux_server/pkg/db"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+// ContactedRelations returns the caller's de-duplicated history of peers they
+// have contacted but are NOT currently friends with, most-recent contact first.
+// It unions durable friend-request senders (any status) with non-friend
+// broadcast-comment conversation counterparties, so the UI can offer a
+// re-connect action for each. A still-pending incoming request surfaces its
+// request_id so the client can accept directly (/relations/handle); otherwise
+// the client falls back to a fresh apply (/relations/apply).
+func ContactedRelations(ctx context.Context, c *app.RequestContext) {
+	agentID, ok := currentAgentID(c)
+	if !ok {
+		return
+	}
+	rows, err := consoledal.ContactedNonFriends(db.DB, agentID)
+	if err != nil {
+		writeJSON(c, http.StatusInternalServerError, 1, "failed to load contacted relations", nil)
+		return
+	}
+
+	list := make([]map[string]interface{}, 0, len(rows))
+	for _, r := range rows {
+		sources := make([]string, 0, 2)
+		if r.HasRequest {
+			sources = append(sources, "request")
+		}
+		if r.HasPm {
+			sources = append(sources, "pm")
+		}
+		pendingID := ""
+		if r.PendingRequestID != 0 {
+			pendingID = strconv.FormatInt(r.PendingRequestID, 10)
+		}
+		list = append(list, map[string]interface{}{
+			"agent_id":           strconv.FormatInt(r.AgentID, 10),
+			"agent_name":         r.AgentName,
+			"is_official":        r.IsOfficial,
+			"show_add_friend":    r.ShowAddFriend,
+			"last_contact_at":    r.LastContactAt,
+			"pending_request_id": pendingID,
+			"sources":            sources,
+		})
+	}
+
+	writeJSON(c, http.StatusOK, 0, "success", map[string]interface{}{
+		"list": list,
+	})
+}

--- a/api/main.go
+++ b/api/main.go
@@ -198,6 +198,12 @@ func main() {
 	h.GET("/api/v1/broadcasts/rated", middleware.AuthMiddleware(), apihandler.MyRatedItems)
 	// Network-wide 7-day most-helpful broadcasts board (top 100 by helpful count).
 	h.GET("/api/v1/broadcasts/top", middleware.AuthMiddleware(), apihandler.TopBroadcasts)
+	// New-user broadcasts: up to 100 broadcasts from agents registered in the
+	// last 3 days, newest first (no praise threshold).
+	h.GET("/api/v1/broadcasts/new-users", middleware.AuthMiddleware(), apihandler.NewUserBroadcasts)
+	// Contacted-but-not-friend history: durable friend-request senders + non-friend
+	// broadcast-comment conversation peers, de-duplicated, most-recent first.
+	h.GET("/api/v1/relations/contacted", middleware.AuthMiddleware(), apihandler.ContactedRelations)
 
 	// AgentRapport quiz (public marketing activity at /agti). Registered
 	// manually like the settings routes above; public by design (no auth).


### PR DESCRIPTION
为工作台新增两个只读 REST 接口。`go build ./...` + `go vet ./api/...` 通过。**无 DB migration**（只查现有表）。

- **GET /api/v1/broadcasts/new-users**：作者注册 ≤3 天的广播，最新优先，LIMIT 100，去掉好评过滤，保留 @pgc/@bot 排除，复用 TopBroadcastRow，响应与 /broadcasts/top 一致（window_days:3）
- **GET /api/v1/relations/contacted**：曾联系过但当前非好友的去重历史 = union(好友申请全状态 + 非好友广播会话对端)，GROUP BY peer 去重，排除当前好友/自己/@pgc/@bot；pending_request_id 区分 accept/apply

配合前端 PR（关系「联系过的非好友」子 tab + 广播「新用户广播」子 tab）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)