### PR TITLE
fix(sort): populate geo from profile Country instead of hardcoded empty string

### DIFF
--- a/rpc/sort/handler.go
+++ b/rpc/sort/handler.go
@@ -155,7 +155,7 @@ func (s *SortServiceESImpl) SortItems(ctx context.Context, req *sort.SortItemsRe
 				}
 				keywords = cleanKeywords
 				domains = cleanKeywords
-				geo = "" // TODO: extract from profile if available
+				geo = ap.Country
 
 				logger.Ctx(ctx).Debug("profile from DB", "keywords", keywords, "domains", domains, "geo", geo)
 
@@ -184,8 +184,9 @@ func (s *SortServiceESImpl) SortItems(ctx context.Context, req *sort.SortItemsRe
 			}
 			keywords = cleanKeywords
 			domains = cleanKeywords
+			geo = ap.Country
 		}
-		logger.Ctx(ctx).Debug("profile from DB", "keywords", keywords, "domains", domains)
+		logger.Ctx(ctx).Debug("profile from DB", "keywords", keywords, "domains", domains, "geo", geo)
 	}
 
 	// Fetch profile embedding for semantic scoring


### PR DESCRIPTION
## Problem

`SortItems` in `rpc/sort/handler.go` had a `TODO: extract from profile if available` at line 158, hardcoding `geo = ""` when fetching profile from DB. This means:

- `buildGeoCountryFilter()` never receives a country → geo-based feed filtering is effectively disabled
- The `else` branch (no profile cache) also never sets `geo`, and its debug log omits the geo field
- `CachedProfile` already has `Geo` and `GeoCountry` fields, and `AgentProfile.Country` exists in the DB — they were just never wired together

## Fix

- **Cache-miss path** (line 158): replace `geo = ""` with `geo = ap.Country`
- **No-cache path** (line 186): add `geo = ap.Country` and include it in the debug log

## Impact

Agents who set their Country during onboarding will now have their geo correctly used for:
- `buildGeoCountryFilter` — items are filtered/scored by geographic relevance
- ES query `geo` field — contributes to relevance scoring in `es_query.go`

No schema changes, no API changes — just reading an existing field that was already available.