### PR TITLE
fix(highlights): 今日精选归因取用户命中关键词

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -245,6 +245,7 @@ type HighlightItem struct {
 	RankScore     float64 `gorm:"column:rank_score"`
 	ServedAt      int64   `gorm:"column:served_at"`
 	ItemFeatures  string  `gorm:"column:item_features"`
+	AgentFeatures string  `gorm:"column:agent_features"`
 	FbScore       int16   `gorm:"column:fb_score"`
 	Summary       string  `gorm:"column:summary"`
 	SummaryZh     string  `gorm:"column:summary_zh"`
@@ -277,6 +278,7 @@ func GetHighlightsForAgent(db *gorm.DB, agentID, sinceMs int64, limit int) ([]Hi
 		    SELECT DISTINCT ON (rl.item_id)
 		           rl.item_id, rl.impression_id, rl.item_score AS rank_score, rl.served_at,
 		           rl.item_features::text        AS item_features,
+		           rl.agent_features::text       AS agent_features,
 		           COALESCE(f.score, -9)         AS fb_score,
 		           COALESCE(p.summary, '')       AS summary,
 		           COALESCE(p.summary_zh, '')    AS summary_zh,

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -2447,8 +2447,16 @@ func ConsoleGetHighlights(ctx context.Context, c *app.RequestContext) {
 
 	// Derive a one-line push reason from the ranking factors captured at
 	// serve time: keyword hit > semantic affinity > freshness.
-	deriveReason := func(featuresJSON string) (string, string) {
-		var f struct {
+	//
+	// For a keyword hit the term must be the user's *own* interest keyword
+	// that this item also carries — i.e. item.keywords ∩ agent.keywords — not
+	// the item's own headline tag. Both snapshots come from the same
+	// replay_logs row (item_features / agent_features). If there is no
+	// intersection (or agent_features is empty on legacy rows) we fall through
+	// to the semantic / freshness branches rather than mislabel the item's
+	// broadcast tag as "your interest".
+	deriveReason := func(agentFeaturesJSON, itemFeaturesJSON string) (string, string) {
+		var item struct {
 			Keywords   []string `json:"keywords"`
 			Domains    []string `json:"domains"`
 			Timeliness string   `json:"timeliness"`
@@ -2458,18 +2466,43 @@ func ConsoleGetHighlights(ctx context.Context, c *app.RequestContext) {
 				Freshness float64 `json:"freshness"`
 			} `json:"rank_scores"`
 		}
-		if json.Unmarshal([]byte(featuresJSON), &f) != nil {
+		if json.Unmarshal([]byte(itemFeaturesJSON), &item) != nil {
 			return "", ""
 		}
+		var agent struct {
+			Keywords []string `json:"keywords"`
+		}
+		// agent_features is optional (empty on legacy rows); ignore parse errors.
+		_ = json.Unmarshal([]byte(agentFeaturesJSON), &agent)
+
+		if item.RankScores.Keyword > 0 && len(item.Keywords) > 0 && len(agent.Keywords) > 0 {
+			// Case-insensitive intersection: keyword storage isn't guaranteed
+			// normalized across the two snapshots.
+			itemSet := make(map[string]struct{}, len(item.Keywords))
+			for _, kw := range item.Keywords {
+				if k := strings.ToLower(strings.TrimSpace(kw)); k != "" {
+					itemSet[k] = struct{}{}
+				}
+			}
+			for _, akw := range agent.Keywords {
+				norm := strings.ToLower(strings.TrimSpace(akw))
+				if norm == "" {
+					continue
+				}
+				if _, ok := itemSet[norm]; ok {
+					// Return the user's own keyword as they follow it.
+					return "keyword", strings.TrimSpace(akw)
+				}
+			}
+			// No real hit on a user keyword — fall through.
+		}
 		switch {
-		case f.RankScores.Keyword > 0 && len(f.Keywords) > 0:
-			return "keyword", f.Keywords[0]
-		case f.RankScores.Semantic >= 0.3 && len(f.Domains) > 0:
-			return "semantic", f.Domains[0]
-		case f.RankScores.Freshness >= 0.8 && (f.Timeliness == "breaking" || f.Timeliness == "timely"):
-			return "fresh", f.Timeliness
-		case len(f.Domains) > 0:
-			return "semantic", f.Domains[0]
+		case item.RankScores.Semantic >= 0.3 && len(item.Domains) > 0:
+			return "semantic", item.Domains[0]
+		case item.RankScores.Freshness >= 0.8 && (item.Timeliness == "breaking" || item.Timeliness == "timely"):
+			return "fresh", item.Timeliness
+		case len(item.Domains) > 0:
+			return "semantic", item.Domains[0]
 		}
 		return "", ""
 	}
@@ -2502,7 +2535,7 @@ func ConsoleGetHighlights(ctx context.Context, c *app.RequestContext) {
 			authorBio = bio
 		}
 
-		reasonType, reasonTerm := deriveReason(it.ItemFeatures)
+		reasonType, reasonTerm := deriveReason(it.AgentFeatures, it.ItemFeatures)
 		hl := map[string]interface{}{
 			"item_id":        strconv.FormatInt(it.ItemID, 10),
 			"impression_id":  it.ImpressionID,


### PR DESCRIPTION
`go build ./...` + `go vet` 通过。无 schema/migration。只动 api 服务。

deriveReason 之前只传 item features、keyword 分支返回 item.keywords[0]，导致「你的关注: EigenFlux」这类错误归因（EigenFlux 是广播标签，非用户兴趣）。

- HighlightItem 加 AgentFeatures；GetHighlightsForAgent 补选 rl.agent_features
- deriveReason 接收 agent+item 两侧，keyword 分支返回 item.keywords ∩ agent.keywords 的第一个交集词（忽略大小写）；无交集贯穿 semantic/fresh/domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)