### PR TITLE
feat: make PGC dashboard owner readable

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -299,96 +299,6 @@
       "description": "抢先送达的那些事件，我们比媒体早多少（中间值）。\n正常：一小时以上。\n要行动：掉到半小时以下，说明赢的都是险胜，抢先随时会翻成落后。"
     },
     {
-      "id": 72,
-      "title": "还有多少条没判完",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "pgc-prometheus"
-      },
-      "gridPos": {
-        "x": 18,
-        "y": 1,
-        "w": 6,
-        "h": 5
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "pgc_event_wins_pending",
-          "instant": true,
-          "legendFormat": "待判",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "mappings": [
-            {
-              "type": "special",
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "无数据",
-                  "color": "red"
-                }
-              }
-            },
-            {
-              "type": "value",
-              "options": {
-                "-1": {
-                  "text": "无数据",
-                  "color": "text",
-                  "index": 0
-                }
-              }
-            }
-          ],
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
-                "color": "red",
-                "value": 200
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto"
-      },
-      "description": "抢先要两家判官都确认才算数，没判完的一律不计入左边的「确认抢先条数」。\n正常：0。\n要行动：这个数一大，就说明左边那个数是被低估的——先看判官算力，不要先怀疑产品。"
-    },
-    {
       "id": 101,
       "type": "row",
       "title": "质量 — 今天有没有伤害用户",
@@ -694,7 +604,7 @@
       "gridPos": {
         "x": 0,
         "y": 14,
-        "w": 5,
+        "w": 6,
         "h": 5
       },
       "targets": [
@@ -753,9 +663,9 @@
       "title": "关键来源断了几个",
       "description": "必须保活的关键来源当前失败的数量。正常为 0；非 0 说明抓取通路已断或被对方封锁，立即排查。这个数字已计入左侧故障总数。",
       "gridPos": {
-        "x": 5,
+        "x": 6,
         "y": 14,
-        "w": 5,
+        "w": 6,
         "h": 5
       },
       "datasource": {
@@ -821,9 +731,9 @@
       "title": "PGC 自己造成的迟到",
       "description": "高优先来源近 3 小时内，因为 PGC 抓取、处理或发布太慢而迟到的条数。这里不混入“上游自己晚发”。正常为 0；非 0 立即看下方来源明细。",
       "gridPos": {
-        "x": 10,
+        "x": 12,
         "y": 14,
-        "w": 5,
+        "w": 6,
         "h": 5
       },
       "datasource": {
@@ -889,9 +799,9 @@
       "title": "一手来源空缺线索",
       "description": "审计发现“媒体已经报道，但对应一手来源未配置或没抓到”的线索数。它不是已经确认的漏文；下方会逐篇列出报道、原因和建议动作。",
       "gridPos": {
-        "x": 15,
+        "x": 18,
         "y": 14,
-        "w": 5,
+        "w": 6,
         "h": 5
       },
       "datasource": {
@@ -948,9 +858,9 @@
       "type": "stat",
       "title": "我们比媒体更早的比例",
       "gridPos": {
-        "x": 20,
-        "y": 14,
-        "w": 4,
+        "x": 18,
+        "y": 1,
+        "w": 6,
         "h": 5
       },
       "datasource": {
@@ -966,11 +876,44 @@
       "fieldConfig": {
         "defaults": {
           "unit": "percent",
-          "decimals": 1
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 20
+              },
+              {
+                "color": "green",
+                "value": 40
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "options": {},
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
       "description": "对外可引用的抢先率：在可比较事件里，PGC 比基准媒体更早的比例。必须和下方样本量一起读；提升主要靠修慢源和补一手来源。"
     },
     {
@@ -2310,8 +2253,8 @@
       "gridPos": {
         "x": 0,
         "y": 62,
-        "w": 24,
-        "h": 7
+        "w": 12,
+        "h": 9
       },
       "datasource": {
         "type": "prometheus",
@@ -2420,6 +2363,204 @@
               "target_hours": 2,
               "state": 3
             }
+          }
+        }
+      ]
+    },
+    {
+      "id": 82,
+      "type": "table",
+      "title": "具体哪些信源有问题",
+      "description": "把上方「被封、高风险失败、更新超时、关键源观察」拆成具体来源。红色当天处理；黄色表示源近期安静或刚出现失败，需要判断是正常发布节奏还是该换更快渠道。点击来源地址可直接复盘。",
+      "gridPos": {
+        "x": 12,
+        "y": 62,
+        "w": 12,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "targets": [
+        {
+          "expr": "pgc_source_health_problem_source_info",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "问题"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "critical_fire": {
+                        "text": "关键来源故障",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "blocked": {
+                        "text": "抓取已封",
+                        "color": "red",
+                        "index": 1
+                      },
+                      "failing_high": {
+                        "text": "连续抓取失败",
+                        "color": "red",
+                        "index": 2
+                      },
+                      "blocked_sla": {
+                        "text": "被封且超过承诺",
+                        "color": "red",
+                        "index": 3
+                      },
+                      "poll_gap_sla": {
+                        "text": "超过轮询承诺",
+                        "color": "red",
+                        "index": 4
+                      },
+                      "quiet_sla": {
+                        "text": "超过无产出承诺",
+                        "color": "yellow",
+                        "index": 5
+                      },
+                      "critical_watch": {
+                        "text": "关键来源近期安静",
+                        "color": "yellow",
+                        "index": 6
+                      },
+                      "failing_low": {
+                        "text": "刚出现抓取失败",
+                        "color": "yellow",
+                        "index": 7
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "优先级"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "T0": {
+                        "text": "必须第一时间",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "T1": {
+                        "text": "高优先",
+                        "color": "yellow",
+                        "index": 1
+                      },
+                      "T2": {
+                        "text": "覆盖来源",
+                        "color": "blue",
+                        "index": 2
+                      },
+                      "T3": {
+                        "text": "长尾来源",
+                        "color": "text",
+                        "index": 3
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "来源地址"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "打开来源",
+                    "url": "${__value.raw}",
+                    "targetBlank": true
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "renameByName": {
+              "source": "来源",
+              "category": "领域",
+              "source_tier": "优先级",
+              "issue": "问题",
+              "detail": "证据",
+              "last_error": "最近错误",
+              "source_url": "来源地址"
+            },
+            "indexByName": {}
           }
         }
       ]

--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -24,7 +24,7 @@
     {
       "id": 100,
       "type": "row",
-      "title": "北极星 — 今天做成了什么",
+      "title": "结果 — 今天做成了什么",
       "collapsed": false,
       "panels": [],
       "gridPos": {
@@ -36,7 +36,7 @@
     },
     {
       "id": 21,
-      "title": "今天发出多少条",
+      "title": "今天发出了多少条信号",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
@@ -105,7 +105,7 @@
     },
     {
       "id": 19,
-      "title": "确认抢先条数",
+      "title": "今天确认抢先了多少条",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
@@ -230,7 +230,7 @@
     },
     {
       "id": 71,
-      "title": "比媒体早多久",
+      "title": "抢先时通常早了多久",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
@@ -300,7 +300,7 @@
     },
     {
       "id": 72,
-      "title": "还没判完的条数",
+      "title": "还有多少条没判完",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
@@ -391,7 +391,7 @@
     {
       "id": 101,
       "type": "row",
-      "title": "止损线 — 红了就停下来处理",
+      "title": "质量 — 今天有没有伤害用户",
       "collapsed": false,
       "panels": [],
       "gridPos": {
@@ -403,7 +403,7 @@
     },
     {
       "id": 73,
-      "title": "今天说错话的条数",
+      "title": "可能转述不准的条数（估计）",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
@@ -412,7 +412,7 @@
       "gridPos": {
         "x": 0,
         "y": 7,
-        "w": 12,
+        "w": 6,
         "h": 6
       },
       "targets": [
@@ -421,16 +421,6 @@
           "expr": "pgc_broadcast_unfaithful_24h",
           "instant": true,
           "legendFormat": "条/天",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          }
-        },
-        {
-          "refId": "B",
-          "expr": "pgc_broadcast_faithfulness_weighted_pct",
-          "instant": true,
-          "legendFormat": "忠实率（两层加权）",
           "datasource": {
             "type": "prometheus",
             "uid": "pgc-prometheus"
@@ -477,16 +467,97 @@
           "values": false
         },
         "orientation": "auto",
-        "textMode": "value_and_name",
-        "colorMode": "value",
+        "textMode": "auto",
+        "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto"
       },
-      "description": "转述歪曲了原文的广播条数（估计值，已覆盖全部两层，包括只凭标题广播的那一层）。\n⚠️ 阈值校准中，暂不染色：首日实测约 344 条/天，而按老口径只看完整来源层会显示 99.5% 忠实，两者是同一个事实。拉满三天分布后再定红线——先拍一个数上去，只会让人第一天就看见红色然后学会忽略它。\n怎么读：这个数的大头来自「仅标题」那一层，它的误差范围也最大（见下方诚实度表）。"
+      "description": "这是质检对全量广播的估计，不是 428 篇已经逐篇确认的错误。大头来自只能拿到标题的来源，因此先用蓝色表示「需要继续校准」，不把它伪装成已确认事故。\n要行动：先看右侧忠实率和下方样本量；连续三天恶化，再按来源抽样追查。"
+    },
+    {
+      "id": 79,
+      "title": "转述忠实率",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 7,
+        "w": 6,
+        "h": 6
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "pgc_broadcast_faithfulness_weighted_pct",
+          "instant": true,
+          "legendFormat": "忠实率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "-1": {
+                  "text": "等待质检",
+                  "color": "text",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "description": "广播是否忠于原文。这个百分比来自抽样估计，必须和下方「看了多少条、误差多大」一起读。\n正常：99% 以上；95%–99% 需要当天抽查；低于 95% 立即处理。"
     },
     {
       "id": 74,
-      "title": "测量本身是否还在跑",
+      "title": "质检有没有停",
       "type": "table",
       "datasource": {
         "type": "prometheus",
@@ -602,7 +673,7 @@
     {
       "id": 30,
       "type": "row",
-      "title": "现在需要处理什么",
+      "title": "行动 — 现在具体要处理什么",
       "collapsed": false,
       "panels": [],
       "gridPos": {
@@ -614,7 +685,7 @@
     },
     {
       "id": 17,
-      "title": "真实故障",
+      "title": "需要立刻处理的故障",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
@@ -623,7 +694,7 @@
       "gridPos": {
         "x": 0,
         "y": 14,
-        "w": 4,
+        "w": 5,
         "h": 5
       },
       "targets": [
@@ -674,17 +745,17 @@
         "graphMode": "area",
         "justifyMode": "auto"
       },
-      "description": "我方侧真实故障的总数：关键来源断路 + 关键信源故障 + 我方管线延迟。应恒为 0，非 0 立即排查。上游自身安静、待加源候选等不紧急的项在右侧『本周待办』。"
+      "description": "PGC 自己能修、且会伤害用户的故障总数：关键来源断路、关键信源故障、PGC 自己造成的迟到。应恒为 0；非 0 立即处理。"
     },
     {
       "id": 34,
       "type": "stat",
-      "title": "关键来源断路",
-      "description": "必须保活的关键信源（探活 = 定期试抓验证通路）当前失败的数量。正常为 0。非 0 说明我方对该源的抓取通路已断（含被对方封锁），立即排查——该数同时计入左侧「真实故障」。",
+      "title": "关键来源断了几个",
+      "description": "必须保活的关键来源当前失败的数量。正常为 0；非 0 说明抓取通路已断或被对方封锁，立即排查。这个数字已计入左侧故障总数。",
       "gridPos": {
-        "x": 4,
+        "x": 5,
         "y": 14,
-        "w": 4,
+        "w": 5,
         "h": 5
       },
       "datasource": {
@@ -747,12 +818,12 @@
     {
       "id": 33,
       "type": "stat",
-      "title": "重要消息正在迟到",
-      "description": "高优先（T0/T1）信源近 3 小时内仍活跃的迟到条目数，含两类：我方管线慢（应为 0，另计入「真实故障」）与上游发布晚到（需评估是否换更快渠道）。同一条目只计一次（按测量点去重取较大值）。常态潮位约 10–40，午后 / 开盘高峰可达 200–300（多为上游晚发）；持续超过 150 看下方明细评估换更快渠道，超过 400 属异常涌高。具体来源见下方明细表。",
+      "title": "PGC 自己造成的迟到",
+      "description": "高优先来源近 3 小时内，因为 PGC 抓取、处理或发布太慢而迟到的条数。这里不混入“上游自己晚发”。正常为 0；非 0 立即看下方来源明细。",
       "gridPos": {
-        "x": 8,
+        "x": 10,
         "y": 14,
-        "w": 4,
+        "w": 5,
         "h": 5
       },
       "datasource": {
@@ -766,7 +837,7 @@
             "type": "prometheus",
             "uid": "pgc-prometheus"
           },
-          "expr": "max(sum by (stage) (pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"})) or vector(0)",
+          "expr": "max(sum by (stage) (pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"})) or vector(0)",
           "instant": true
         }
       ],
@@ -786,11 +857,11 @@
               },
               {
                 "color": "yellow",
-                "value": 150
+                "value": 1
               },
               {
                 "color": "red",
-                "value": 400
+                "value": 10
               }
             ]
           }
@@ -807,88 +878,20 @@
         },
         "orientation": "auto",
         "textMode": "auto",
-        "colorMode": "value",
+        "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto"
       }
     },
     {
-      "id": 61,
-      "title": "本周待办",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "pgc-prometheus"
-      },
-      "gridPos": {
-        "x": 12,
-        "y": 14,
-        "w": 4,
-        "h": 5
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "(sum(pgc_source_health_critical_watch) or vector(0)) + (sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0))",
-          "instant": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "mappings": [],
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 15
-              },
-              {
-                "color": "red",
-                "value": 30
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto",
-        "textMode": "auto",
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto"
-      },
-      "description": "无需立即处理的观察项：上游自身安静的关键源、待加源候选、超期项。每周过一遍即可；需要立即处理的在左侧『真实故障』。"
-    },
-    {
       "id": 32,
       "type": "stat",
-      "title": "应补的一手来源",
-      "description": "审计发现应有一手源但未配置（或配置后长期无产出）的重大事件数。属于待办清单，不是故障——数字本身无好坏，有空时挑高价值的补。",
+      "title": "一手来源空缺线索",
+      "description": "审计发现“媒体已经报道，但对应一手来源未配置或没抓到”的线索数。它不是已经确认的漏文；下方会逐篇列出报道、原因和建议动作。",
       "gridPos": {
-        "x": 16,
+        "x": 15,
         "y": 14,
-        "w": 4,
+        "w": 5,
         "h": 5
       },
       "datasource": {
@@ -968,17 +971,331 @@
         "overrides": []
       },
       "options": {},
-      "description": "对外唯一可引用的抢先率（模型双判确认制，每日 10:30 更新）。当前诚实水平约 5-6%，提升靠补齐输局对应的信源。注意：此面板为全板唯一对外口径，删除即事故（设计文档有保护条款）。"
+      "description": "对外可引用的抢先率：在可比较事件里，PGC 比基准媒体更早的比例。必须和下方样本量一起读；提升主要靠修慢源和补一手来源。"
+    },
+    {
+      "id": 80,
+      "title": "哪些来源正在拖慢",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 12,
+        "h": 9
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(20, sum by (source, source_tier, kind) (pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\",stage=\"source_to_index\"}))",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "原因"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "source_latency": {
+                        "text": "PGC 抓取或处理慢",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "source_feed_lag": {
+                        "text": "上游来源自己晚发",
+                        "color": "blue",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "优先级"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "T0": {
+                        "text": "必须第一时间",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "T1": {
+                        "text": "高优先",
+                        "color": "yellow",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "renameByName": {
+              "source": "来源",
+              "source_tier": "优先级",
+              "kind": "原因",
+              "Value": "近 3 小时迟到条数"
+            },
+            "indexByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "近 3 小时迟到条数",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ],
+      "description": "这里把模糊的“78 条迟到”拆到具体来源。红色是 PGC 自己能修的慢；蓝色是上游来源本身晚发，需要找更快的一手渠道。按迟到条数从高到低处理。"
+    },
+    {
+      "id": 81,
+      "title": "哪篇报道暴露了一手来源空缺",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "pgc-prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 19,
+        "w": 12,
+        "h": 9
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "pgc_first_source_audit_attention_item_info",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "级别"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "critical": {
+                        "text": "立刻处理",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "warn": {
+                        "text": "本周处理",
+                        "color": "yellow",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "原因"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "primary_source_not_configured": {
+                        "text": "一手来源未配置",
+                        "color": "yellow",
+                        "index": 0
+                      },
+                      "textual_source_configured_but_quiet": {
+                        "text": "已配置，但没抓到",
+                        "color": "yellow",
+                        "index": 1
+                      },
+                      "coverage_seen_before_benchmark_primary_missing": {
+                        "text": "有二级覆盖，一手仍缺",
+                        "color": "yellow",
+                        "index": 2
+                      },
+                      "media_cited_no_first_party": {
+                        "text": "媒体提到一手来源，但未收录",
+                        "color": "yellow",
+                        "index": 3
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "原文"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "打开原文",
+                    "url": "${__value.raw}",
+                    "targetBlank": true
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "renameByName": {
+              "severity": "级别",
+              "verdict": "原因",
+              "benchmark_source": "报道来源",
+              "benchmark_category": "领域",
+              "benchmark_title": "报道标题",
+              "benchmark_url": "原文",
+              "action": "建议动作"
+            },
+            "indexByName": {}
+          }
+        }
+      ],
+      "description": "不再只给你一个“5”。每一行都是一篇具体报道：谁先报道、标题是什么、为什么暴露了一手来源空缺、下一步该补什么。点击「原文」即可复盘。"
     },
     {
       "id": 102,
       "type": "row",
-      "title": "丢了什么 · 为什么",
+      "title": "漏文 — 到底漏了什么，为什么",
       "collapsed": false,
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 19,
+        "y": 28,
         "w": 24,
         "h": 1
       }
@@ -993,7 +1310,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 20,
+        "y": 29,
         "w": 14,
         "h": 8
       },
@@ -1089,7 +1406,7 @@
       },
       "gridPos": {
         "x": 14,
-        "y": 20,
+        "y": 29,
         "w": 10,
         "h": 8
       },
@@ -1133,7 +1450,132 @@
             "mode": "palette-classic"
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "第一判官疑似"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixedColor",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "两家确认真漏"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "第二判官否决"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixedColor",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "判官不可用"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "还没复核完"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "reduceOptions": {
@@ -1155,19 +1597,19 @@
     {
       "id": 103,
       "type": "row",
-      "title": "每个数字有多可信",
+      "title": "可信度 — 这些数字能不能信",
       "collapsed": false,
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 28,
+        "y": 37,
         "w": 24,
         "h": 1
       }
     },
     {
       "id": 77,
-      "title": "每个数字有多可信",
+      "title": "这些数字看了多少条，误差有多大",
       "type": "table",
       "datasource": {
         "type": "prometheus",
@@ -1175,7 +1617,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 29,
+        "y": 38,
         "w": 24,
         "h": 9
       },
@@ -1305,19 +1747,19 @@
     {
       "id": 104,
       "type": "row",
-      "title": "趋势",
+      "title": "趋势 — 最近有没有变好",
       "collapsed": false,
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 38,
+        "y": 47,
         "w": 24,
         "h": 1
       }
     },
     {
       "id": 9,
-      "title": "抢先和延迟趋势",
+      "title": "抢先率和延迟最近有没有变好",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
@@ -1325,8 +1767,8 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 39,
-        "w": 12,
+        "y": 48,
+        "w": 24,
         "h": 8
       },
       "targets": [
@@ -1404,128 +1846,14 @@
       "description": "事件延迟（越低越好）与胜率走势，模型约每 30 分钟重算。**看「可赢胜率」**：只算我们本可以更快的对决——对手在转发或汇编别人的信息（通稿/转载），或对手发布的本身就是官方公告（那说明我们自己的官方源线慢了）。它低了才该行动（加快轮询/补一手源）。「总胜率」把记者独家原创也算进分母，那类对决世界上不存在更早的源，输了不是管线慢（2026-07-16 实测约六成输局属此类）——总胜率低但可赢胜率高 = 新闻结构，不是故障。2026-07-02 起模型确认口径，2026-07-16 起有可赢/总口径两条线，跨断点不可比。"
     },
     {
-      "id": 37,
-      "type": "timeseries",
-      "title": "问题有没有变多",
-      "description": "『真实故障』应贴地为 0；『本周待办』允许有水位，看趋势不看绝对值。",
-      "gridPos": {
-        "x": 12,
-        "y": 39,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "pgc-prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "(sum(pgc_source_health_canaries_failed) or vector(0)) + (sum(pgc_source_health_critical_fire) or vector(0)) + (max(sum by (stage) (pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=\"source_latency\"})) or vector(0))",
-          "instant": false,
-          "range": true,
-          "legendFormat": "真实故障（应为 0）"
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "pgc_first_source_audit_attention",
-          "instant": false,
-          "range": true,
-          "legendFormat": "应补的一手来源"
-        },
-        {
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "max(sum by (stage) (pgc_signal_latency_active_source_breaches_3h{source_tier=~\"T0|T1\",kind=~\"source_latency|source_feed_lag\"})) or vector(0)",
-          "instant": false,
-          "range": true,
-          "legendFormat": "高优先延迟"
-        },
-        {
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "pgc_source_health_canaries_failed",
-          "instant": false,
-          "range": true,
-          "legendFormat": "关键源探活失败"
-        },
-        {
-          "refId": "E",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "pgc_source_health_critical_fire",
-          "instant": false,
-          "range": true,
-          "legendFormat": "关键信源故障"
-        },
-        {
-          "refId": "F",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "pgc-prometheus"
-          },
-          "expr": "pgc_source_health_sla_attention",
-          "instant": false,
-          "range": true,
-          "legendFormat": "信源更新慢"
-        },
-        {
-          "expr": "(sum(pgc_source_health_critical_watch) or vector(0)) + (sum(pgc_first_source_audit_attention) or vector(0)) + (sum(pgc_source_health_sla_attention) or vector(0))",
-          "legendFormat": "本周待办合计",
-          "refId": "W"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 2,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "multi"
-        }
-      }
-    },
-    {
       "id": 20,
       "type": "row",
-      "title": "系统是否正常",
+      "title": "运行 — 信源、积压与额度是否健康",
       "collapsed": false,
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 47,
+        "y": 56,
         "w": 24,
         "h": 1
       }
@@ -1540,8 +1868,8 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 48,
-        "w": 6,
+        "y": 57,
+        "w": 4,
         "h": 5
       },
       "targets": [
@@ -1600,16 +1928,16 @@
     },
     {
       "id": 23,
-      "title": "后台任务多久没运行",
+      "title": "信源现在是什么情况",
       "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "pgc-prometheus"
       },
       "gridPos": {
-        "x": 6,
-        "y": 48,
-        "w": 6,
+        "x": 4,
+        "y": 57,
+        "w": 8,
         "h": 5
       },
       "targets": [
@@ -1619,36 +1947,196 @@
             "type": "prometheus",
             "uid": "pgc-prometheus"
           },
-          "expr": "max(pgc_worker_last_run_age_seconds)",
-          "instant": true
+          "expr": "pgc_source_health_active_sources",
+          "instant": true,
+          "legendFormat": "正在运行"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_configured_sources",
+          "instant": true,
+          "legendFormat": "已配置"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_blocked_sources",
+          "instant": true,
+          "legendFormat": "被封"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_failing_high_sources",
+          "instant": true,
+          "legendFormat": "高风险失败"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_sla_attention",
+          "instant": true,
+          "legendFormat": "超时需处理"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "pgc-prometheus"
+          },
+          "expr": "pgc_source_health_critical_watch",
+          "instant": true,
+          "legendFormat": "关键源观察"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "short",
           "mappings": [],
           "color": {
-            "mode": "thresholds"
+            "mode": "fixedColor",
+            "fixedColor": "blue"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "被封"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 10
+                    }
+                  ]
+                }
+              }
+            ]
           },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "高风险失败"
+            },
+            "properties": [
               {
-                "color": "green",
-                "value": null
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
               },
               {
-                "color": "yellow",
-                "value": 600
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "超时需处理"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
               },
               {
-                "color": "red",
-                "value": 1800
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "关键源观察"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    }
+                  ]
+                }
               }
             ]
           }
-        },
-        "overrides": []
+        ]
       },
       "options": {
         "reduceOptions": {
@@ -1658,13 +2146,13 @@
           "fields": "",
           "values": false
         },
-        "orientation": "auto",
-        "textMode": "auto",
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto"
       },
-      "description": "最久未运行的后台任务距上次运行的时间。超过 600 秒可能卡住。"
+      "description": "直接回答信源现状：配置、运行、被封、高风险失败、更新超时和关键源观察分别有多少。红色当天处理；黄色逐个评估是否换接口或补更快渠道。"
     },
     {
       "id": 36,
@@ -1673,7 +2161,7 @@
       "description": "按当前消耗速度，twitterapi.io 付费额度剩余可用天数。",
       "gridPos": {
         "x": 12,
-        "y": 48,
+        "y": 57,
         "w": 6,
         "h": 5
       },
@@ -1744,7 +2232,7 @@
       },
       "gridPos": {
         "x": 18,
-        "y": 48,
+        "y": 57,
         "w": 6,
         "h": 5
       },
@@ -1821,7 +2309,7 @@
       "description": "NewsAPI 是二级覆盖雷达，不是一手信源。这里显示每个主题抓到的最新文章距离现在多久，以及允许的最大时间。状态为「开始落后」需要当天调整；「严重落后」会实时推送告警，避免把旧消息当新消息送出。",
       "gridPos": {
         "x": 0,
-        "y": 53,
+        "y": 62,
         "w": 24,
         "h": 7
       },
@@ -1935,44 +2423,8 @@
           }
         }
       ]
-    },
-    {
-      "id": 25,
-      "title": "原始日志（工程师排障）",
-      "type": "logs",
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 60,
-        "w": 24,
-        "h": 8
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "expr": "{service=\"pgc-pipeline\"}",
-          "maxLines": 200
-        }
-      ],
-      "options": {
-        "showTime": true,
-        "showLabels": false,
-        "showCommonLabels": false,
-        "wrapLogMessage": true,
-        "prettifyLogMessage": true,
-        "enableLogDetails": true,
-        "sortOrder": "Descending",
-        "dedupStrategy": "none"
-      }
     }
   ],
-  "description": "北极星＝今天确认抢先了多少条。下面三层：红了就停手的止损线、丢了什么的台账、以及每个数字有多可信。",
-  "version": 2
+  "description": "老板视角：先看今天交付了什么，再看是否伤害用户、具体哪一个来源或哪一篇文章需要处理，最后看信源与额度是否健康。",
+  "version": 3
 }

--- a/docs/dev/2026-06-16-pgc-grafana-prd.md
+++ b/docs/dev/2026-06-16-pgc-grafana-prd.md
@@ -89,7 +89,7 @@ only generic crawler/source-health charts.
    - 今天发出了多少条信号
    - 今天确认抢先了多少条
    - 抢先时通常早了多久
-   - 还有多少条没判完
+   - 我们比媒体更早的比例
 
 2. 质量 — 今天有没有伤害用户
    - 可能转述不准的条数（明确标为估计）
@@ -101,7 +101,6 @@ only generic crawler/source-health charts.
    - 关键来源断了几个
    - PGC 自己造成的迟到
    - 一手来源空缺线索
-   - 我们比媒体更早的比例
    - 哪些来源正在拖慢：来源名、优先级、PGC 慢或上游晚发、迟到条数
    - 哪篇报道暴露一手来源空缺：标题、原文、原因、建议动作
 
@@ -121,6 +120,7 @@ only generic crawler/source-health charts.
    - Twitter 额度还能使用多久
    - NewsAPI 与网页代理本月额度
    - NewsAPI 每个主题是否新鲜
+   - 当前有问题的具体来源、问题类型、证据、最近错误和来源地址
 
 ## Acceptance Criteria
 
@@ -142,6 +142,9 @@ only generic crawler/source-health charts.
 - Every sampled percentage identifies its sample-size row in the trust table.
 - Source status shows configured, active, blocked, high-failure, SLA-attention,
   and critical-watch counts rather than worker internals.
+- `具体哪些信源有问题` queries
+  `pgc_source_health_problem_source_info`, is bounded to 50 current rows, and
+  clears stale rows whenever the source-health report changes or disappears.
 - The discard dual-review panel colors zero confirmed losses green, suspected
   candidates yellow, vetoes blue, and any unavailable or unfinished review as
   yellow/red.

--- a/docs/dev/2026-06-16-pgc-grafana-prd.md
+++ b/docs/dev/2026-06-16-pgc-grafana-prd.md
@@ -16,6 +16,11 @@ Revision: 2026-07-24, owner-language redesign: the first screen now asks what
 needs action; value/coverage/correctness/speed are peer product outcomes; the
 NewsAPI topic panel shows cursor freshness instead of token burn so healthy
 HTTP calls cannot hide day-old coverage.
+Revision: 2026-07-31, production visual acceptance and owner-comprehension
+redesign: separate estimated wrong-item count from faithfulness percentage;
+separate PGC-owned latency from upstream publication lag; replace opaque totals
+with source-level and article-level evidence tables; expose current source
+inventory; remove raw logs and duplicate trend panels from the owner surface.
 
 ## Problem
 
@@ -48,12 +53,12 @@ only generic crawler/source-health charts.
   signal, not only as JSON/webhook detail.
 - Put active actionable latency failures in the first visible SLA panels, while
   keeping 24h and raw breach counters available as review/diagnostic evidence.
-- Separate delivery, source health, quality/cost, diagnostics, and logs.
+- Separate delivery, source health, quality, speed, and paid capacity.
 - Prefer rates, rolling windows, and ratios over raw lifetime totals when the
   question is operational.
 - Keep drilldown panels close to the summary metric they explain.
-- Use the stable Grafana datasource UID `pgc-prometheus` for PGC Prometheus
-  panels and `loki` for logs.
+- Use the stable Grafana datasource UID `pgc-prometheus` for every dashboard
+  panel.
 - Keep the dashboard provisionable from JSON and testable through Grafana's API.
 
 ## Non-Goals
@@ -64,139 +69,82 @@ only generic crawler/source-health charts.
   cockpit, while webhooks remain the push-alert surface.
 - This PRD does not create alert rules. Alerting can be layered on top once the
   dashboard panels settle.
+- Raw logs remain available to engineers in Loki, but do not occupy the owner
+  dashboard. A user should never need to read logs to understand a red number.
 
 ## Users
 
-- On-call engineer: needs to know whether PGC is stuck, degraded, or merely
-  noisy.
+- Owner / executive: needs each panel to answer a concrete product question,
+  with a named source or article behind every action count.
 - Product/operator: needs to see whether important sources and topics are being
   delivered.
+- On-call engineer: needs to know whether PGC is stuck, degraded, or merely
+  observing upstream publication lag.
 - Backend engineer: needs to isolate whether a problem is crawl, extract, LLM,
   publish, source inventory, or external API budget.
 
 ## Dashboard Structure
 
-1. 总览 / Owner Cockpit
-   - 现在需要立刻处理几件事
-   - 一手复盘还有多少待处理
-   - 高优先级信号仍在超时吗
-   - Canary 是否全绿
-   - Source SLA 是否破线
-   - TwitterAPI 还能撑多久
-   - 关键风险是在上升还是下降
-   - 现在先处理哪些信源
+1. 结果 — 今天做成了什么
+   - 今天发出了多少条信号
+   - 今天确认抢先了多少条
+   - 抢先时通常早了多久
+   - 还有多少条没判完
 
-2. 一手有没有漏 / First-Source Coverage
-   - 今天有多少一手问题要处理
-   - 严重漏配/晚到有多少
-   - 审计刚刚跑过吗
-   - 今天审了多少 benchmark
-   - 一手问题是在变多还是变少
-   - 问题属于哪种类型
-   - 问题严重到什么程度
-   - 一手源库覆盖够不够
+2. 质量 — 今天有没有伤害用户
+   - 可能转述不准的条数（明确标为估计）
+   - 转述忠实率（明确显示百分号）
+   - 质检有没有停
 
-3. 信号够不够快 / Signal Latency
-   - 现在高优先级信号还在超时吗
-   - 官方源多久进入 PGC
-   - 机器源是否保持低延迟
-   - 高优先级信号多久发出去
-   - 哪类源最晚被我们看到
-   - 哪类源最晚发给下游
-   - 哪些类别需要马上处理
-   - 这些超时是事故还是回补噪音
-   - 当前哪些信源正在拖慢
+3. 行动 — 现在具体要处理什么
+   - PGC 自己能修的故障数
+   - 关键来源断了几个
+   - PGC 自己造成的迟到
+   - 一手来源空缺线索
+   - 我们比媒体更早的比例
+   - 哪些来源正在拖慢：来源名、优先级、PGC 慢或上游晚发、迟到条数
+   - 哪篇报道暴露一手来源空缺：标题、原文、原因、建议动作
 
-4. 每条信号卡在哪一跳 / Event Timeline
-   - 链路事实还在写入吗
-   - 24h 写了多少链路事件
-   - 24h 有多少内容可复盘
-   - 24h 有多少推送证据
-   - 链路证据是否稳定增长
-   - 慢/断在哪个阶段
+4. 漏文 — 到底漏了什么，为什么
+   - 过去 24 小时的损失按原因拆分
+   - 第一判官疑似、两家确认真漏、二判否决、不可用、未完成分别显示
 
-5. 信源是否可靠 / Source Reliability
-   - Canary 有没有失败
-   - 关键源是否需要处理
-   - 信源 SLA 是否破线
-   - 健康报告刚刚跑过吗
-   - 活跃源覆盖率够不够
-   - 源健康是在变好还是变差
-   - 哪些源违反 SLA
-   - 哪些 Canary 失败
-   - 哪些源被 block
-   - 哪些源快被 block
+5. 可信度 — 这些数字能不能信
+   - 指标值、样本量、误差范围、没判成数量、未覆盖人群同表展示
 
-6. 内容有没有送达 / Delivery
-   - 近 1 小时发出多少
-   - 队列是否积压
-   - 当前有多少阻塞源
-   - NewsAPI 预算是否安全
-   - TwitterAPI 还能撑多久
-   - 外部 API 检查是否异常
-   - 发布量是否稳定
-   - 队列卡在哪个状态
-   - 24h 内容状态分布
-   - 哪些来源贡献最多
-   - 哪些来源正在异常
+6. 趋势 — 最近有没有变好
+   - 抢先率和延迟放在一张趋势图中，避免重复趋势面板
 
-7. 生产链路是否健康 / Pipeline Health
-   - 哪些源连续失败
-   - Worker 是否卡住
-   - LLM 是否在报错
-   - FD 是否有压力
-   - 来源转化是否健康
-   - 哪些来源最热
-
-8. 质量和成本是否失控 / Quality & Cost
-   - LLM 调用是否稳定
-   - LLM p95 是否变慢
-   - Token 成本是否异常
-   - Signal Gate 是否过严
-   - 端到端发布是否超时
-
-9. 工程诊断 / Deep Dive
-   - Worker 心跳明细
-   - 各阶段耗时
-   - 错误压力是否升高
-   - Pipeline 日志
+7. 运行 — 信源、积压与额度是否健康
+   - 是否持续积压
+   - 配置、运行、被封、高风险失败、超时需处理、关键源观察的来源数
+   - Twitter 额度还能使用多久
+   - NewsAPI 与网页代理本月额度
+   - NewsAPI 每个主题是否新鲜
 
 ## Acceptance Criteria
 
 - Grafana dashboard loads with no "data source not found" errors.
 - Every Prometheus panel uses `uid=pgc-prometheus`.
-- Loki log panel uses `uid=loki`.
-- The first screen is an owner cockpit, not an engineering deep dive: it must
-  include the row `总览 / Owner Cockpit`, stat panels for immediate action count,
-  first-source attention, active T0/T1 latency, canary failures, source SLA
-  failures, and TwitterAPI days-to-empty, plus one trend panel and one active
-  source drilldown table.
-- First-source audit panels query `pgc_first_source_audit_*` metrics and return
-  non-empty frames in production.
-- Low-latency panels query `pgc_signal_latency_*` metrics and return production
-  data where appropriate; first-screen SLA breach panels use
-  `pgc_signal_latency_actionable_breaches_3h`, while 24h actionable/raw breach
-  metrics remain available for review. The active SLA breach table is allowed
-  to be empty when no class/tier has current actionable breaches.
-- The latency breach-kind panel queries `pgc_signal_latency_breach_kind_24h` so
-  operators can explain why raw SLA debt is not always an active first-source
-  incident.
-- The active source latency panel queries
-  `pgc_signal_latency_active_source_breaches_3h{kind=~"source_latency|source_feed_lag"}`,
-  so an owner can see the exact source names currently dragging the
-  low-latency promise instead of stopping at class/tier aggregates. The `kind`
-  label distinguishes PGC/processing/polling latency from upstream RSS feed lag;
-  non-actionable active reasons remain visible in the adjacent breach-kind
-  panel.
-- Source reliability includes a stat panel for
-  `pgc_source_health_sla_attention{job="pgc-pipeline"}` and the source-health
-  trend panel includes the same series, so registry-defined poll-gap, quiet, and
-  blocked-source SLA failures are visible in both current-state and historical
-  views.
-- The source SLA drilldown table queries
-  `pgc_source_health_sla_attention_source{job="pgc-pipeline"}` and is allowed
-  to be empty in the healthy state; when non-empty it must expose source name,
-  category, source type/class/tier, stable reason, and critical label.
+- The owner dashboard contains no raw log panel and no opaque total whose
+  components cannot be explained nearby.
+- `PGC 自己造成的迟到` only counts `kind="source_latency"`; it must not mix
+  upstream `source_feed_lag` into a PGC fault.
+- `哪些来源正在拖慢` includes both `source_latency` and `source_feed_lag` and
+  exposes source name, priority, reason, and three-hour count.
+- `哪篇报道暴露了一手来源空缺` queries
+  `pgc_first_source_audit_attention_item_info` and exposes title, original URL,
+  benchmark source, category, reason, severity, and action.
+- The first-source detail metric is bounded to at most 25 current attention
+  records and clears old label sets on every refresh.
+- Estimated wrong-item count and faithfulness percentage are separate panels;
+  the count is explicitly labeled as estimated and the rate uses a percent unit.
+- Every sampled percentage identifies its sample-size row in the trust table.
+- Source status shows configured, active, blocked, high-failure, SLA-attention,
+  and critical-watch counts rather than worker internals.
+- The discard dual-review panel colors zero confirmed losses green, suspected
+  candidates yellow, vetoes blue, and any unavailable or unfinished review as
+  yellow/red.
 - Representative panel queries return non-empty frames through Grafana API.
 - Dashboard JSON is valid, provisionable, and committed to git.
 - `scripts/local/validate_pgc_grafana_dashboard.py` passes static validation and

--- a/scripts/local/eval_pgc_dashboard_colors.py
+++ b/scripts/local/eval_pgc_dashboard_colors.py
@@ -43,7 +43,13 @@ def series_name(target: dict, series: dict) -> str:
     return series.get("metric", {}).get("__name__", "")
 
 
-def apply_overrides(panel: dict, name: str, steps: list[dict], mappings: list):
+def apply_overrides(
+    panel: dict,
+    name: str,
+    steps: list[dict],
+    mappings: list,
+    color: dict,
+):
     """Resolve per-series overrides the way Grafana does.
 
     Added 2026-07-28: without this the tool judged EVERY series by the panel's
@@ -61,7 +67,9 @@ def apply_overrides(panel: dict, name: str, steps: list[dict], mappings: list):
                 steps = (prop.get("value") or {}).get("steps", steps)
             elif prop.get("id") == "mappings":
                 mappings = prop.get("value") or mappings
-    return steps, mappings
+            elif prop.get("id") == "color":
+                color = prop.get("value") or color
+    return steps, mappings, color
 
 
 def mapped(value: float, mappings: list):
@@ -113,8 +121,11 @@ def main() -> int:
         default_mappings = (
             panel.get("fieldConfig", {}).get("defaults", {}).get("mappings", []) or []
         )
+        default_color = (
+            panel.get("fieldConfig", {}).get("defaults", {}).get("color", {}) or {}
+        )
         targets = [t for t in panel.get("targets", []) if t.get("expr")]
-        if not steps or not targets:
+        if not targets:
             continue
         print(f"[{panel.get('id')}] {panel.get('title')}")
         for target in targets:
@@ -139,9 +150,18 @@ def main() -> int:
                     if k not in ("__name__", "instance", "job")
                 )
                 name = series_name(target, series)
-                s_steps, s_maps = apply_overrides(panel, name, steps, default_mappings)
+                s_steps, s_maps, s_color = apply_overrides(
+                    panel, name, steps, default_mappings, default_color
+                )
                 text, mapped_color = mapped(value, s_maps)
-                color = mapped_color or color_for(value, s_steps)
+                if mapped_color:
+                    color = mapped_color
+                elif s_color.get("mode") == "fixedColor":
+                    color = s_color.get("fixedColor", "text")
+                elif s_steps:
+                    color = color_for(value, s_steps)
+                else:
+                    continue
                 if color in ("red", "orange", "yellow"):
                     attention += 1
                 icon = _ICONS.get(color, f"[{color}]")

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -38,6 +38,7 @@ EXPECTED_SECTIONS = [
 NATURALLY_EMPTY_PANEL_IDS = {
     80,  # 没有任何来源延迟时，明细表为空就是健康
     81,  # 没有一手来源空缺线索时，明细表为空就是健康
+    82,  # 没有当前信源问题时，明细表为空就是健康
 }
 
 ACTIONABLE_LATENCY_PANEL_IDS = {
@@ -87,6 +88,7 @@ OWNER_COCKPIT_PANELS = {
     79: ["pgc_broadcast_faithfulness_weighted_pct"],
     80: ["pgc_signal_latency_active_source_breaches_3h"],
     81: ["pgc_first_source_audit_attention_item_info"],
+    82: ["pgc_source_health_problem_source_info"],
     76: ["pgc_loss_ledger_events"],
     77: ["pgc_metric_value", "pgc_metric_sample_size", "pgc_metric_ci_halfwidth"],
     53: ["pgc_discard_audit_dual_review"],

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -19,36 +19,43 @@ import urllib.request
 from pathlib import Path
 
 
-# 2026-07-28 重排：北极星换成一个数，四个产品结果百分比合并进「每个数字有多可信」。
+# 2026-07-31 重排：每一层都用老板能直接回答的问题命名，并把模糊总数
+# 下钻到具体来源和具体报道。
 EXPECTED_SECTIONS = [
-    "北极星 — 今天做成了什么",
-    "止损线 — 红了就停下来处理",
-    "现在需要处理什么",
-    "丢了什么 · 为什么",
-    "每个数字有多可信",
-    "系统是否正常",
+    "结果 — 今天做成了什么",
+    "质量 — 今天有没有伤害用户",
+    "行动 — 现在具体要处理什么",
+    "漏文 — 到底漏了什么，为什么",
+    "可信度 — 这些数字能不能信",
+    "趋势 — 最近有没有变好",
+    "运行 — 信源、积压与额度是否健康",
 ]
 
 # Panels whose empty prod result is the ideal steady state (e.g. a failure list).
 # 2026-07-08: emptied — every previous entry was a 76-panel-era id that no longer
 # exists; a reused id would silently inherit the exemption. Add ids back only for
 # panels that exist AND are legitimately empty when healthy.
-NATURALLY_EMPTY_PANEL_IDS: set[int] = set()
+NATURALLY_EMPTY_PANEL_IDS = {
+    80,  # 没有任何来源延迟时，明细表为空就是健康
+    81,  # 没有一手来源空缺线索时，明细表为空就是健康
+}
 
 ACTIONABLE_LATENCY_PANEL_IDS = {
     33,  # 活跃高优先延迟
 }
 
-# 2026-07-28: 62(哪些来源正在迟到) 并入 76 台账的「抓到了但慢」桶——同一件事
-# 不再占两格。明细仍可从 33 的告警和 Loki 查到。
-ACTIVE_SOURCE_LATENCY_PANEL_IDS: set[int] = set()
-
-SOURCE_HEALTH_SLA_PANEL_IDS = {
-    61,  # 观察清单 (旧名 信源 SLA)
+# 2026-07-31: 80 恢复来源级明细。用户不应为了理解一个总数去翻日志。
+ACTIVE_SOURCE_LATENCY_PANEL_IDS = {
+    80,
 }
 
-# 2026-07-06 语义拆分：17=待处理故障(旧名 火情; 我方契约侧真坏的, 恒0)、61=观察清单
-# (旧名 信源 SLA; 出版方安静/加源候选/超期, 允许有水位)。风险趋势(37)双线。
+SOURCE_HEALTH_SLA_PANEL_IDS = {
+    23,
+}
+
+# 2026-07-06 语义拆分：17=待处理故障（我方契约侧真坏的，恒 0）。
+# 2026-07-31: 删除把多种原因揉成一个数的 61，来源现状集中到 23，
+# 具体迟到与一手源空缺分别由 80/81 展开。
 # 63=抢先率（对外口径）(旧名 榜单胜率)——它已经两次被改板误删, 从此由本校验器守护
 # (见下方 OUTWARD_METRIC_MUST_EXIST)。
 OWNER_COCKPIT_PANELS = {
@@ -61,11 +68,13 @@ OWNER_COCKPIT_PANELS = {
     33: ["pgc_signal_latency_active_source_breaches_3h"],
     34: ["pgc_source_health_canaries_failed"],
     36: ["pgc_twitterapi_credits_days_to_empty"],
-    37: ["pgc_source_health_sla_attention"],
     78: ["pgc_newsapi_key_tokens_pct", "pgc_scraperapi_credits_pct"],
-    61: [
+    23: [
+        "pgc_source_health_active_sources",
+        "pgc_source_health_configured_sources",
+        "pgc_source_health_blocked_sources",
+        "pgc_source_health_failing_high_sources",
         "pgc_source_health_critical_watch",
-        "pgc_first_source_audit_attention",
         "pgc_source_health_sla_attention",
     ],
     64: ["pgc_newsapi_cursor_lag_hours"],
@@ -75,6 +84,9 @@ OWNER_COCKPIT_PANELS = {
     19: ["pgc_event_real_wins", "pgc_north_star_state"],
     74: ["pgc_audit_last_success_timestamp"],
     73: ["pgc_broadcast_unfaithful_24h"],
+    79: ["pgc_broadcast_faithfulness_weighted_pct"],
+    80: ["pgc_signal_latency_active_source_breaches_3h"],
+    81: ["pgc_first_source_audit_attention_item_info"],
     76: ["pgc_loss_ledger_events"],
     77: ["pgc_metric_value", "pgc_metric_sample_size", "pgc_metric_ci_halfwidth"],
     53: ["pgc_discard_audit_dual_review"],
@@ -86,6 +98,7 @@ OWNER_COCKPIT_PANELS = {
 # 值 -> 它的样本量在哪里被看到。新增百分比面板必须在这里登记，否则校验失败。
 SAMPLED_RATE_PANELS = {
     63: "77 诚实度表的「确认抢先条数」行",
+    79: "77 诚实度表的「转述忠于原文」行",
 }
 # 不是抽样得出的比率(账单、进度、全量占比这类精确值)，不需要样本量。
 # 53 各域丢弃占比 = 24h 全量 discarded/all_bench，不是抽样估计。
@@ -244,9 +257,13 @@ def static_validate(dashboard: dict) -> list[str]:
         exprs = [target.get("expr", "") for target in panel.get("targets", []) or []]
         if not any("pgc_signal_latency_active_source_breaches_3h" in expr for expr in exprs):
             errors.append(f"panel {panel_id} must use active source latency breaches")
-        if not any("source_latency" in expr and "source_feed_lag" in expr for expr in exprs):
+        if not any("source_latency" in expr for expr in exprs):
             errors.append(
-                f"panel {panel_id} must count actionable source_latency/source_feed_lag rows"
+                f"panel {panel_id} must count PGC-owned source_latency rows"
+            )
+        if any("source_feed_lag" in expr for expr in exprs):
+            errors.append(
+                f"panel {panel_id} must not mix upstream source_feed_lag into PGC-owned latency"
             )
 
     for panel_id in ACTIVE_SOURCE_LATENCY_PANEL_IDS:
@@ -293,8 +310,6 @@ def static_validate(dashboard: dict) -> list[str]:
 
     if prometheus_targets < 20:
         errors.append(f"expected at least 20 Prometheus targets, found {prometheus_targets}")
-    if loki_targets < 1:
-        errors.append("expected at least one Loki target")
     return errors
 
 


### PR DESCRIPTION
## Product decision
The PGC dashboard must answer concrete owner questions. A count without a named source or article is not an actionable dashboard.

## What changed
- rename every section around the owner question it answers
- split the estimated wrong-item count from the faithfulness percentage and restore the `%` unit
- separate PGC-owned latency from upstream publication lag
- add source-level latency evidence and article-level first-source-gap evidence
- show configured, active, blocked, high-failure, overdue, and watched source counts
- fix discard-review color semantics: confirmed zero is green, suspects yellow, vetoes blue
- remove the opaque weekly-total stat, duplicate trend, and raw logs from the owner surface; content panel count remains at the 23-panel ratchet
- strengthen structural and live-color validators and update the PRD

## Verification
- static dashboard validator: 30 panels / 43 Prometheus targets
- live production Prometheus sweep: all 43 queries valid
- JSON parse and Python compile: pass
- `git diff --check`: clean

## Dependency
Article-level table data is supplied by eigenflux-pgc PR #100.