### PR TITLE
修:信源体检火警不该烧在陈旧快照上

### DIFF
--- a/configs/grafana/alerting/pgc-rules.yml
+++ b/configs/grafana/alerting/pgc-rules.yml
@@ -85,7 +85,14 @@ groups:
             relativeTimeRange: { from: 600, to: 0 }
             datasourceUid: pgc-prometheus
             model:
-              expr: pgc_source_health_critical_fire
+              # 2026-07-28: 只在体检快照还新鲜时才认这个火警。信源体检报告
+              # 是每天 09:45 CST 才重跑一次的快照，所以问题修好之后它还会
+              # 继续烧到第二天——当天实测过：供应商 08:32 UTC 换好证书、源在
+              # 10:03-10:09 UTC 全部恢复轮询，而火警仍基于 01:46 UTC 那份
+              # 故障期快照在响。`or vector(0)` 是必须的：本规则 noDataState
+              # 是 Alerting，光用 `and on()` 会把陈旧变成空、空又变成告警。
+              # 快照本身陈旧了由「PGC 审计停摆」负责喊，不会没人管。
+              expr: (pgc_source_health_critical_fire and on() (pgc_source_health_report_age_seconds < 129600)) or vector(0)
               instant: true
               refId: A
           - refId: C
@@ -197,7 +204,7 @@ groups:
         noDataState: Alerting
         execErrState: Alerting
         annotations:
-          summary: 质量审计（内容值得看的比例 / 转述是否忠于原文 / 是否误删真实信息）已经超过 36 小时没有出过新结果——看板上这几个数字是旧的，别据此判断内容质量。常见原因是审计抢不到判决锁被挤掉。
+          summary: 每日体检（内容值得看的比例 / 转述是否忠于原文 / 是否误删真实信息 / 信源体检）已经超过 36 小时没有出过新结果——看板上这几个数字是旧的，别据此判断内容质量。常见原因是审计抢不到判决锁被挤掉。
         labels:
           service: pgc
         data:
@@ -208,7 +215,7 @@ groups:
               # 三个日更审计取最旧的一个。周期 24h，阈值 36h＝漏跑一次后
               # 约 12 小时报警，既能抓单次漏跑又不会因为跑得慢而抖动
               # （报告是在跑完时才写的，跑得慢不会推高年龄）。
-              expr: max({__name__=~"pgc_broadcast_faithfulness_age_seconds|pgc_broadcast_signal_age_seconds|pgc_discard_audit_age_seconds"})
+              expr: max({__name__=~"pgc_broadcast_faithfulness_age_seconds|pgc_broadcast_signal_age_seconds|pgc_discard_audit_age_seconds|pgc_source_health_report_age_seconds"})
               instant: true
               refId: A
           - refId: C


### PR DESCRIPTION
## 现象

火警在响，但**源其实早就好了**。

## 实测

| 时刻 (UTC) | 事件 |
|---|---|
| 00:42 | ScraperAPI 供应商叶证书过期（今早的根因） |
| **01:46** | **信源体检报告生成——正好落在故障窗口内** |
| 08:32 | 供应商换好新证书（有效期至 10/26） |
| 10:03–10:09 | Databricks / Vercel / European Parliament / Nature **全部恢复成功轮询，无一封禁** |
| 至今 | 火警仍在响，因为它读的是 01:46 那份快照 |

信源体检报告**每天 09:45 CST 才重跑一次**。所以一个「必须当天处理」的告警，会在问题修好后继续烧到第二天早上；反过来，新故障也可能被埋最多一天。

**和今天查的审计停摆是同一个病：把日更快照当成实时信号。**

## 处理

手工重跑报告（用 `--no-push`，不推重复卡片）后：

```
critical_fire   2 -> 0
canaries_failed 1 -> 0
54 条探针全过
```

剩余 `critical_watch = 10` 是安静发布方（ARC / 澳央行 / 瑞士央行 / Discord Blog 等），`consecutive_fails=0` 且无报错，属正常水位不是火。

## 本 PR 改了什么

`pgc_source_health_report_age_seconds` **早就存在，只是没有任何告警用它**。

1. **火警加新鲜度闸**：快照超过 36 小时就不再认这个火。

   ⚠️ `or vector(0)` 是必须的——本规则 `noDataState: Alerting`，光用 `and on()` 会把「陈旧」变成「空」、空又变成「告警」，等于没修。两个分支都对 prod 实测过：新鲜时返回真实值，陈旧时返回 0。

2. **「PGC 审计停摆」的监视范围加上信源体检报告**，所以快照真的陈旧了仍然有人喊，只是不再伪装成火警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
