### PR TITLE
fix: use supported Grafana fixed color mode

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -1439,7 +1439,7 @@
               {
                 "id": "color",
                 "value": {
-                  "mode": "fixedColor",
+                  "mode": "fixed",
                   "fixedColor": "yellow"
                 }
               }
@@ -1484,7 +1484,7 @@
               {
                 "id": "color",
                 "value": {
-                  "mode": "fixedColor",
+                  "mode": "fixed",
                   "fixedColor": "blue"
                 }
               }
@@ -1986,7 +1986,7 @@
           "unit": "short",
           "mappings": [],
           "color": {
-            "mode": "fixedColor",
+            "mode": "fixed",
             "fixedColor": "blue"
           }
         },

--- a/scripts/local/eval_pgc_dashboard_colors.py
+++ b/scripts/local/eval_pgc_dashboard_colors.py
@@ -156,7 +156,7 @@ def main() -> int:
                 text, mapped_color = mapped(value, s_maps)
                 if mapped_color:
                     color = mapped_color
-                elif s_color.get("mode") == "fixedColor":
+                elif s_color.get("mode") == "fixed":
                     color = s_color.get("fixedColor", "text")
                 elif s_steps:
                     color = color_for(value, s_steps)

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -136,6 +136,26 @@ def static_validate(dashboard: dict) -> list[str]:
         errors.append("dashboard title must be EigenFlux - PGC Pipeline")
 
     panels = dashboard.get("panels", [])
+
+    def find_legacy_fixed_color(value, path: str = "dashboard") -> list[str]:
+        found: list[str] = []
+        if isinstance(value, dict):
+            if value.get("mode") == "fixedColor":
+                found.append(path)
+            for key, child in value.items():
+                found.extend(find_legacy_fixed_color(child, f"{path}.{key}"))
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                found.extend(find_legacy_fixed_color(child, f"{path}[{index}]"))
+        return found
+
+    legacy_fixed_color_paths = find_legacy_fixed_color(dashboard)
+    if legacy_fixed_color_paths:
+        errors.append(
+            "Grafana color mode must be 'fixed', not unsupported 'fixedColor': "
+            + ", ".join(legacy_fixed_color_paths)
+        )
+
     ids = [p.get("id") for p in panels]
     dupes = {i for i in ids if ids.count(i) > 1}
     if dupes:


### PR DESCRIPTION
## Incident
The production PGC dashboard could crash during lazy panel rendering with `fixedColor not found`. Grafana 11.6 supports color mode `fixed`; `fixedColor` is the companion value field, not a mode name.

## Fix
- replace all three unsupported `mode: fixedColor` values with `mode: fixed`
- update the production color evaluator
- add a recursive validator guard that rejects this incompatible mode anywhere in the dashboard

## Verification
- static dashboard validator passes
- injected legacy mode is rejected by the new guard
- Python compile, JSON parse, and diff checks pass