### PR TITLE
fix: use IPv4 relay healthcheck

### DIFF
--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -45,7 +45,7 @@ services:
     volumes:
       - ./configs/nginx/gdelt-relay.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz | grep -q '^ok$'"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz | grep -q '^ok$'"]
       interval: 10s
       timeout: 5s
       retries: 6


### PR DESCRIPTION
The relay serves correctly on IPv4, but Alpine resolves localhost to IPv6 first and Docker reports a false unhealthy state. Pin the in-container health probe to 127.0.0.1. Production API reachability and source-IP denial already pass.