### PR TITLE
fix: disable broken Loki Explore plugin

### DIFF
--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -92,6 +92,9 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=${GF_AUTH_ANONYMOUS_ORG_ROLE:-Admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin}
       - GF_SERVER_ROOT_URL=${GF_SERVER_ROOT_URL:-}
+      # Grafana 11.6's bundled Loki Explore app fails to load react/jsx-runtime
+      # and logs a 404 on every dashboard. Loki datasource panels do not use it.
+      - GF_PLUGINS_DISABLE_PLUGINS=${GF_PLUGINS_DISABLE_PLUGINS:-grafana-lokiexplore-app}
       # PostgreSQL datasource connection (consumed by configs/grafana/datasources.yml).
       # The DB host is independent of METRICS_HOST (scrape target): defaults to the
       # local dev DB; in cloud set GRAFANA_PG_* in .env (e.g. the managed RDS endpoint


### PR DESCRIPTION
Grafana 11.6's bundled grafana-lokiexplore-app fails to load react/jsx-runtime and emits 404 errors on every dashboard. Disable only that unused app; Loki datasource panels remain enabled. Compose expansion passed on aliapmo.