### PR TITLE
fix(pm): ListConversations 支持 broadcast_all（修联系过的非好友空数据）

### DIFF
--- a/rpc/pm/dal/db.go
+++ b/rpc/pm/dal/db.go
@@ -143,6 +143,13 @@ func ListConversationsFiltered(db *gorm.DB, agentID, cursor int64, limit int, or
 	case "friend":
 		countCond = "msg_count >= 1"
 		originFilter = " AND origin_type = ?"
+	case "broadcast_all":
+		// Complete superset of broadcast-originated conversations regardless of
+		// the ice-break threshold (msg_count >= 1). The Relations "contacted
+		// non-friends" tab pages through this and keeps category = non_friend.
+		// NOTE: not a real origin_type value — do NOT add a literal origin filter,
+		// or it would match zero rows.
+		countCond = "origin_type <> 'friend' AND msg_count >= 1"
 	case "":
 		countCond = "((origin_type = 'friend' AND msg_count >= 1) OR (origin_type <> 'friend' AND msg_count >= 2))"
 	default:


### PR DESCRIPTION
后端未实现 broadcast_all，当字面过滤 origin_type='broadcast_all' 匹配 0 行导致该 tab 永远空。加 case 返回所有广播起会话(msg_count>=1)。go build/vet 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)