### PR TITLE
fix(api,pm): 新用户广播内容过滤 + 未读计数精选

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -914,8 +914,9 @@ func NewUserBroadcasts(db *gorm.DB, nowMs, windowMs, callerAgentID int64, limit 
 		  FROM item_stats s
 		  LEFT JOIN agents a          ON a.agent_id = s.author_agent_id
 		  LEFT JOIN agent_settings st ON st.agent_id = s.author_agent_id
-		  LEFT JOIN processed_items p ON p.item_id = s.item_id
+		  JOIN processed_items p      ON p.item_id = s.item_id
 		 WHERE a.created_at >= ?
+		   AND (COALESCE(p.summary_zh, '') <> '' OR COALESCE(p.summary, '') <> '')
 		   AND COALESCE(a.email, '') NOT LIKE '%@pgc.eigenflux.one'
 		   AND COALESCE(a.email, '') NOT LIKE '%@bot.eigenflux.one'
 		 ORDER BY s.created_at DESC, s.item_id DESC

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -2107,11 +2107,15 @@ func ConsoleGetToday(ctx context.Context, c *app.RequestContext) {
 		return nil
 	})
 
-	// Parallel: total unread message count (for the messages nav badge).
+	// Parallel: unread count for the messages nav badge. Matches what the Messages
+	// page actually shows — friend DMs + ice-broken non-friend threads — so it
+	// excludes broadcast-comment discussions (their own tab was removed) and cold
+	// single-comment non-friend pings (hidden until a reply). Otherwise the badge
+	// would count messages the user can't reach/clear from Messages.
 	g.Go(func() error {
 		uresp, err := clients.PMClient.GetUnreadCount(gCtx, &pmrpc.GetUnreadCountReq{AgentId: agentID})
 		if err == nil && uresp.BaseResp != nil && uresp.BaseResp.Code == 0 {
-			unreadCount = uresp.Count
+			unreadCount = uresp.GetCountFriend() + uresp.GetCountNonFriend()
 		}
 		return nil
 	})

--- a/rpc/pm/dal/db.go
+++ b/rpc/pm/dal/db.go
@@ -272,6 +272,7 @@ func CountUnreadByOrigin(db *gorm.DB, agentID int64) (broadcastComment, nonFrien
 		   END AS bucket, COUNT(*) AS n
 		 FROM private_messages pm JOIN conversations c ON pm.conv_id = c.conv_id
 		 WHERE pm.receiver_id = ? AND pm.is_read = false
+		   AND (c.origin_type = 'friend' OR c.msg_count >= 2)
 		 GROUP BY bucket`, agentID, agentID, agentID,
 	).Scan(&rows).Error
 	for _, r := range rows {


### PR DESCRIPTION
配合工作台第一轮测试修复。`go build ./...` + `go vet` 通过。无 schema/migration 变更。

- #2 NewUserBroadcasts 改 INNER JOIN processed_items + 要求 summary/summary_zh 非空，过滤空内容新广播
- 未读精选：CountUnreadByOrigin 仅统计 ice-broken 广播会话（msg_count>=2）；console/today 的 unread_count 改用 friend + non_friend（排除广播讨论桶），与消息页可见/可清除未读一致

配合前端 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)