### PR TITLE
fix: use owner language in PGC evidence tables

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1168,10 +1168,10 @@
               }
             ]
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "原文"
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "原文"
             },
             "properties": [
               {
@@ -1186,10 +1186,46 @@
               },
               {
                 "id": "custom.width",
-                "value": 90
-              }
-            ]
+            "value": 90
           }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "报道标题"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 440
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "报道来源"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 180
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "原因"
+        },
+        "properties": [
+          {
+            "id": "custom.width",
+            "value": 230
+          }
+        ]
+      }
         ]
       },
       "options": {
@@ -2544,21 +2580,21 @@
         {
           "id": "organize",
           "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true,
-              "__name__": true,
-              "instance": true,
-              "job": true
+        "excludeByName": {
+          "Time": true,
+          "Value": true,
+          "__name__": true,
+          "detail": true,
+          "instance": true,
+          "job": true
             },
             "renameByName": {
               "source": "来源",
-              "category": "领域",
-              "source_tier": "优先级",
-              "issue": "问题",
-              "detail": "证据",
-              "last_error": "最近错误",
-              "source_url": "来源地址"
+          "category": "领域",
+          "source_tier": "优先级",
+          "issue": "问题",
+          "last_error": "最近错误",
+          "source_url": "来源地址"
             },
             "indexByName": {}
           }

--- a/docs/dev/2026-06-16-pgc-grafana-prd.md
+++ b/docs/dev/2026-06-16-pgc-grafana-prd.md
@@ -120,7 +120,7 @@ only generic crawler/source-health charts.
    - Twitter 额度还能使用多久
    - NewsAPI 与网页代理本月额度
    - NewsAPI 每个主题是否新鲜
-   - 当前有问题的具体来源、问题类型、证据、最近错误和来源地址
+   - 当前有问题的具体来源、中文问题类型、最近错误和来源地址
 
 ## Acceptance Criteria
 
@@ -139,6 +139,9 @@ only generic crawler/source-health charts.
   available for investigation.
 - Evidence-heavy action and source-health tables use the full dashboard width
   so titles, source names, and failure evidence remain readable.
+- Owner-facing tables hide internal English diagnostics such as `action`,
+  `auto-permanent`, and `quiet_7d`; the mapped Chinese problem, linked source,
+  and exact last error remain visible.
 - The first-source detail metric is bounded to at most 25 current attention
   records and clears old label sets on every refresh.
 - Estimated wrong-item count and faithfulness percentage are separate panels;

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -267,6 +267,24 @@ def static_validate(dashboard: dict) -> list[str]:
             "owner-facing reason and linked evidence are sufficient"
         )
 
+    source_health_panel = panels_by_id.get(82)
+    source_health_transforms = (
+        source_health_panel.get("transformations", []) if source_health_panel else []
+    )
+    source_health_excluded_fields = {
+        name
+        for transform in source_health_transforms
+        for name, excluded in transform.get("options", {})
+        .get("excludeByName", {})
+        .items()
+        if excluded
+    }
+    if source_health_panel and "detail" not in source_health_excluded_fields:
+        errors.append(
+            "panel 82 must hide the internal detail label; "
+            "owner-facing issue, source, and last error provide the evidence"
+        )
+
     all_exprs = "\n".join(
         t.get("expr", "") for p in dashboard.get("panels", [])
         for t in p.get("targets", []) or [])


### PR DESCRIPTION
## Summary
- widen first-source article titles for production readability
- remove internal status strings from the owner-facing source-health table
- keep Chinese problem labels, exact source links, and last errors visible
- enforce the owner-language rule in the validator and PRD

## Verification
- python3 scripts/local/validate_pgc_grafana_dashboard.py
- python3 -m py_compile scripts/local/validate_pgc_grafana_dashboard.py scripts/local/eval_pgc_dashboard_colors.py
- jq empty configs/grafana/dashboards/pgc-pipeline.json
- git diff --check