### PR TITLE
ops: add private GDELT relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -266,6 +266,8 @@ JAEGER_OTLP_PORT=4317
 LOKI_PORT=3122
 GRAFANA_PORT=3123
 PROMETHEUS_PORT=9090
+GDELT_RELAY_BIND=127.0.0.1
+GDELT_RELAY_PORT=3124
 
 # Prometheus scrape target host (default: host.docker.internal for local dev)
 # On cloud: set to the app server's internal IP so Prometheus can reach metrics endpoints

--- a/configs/nginx/gdelt-relay.conf
+++ b/configs/nginx/gdelt-relay.conf
@@ -1,0 +1,26 @@
+server {
+    listen 8080;
+    server_name _;
+
+    location = /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location = /api/v2/doc/doc {
+        allow 10.0.0.212;
+        deny all;
+
+        proxy_set_header Host api.gdeltproject.org;
+        proxy_ssl_server_name on;
+        proxy_ssl_name api.gdeltproject.org;
+        proxy_connect_timeout 15s;
+        proxy_read_timeout 90s;
+        proxy_pass https://api.gdeltproject.org;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -33,6 +33,23 @@ services:
       timeout: 5s
       retries: 10
 
+  # Internal-only GDELT egress for PGC. GDELT rate-limits the app server's
+  # datacenter IP, while the monitoring host has a healthy route. The relay
+  # exposes one upstream path and accepts traffic only from the PGC host.
+  gdelt-relay:
+    image: nginx:1.27-alpine
+    profiles: ["pgc-relay"]
+    restart: unless-stopped
+    ports:
+      - "${GDELT_RELAY_BIND:-127.0.0.1}:${GDELT_RELAY_PORT:-3124}:8080"
+    volumes:
+      - ./configs/nginx/gdelt-relay.conf:/etc/nginx/conf.d/default.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz | grep -q '^ok$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+
   prometheus:
     image: prom/prometheus:v3.4.0
     ports:


### PR DESCRIPTION
## Summary
- add an opt-in Nginx relay for the single GDELT DOC API path
- bind to a configurable private address and allow only the PGC production host
- keep the relay outside the public monitoring profile and add a container health check

## Why
GDELT returns 429 to the PGC app server and ScraperAPI now returns 500 on every tier, while the monitoring host has a healthy direct route. This preserves the existing coverage source without exposing a general-purpose proxy.

## Verification
- Compose expansion passed on aliapmo
- nginx 1.27 configuration test passed on aliapmo
- production reachability/security check follows after merge