### PR TITLE
fix: make source problem table owner-readable

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -2499,6 +2499,10 @@
                     }
                   }
                 ]
+              },
+              {
+                "id": "custom.width",
+                "value": 170
               }
             ]
           },
@@ -2537,6 +2541,34 @@
                     }
                   }
                 ]
+              },
+              {
+                "id": "custom.width",
+                "value": 130
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "领域"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "来源"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 420
               }
             ]
           },
@@ -2558,7 +2590,22 @@
               },
               {
                 "id": "custom.width",
-                "value": 90
+                "value": 110
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "regex",
+                    "options": {
+                      "pattern": ".+",
+                      "result": {
+                        "text": "打开来源",
+                        "index": 0
+                      }
+                    }
+                  }
+                ]
               }
             ]
           }
@@ -2586,7 +2633,8 @@
           "__name__": true,
           "detail": true,
           "instance": true,
-          "job": true
+          "job": true,
+          "last_error": true
             },
             "renameByName": {
               "source": "来源",
@@ -2596,7 +2644,13 @@
           "last_error": "最近错误",
           "source_url": "来源地址"
             },
-            "indexByName": {}
+            "indexByName": {
+              "category": 0,
+              "issue": 1,
+              "source": 2,
+              "source_tier": 3,
+              "source_url": 4
+            }
           }
         }
       ]

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -299,10 +299,15 @@ def static_validate(dashboard: dict) -> list[str]:
         .items()
         if excluded
     }
-    if source_health_panel and "detail" not in source_health_excluded_fields:
+    visible_internal_source_fields = {
+        "detail",
+        "last_error",
+    } - source_health_excluded_fields
+    if source_health_panel and visible_internal_source_fields:
         errors.append(
-            "panel 82 must hide the internal detail label; "
-            "owner-facing issue, source, and last error provide the evidence"
+            "panel 82 must hide raw internal diagnostics that make the owner "
+            "table unreadable: "
+            + ", ".join(sorted(visible_internal_source_fields))
         )
 
     all_exprs = "\n".join(


### PR DESCRIPTION
## Summary
- hide raw English adapter errors from the owner-facing source problem table
- use stable widths for issue, source, priority, and domain columns
- render the official source URL as a compact open-source action
- make the dashboard validator reject raw internal diagnostics in this panel

## Verification
- static dashboard validator passed (30 panels / 43 Prometheus targets)
- production query for panel 82 passed
- visual production acceptance follows after provisioning