### PR TITLE
fix(grafana): show explicit healthy source state

### DIFF
--- a/configs/grafana/dashboards/pgc-pipeline.json
+++ b/configs/grafana/dashboards/pgc-pipeline.json
@@ -2407,7 +2407,7 @@
       "id": 82,
       "type": "table",
       "title": "具体哪些信源有问题",
-      "description": "把上方「被封、高风险失败、更新超时、关键源观察」拆成具体来源。红色当天处理；黄色表示源近期安静或刚出现失败，需要判断是正常发布节奏还是该换更快渠道。点击来源地址可直接复盘。",
+      "description": "把上方「被封、高风险失败、更新超时、关键源观察」拆成具体来源。绿色表示当前无需处理；红色当天处理；黄色表示源近期安静或刚出现失败，需要判断是正常发布节奏还是该换更快渠道。点击来源地址可直接复盘。",
       "gridPos": {
         "x": 0,
         "y": 78,
@@ -2420,7 +2420,7 @@
       },
       "targets": [
         {
-          "expr": "pgc_source_health_problem_source_info",
+          "expr": "pgc_source_health_problem_source_info OR label_replace(label_replace(label_replace(label_replace(absent(pgc_source_health_problem_source_info), \"source\", \"全部运行中的信源\", \"\", \"\"), \"category\", \"健康\", \"\", \"\"), \"source_tier\", \"-\", \"\", \"\"), \"issue\", \"healthy\", \"\", \"\")",
           "refId": "A",
           "instant": true,
           "format": "table"
@@ -2495,6 +2495,11 @@
                         "text": "刚出现抓取失败",
                         "color": "yellow",
                         "index": 7
+                      },
+                      "healthy": {
+                        "text": "没有需要处理的信源",
+                        "color": "green",
+                        "index": 8
                       }
                     }
                   }
@@ -2537,6 +2542,11 @@
                         "text": "长尾来源",
                         "color": "text",
                         "index": 3
+                      },
+                      "-": {
+                        "text": "正常",
+                        "color": "green",
+                        "index": 4
                       }
                     }
                   }

--- a/scripts/local/validate_pgc_grafana_dashboard.py
+++ b/scripts/local/validate_pgc_grafana_dashboard.py
@@ -309,6 +309,19 @@ def static_validate(dashboard: dict) -> list[str]:
             "table unreadable: "
             + ", ".join(sorted(visible_internal_source_fields))
         )
+    source_health_exprs = [
+        target.get("expr", "")
+        for target in source_health_panel.get("targets", []) or []
+    ] if source_health_panel else []
+    if source_health_panel and not any(
+        "absent(pgc_source_health_problem_source_info)" in expr
+        and '"issue", "healthy"' in expr
+        for expr in source_health_exprs
+    ):
+        errors.append(
+            "panel 82 must render an explicit healthy row instead of Grafana's "
+            "ambiguous English No data state"
+        )
 
     all_exprs = "\n".join(
         t.get("expr", "") for p in dashboard.get("panels", [])


### PR DESCRIPTION
## Why\nThe owner-facing source problem table rendered Grafana's ambiguous English `No data` message when every source was healthy.\n\n## What\n- render an explicit Chinese healthy row only when the problem metric is absent\n- preserve the existing concrete problem rows when any source needs attention\n- add a validator guard so the empty-state contract cannot regress\n\n## Verification\n- dashboard JSON parses\n- validator passes: 30 panels / 43 Prometheus targets\n- fallback PromQL evaluated successfully against production Prometheus