### PR TITLE
fix(pipeline): reclaim item messages left pending by HandleRetry

### DIFF
--- a/pipeline/consumer/item_consumer.go
+++ b/pipeline/consumer/item_consumer.go
@@ -23,10 +23,14 @@ import (
 )
 
 const (
-	itemStream          = "stream:item:publish"
-	itemGroup           = "cg:item:publish"
-	itemConsumerName    = "item-worker-1"
-	itemMetricsLabel    = "item:publish"
+	itemStream            = "stream:item:publish"
+	itemGroup             = "cg:item:publish"
+	itemConsumerName      = "item-worker-1"
+	itemMetricsLabel      = "item:publish"
+	itemMaxRetryCount     = int64(3)
+	itemRetryMinIdle      = time.Second
+	itemRetryPollInterval = 200 * time.Millisecond
+	itemReadBlock         = 500 * time.Millisecond
 )
 
 var (
@@ -35,12 +39,22 @@ var (
 	ackItemMessage            = mq.Ack
 )
 
+// ItemConsumer enriches published items with LLM-extracted metadata.
+//
+// The tunable fields (consumerName, maxRetries, retryMinIdle, readBlock,
+// handleMessage) are kept on the consumer struct so miniredis-based tests can
+// override them between NewItemConsumer and Start, mirroring ItemStatsConsumer.
 type ItemConsumer struct {
 	llmClient        *llm.Client
 	safetyClient     *llm.Client
 	embeddingClient  *embedding.Client
 	qualityThreshold float64
-	runner           *StreamConsumer
+	consumerName     string
+	workers          int
+	maxRetries       int64
+	retryMinIdle     time.Duration
+	readBlock        time.Duration
+	handleMessage    MessageHandler
 }
 
 func NewItemConsumer(cfg *config.Config, prompts *llm.PromptRegistry) *ItemConsumer {
@@ -49,23 +63,33 @@ func NewItemConsumer(cfg *config.Config, prompts *llm.PromptRegistry) *ItemConsu
 		safetyClient:     llm.NewSafetyClient(cfg, prompts),
 		embeddingClient:  embedding.NewClient(cfg.EmbeddingProvider, cfg.EmbeddingApiKey, cfg.EmbeddingBaseURL, cfg.EmbeddingModel, cfg.EmbeddingDimensions),
 		qualityThreshold: cfg.QualityThreshold,
+		consumerName:     itemConsumerName,
+		maxRetries:       itemMaxRetryCount,
+		retryMinIdle:     itemRetryMinIdle,
+		readBlock:        itemReadBlock,
+		workers:          cfg.ItemConsumerWorkers,
 	}
-	c.runner = &StreamConsumer{
-		Name:                    "ItemConsumer",
-		Stream:                  itemStream,
-		Group:                   itemGroup,
-		ConsumerName:            itemConsumerName,
-		MetricsLabel:            itemMetricsLabel,
-		Workers:                 cfg.ItemConsumerWorkers,
-		FatalOnGroupCreateError: true,
-		Handle:                  c.handle,
-	}
+	c.handleMessage = c.handle
 	return c
 }
 
 func (c *ItemConsumer) Start(ctx context.Context) {
 	logger.Default().Info("ItemConsumer starting", "qualityThreshold", c.qualityThreshold)
-	c.runner.Run(ctx)
+	runner := &StreamConsumer{
+		Name:                    "ItemConsumer",
+		Stream:                  itemStream,
+		Group:                   itemGroup,
+		ConsumerName:            c.consumerName,
+		MetricsLabel:            itemMetricsLabel,
+		Workers:                 c.workers,
+		MaxRetries:              c.maxRetries,
+		RetryMinIdle:            c.retryMinIdle,
+		PollInterval:            itemRetryPollInterval,
+		ReadBlock:               c.readBlock,
+		FatalOnGroupCreateError: true,
+		Handle:                  c.handleMessage,
+	}
+	runner.Run(ctx)
 }
 
 func (c *ItemConsumer) handle(ctx context.Context, msgID string, values map[string]any) HandleResult {

--- a/pipeline/consumer/item_consumer_retry_test.go
+++ b/pipeline/consumer/item_consumer_retry_test.go
@@ -1,0 +1,208 @@
+package consumer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"eigenflux_server/pkg/config"
+	"eigenflux_server/pkg/mq"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupItemConsumerRedis points mq.RDB at an in-process miniredis for the
+// duration of the test.
+func setupItemConsumerRedis(t *testing.T) {
+	t.Helper()
+
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		_ = client.Close()
+		mr.Close()
+	})
+
+	mq.RDB = client
+	t.Cleanup(func() {
+		mq.RDB = nil
+	})
+}
+
+// newTestItemConsumer builds an ItemConsumer with the production retry
+// configuration but test-sized timings, and replaces the message handler.
+// It deliberately does NOT override maxRetries: the delivery guarantee under
+// test is the one NewItemConsumer ships with.
+func newTestItemConsumer(t *testing.T, name string, handle MessageHandler) *ItemConsumer {
+	t.Helper()
+
+	c := NewItemConsumer(&config.Config{ItemConsumerWorkers: 1}, nil)
+	c.consumerName = name
+	c.retryMinIdle = 5 * time.Millisecond
+	c.readBlock = 10 * time.Millisecond
+	c.handleMessage = handle
+	return c
+}
+
+// runItemConsumer starts the consumer and returns a stop function.
+func runItemConsumer(t *testing.T, c *ItemConsumer) func() {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		c.Start(ctx)
+		close(done)
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+func publishItem(t *testing.T, itemID string) {
+	t.Helper()
+	_, err := mq.Publish(context.Background(), itemStream, map[string]any{"item_id": itemID})
+	require.NoError(t, err)
+}
+
+func pendingCount(t *testing.T) int64 {
+	t.Helper()
+	n, err := mq.PendingCount(context.Background(), itemStream, itemGroup)
+	require.NoError(t, err)
+	return n
+}
+
+// TestItemConsumerReclaimsMessageAfterTransientRetry is the regression test for
+// the enrichment-reliability bug.
+//
+// A single transient failure (in production: a failed UpdateProcessedItemStatus
+// write) makes handle() return HandleRetry. StreamConsumer deliberately skips
+// the ACK for that result. With MaxRetries == 0 the runner only ever calls
+// mq.Consume (XREADGROUP ">"), which reads *new* entries and never reclaims the
+// pending-entries list — so the message stays in the PEL forever and the item
+// is never enriched.
+//
+// Before the fix this test fails: the retry is never redelivered, so attempts
+// stays at 1 and the PEL never drains.
+func TestItemConsumerReclaimsMessageAfterTransientRetry(t *testing.T) {
+	setupItemConsumerRedis(t)
+
+	var attempts atomic.Int64
+	c := newTestItemConsumer(t, "test-item-retry-recovers",
+		func(ctx context.Context, msgID string, values map[string]any) HandleResult {
+			if attempts.Add(1) == 1 {
+				return HandleRetry
+			}
+			return HandleSuccess
+		})
+
+	stop := runItemConsumer(t, c)
+	defer stop()
+
+	publishItem(t, "1001")
+
+	require.Eventuallyf(t, func() bool {
+		return attempts.Load() >= 2 && pendingCount(t) == 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"message returning HandleRetry was never reclaimed and redelivered")
+
+	assert.EqualValues(t, 0, pendingCount(t), "pending entries list must drain after a successful retry")
+}
+
+// TestItemConsumerRetryIsBounded pins the upper bound on redelivery: a handler
+// that never succeeds must not be retried forever. Once the retry count reaches
+// MaxRetries the runner drops the message and ACKs it, so the PEL drains.
+func TestItemConsumerRetryIsBounded(t *testing.T) {
+	setupItemConsumerRedis(t)
+
+	var attempts atomic.Int64
+	c := newTestItemConsumer(t, "test-item-retry-bounded",
+		func(ctx context.Context, msgID string, values map[string]any) HandleResult {
+			attempts.Add(1)
+			return HandleRetry
+		})
+
+	stop := runItemConsumer(t, c)
+	defer stop()
+
+	publishItem(t, "1002")
+
+	// Wait for the message to actually be delivered and retried at least once
+	// before checking that it was dropped — an empty PEL on its own is also the
+	// state before first delivery.
+	require.Eventuallyf(t, func() bool {
+		return attempts.Load() >= 2 && pendingCount(t) == 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"permanently failing message was never retried and then dropped after MaxRetries")
+
+	observed := attempts.Load()
+	assert.LessOrEqual(t, observed, itemMaxRetryCount+1,
+		"handler ran %d times, expected at most MaxRetries+1 (%d)", observed, itemMaxRetryCount+1)
+	assert.Greater(t, observed, int64(1), "a permanently failing message should be retried at least once")
+
+	// The drop must be terminal: no further redelivery after the PEL drains.
+	settled := attempts.Load()
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, settled, attempts.Load(), "dropped message must not be redelivered again")
+	assert.EqualValues(t, 0, pendingCount(t))
+}
+
+// TestItemConsumerSuccessPathAcksExactlyOnce guards against the retry change
+// introducing duplicate delivery on the happy path.
+func TestItemConsumerSuccessPathAcksExactlyOnce(t *testing.T) {
+	setupItemConsumerRedis(t)
+
+	var attempts atomic.Int64
+	c := newTestItemConsumer(t, "test-item-success-once",
+		func(ctx context.Context, msgID string, values map[string]any) HandleResult {
+			attempts.Add(1)
+			return HandleSuccess
+		})
+
+	stop := runItemConsumer(t, c)
+	defer stop()
+
+	publishItem(t, "1003")
+
+	require.Eventually(t, func() bool {
+		return attempts.Load() == 1 && pendingCount(t) == 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+	assert.EqualValues(t, 1, attempts.Load(), "a successful message must be processed exactly once")
+	assert.EqualValues(t, 0, pendingCount(t))
+}
+
+// TestItemConsumerFailureIsAckedNotRetried documents the distinction the fix
+// preserves: HandleFailure is a poison-message verdict and is ACKed and
+// dropped immediately, unlike HandleRetry.
+func TestItemConsumerFailureIsAckedNotRetried(t *testing.T) {
+	setupItemConsumerRedis(t)
+
+	var attempts atomic.Int64
+	c := newTestItemConsumer(t, "test-item-failure-dropped",
+		func(ctx context.Context, msgID string, values map[string]any) HandleResult {
+			attempts.Add(1)
+			return HandleFailure
+		})
+
+	stop := runItemConsumer(t, c)
+	defer stop()
+
+	publishItem(t, "1004")
+
+	require.Eventually(t, func() bool {
+		return attempts.Load() == 1 && pendingCount(t) == 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+	assert.EqualValues(t, 1, attempts.Load(), "HandleFailure must not be redelivered")
+	assert.EqualValues(t, 0, pendingCount(t))
+}


### PR DESCRIPTION
## Description

`ItemConsumer` ran `StreamConsumer` in simple mode — `NewItemConsumer` never set `MaxRetries`, so it
defaulted to `0` — while `ItemConsumer.handle` returns `HandleRetry` in 6 places. `StreamConsumer`
deliberately skips the ACK for `HandleRetry`, and in simple mode the runner only calls `mq.Consume`
(`XREADGROUP ">"`), which reads *new* entries and never reclaims the pending-entries list. The
message therefore stays in the PEL permanently and the item is never enriched.

This is the behaviour already documented at `pipeline/consumer/stream_consumer.go:23-27`:

> `HandleRetry`: do NOT ack the message. […] Only meaningful when `MaxRetries` is set; in simple
> mode (`MaxRetries = 0`) this still skips the ACK, **leaving the message pending until the
> consumer-group expires or is reset.**

All 6 `HandleRetry` sites (lines 105, 120, 193, 201, 247, 260) are failed
`UpdateProcessedItemStatus` writes, so **a single transient PostgreSQL error is enough** — no
process crash, container restart, or worker interruption is involved.

### Why the fix is scoped to `ItemConsumer` alone

All 10 `StreamConsumer` users were audited:

| `MaxRetries` | Consumer | `return HandleRetry` count |
|---|---|---|
| 0 (simple) | `agentcard`, `order_event`, `profile` | 0 / 0 / 0 |
| **0 (simple)** | **`item`** | **6** |
| 3 | `item_stats`, `followup`, `replay`, `official_welcome`, `official_first_broadcast` | retry-aware |
| 5 | `service` | retry-aware |

The other three simple-mode consumers never return `HandleRetry`, so they always ACK and cannot
leak. Every consumer that does return `HandleRetry` already sets `MaxRetries > 0`. `item` is the
only "simple mode + returns `HandleRetry`" combination, so no other consumer needs changing.

## Related Issue

Closes #113

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- Configure `ItemConsumer` for retry-aware mode using the same defaults `ItemStatsConsumer` already
  uses: `MaxRetries = 3`, `RetryMinIdle = 1s`, `PollInterval = 200ms`, `ReadBlock = 500ms`.
- Move `StreamConsumer` construction from `NewItemConsumer` into `Start`, and keep the tunable
  fields (`consumerName`, `maxRetries`, `retryMinIdle`, `readBlock`, `handleMessage`) on the struct
  so miniredis-based tests can override them — mirroring the pattern `ItemStatsConsumer` documents
  for exactly this reason.
- Add `pipeline/consumer/item_consumer_retry_test.go` with four regression tests.

No change to `ItemConsumer.handle` itself, and no other consumer touched.

## Testing

- [x] Unit tests pass (`go test ./...`)
- [ ] Integration tests pass
- [x] Manual testing performed
- [x] Added new tests for new functionality

New tests (`pipeline/consumer/item_consumer_retry_test.go`, miniredis-backed, no external services):

| Test | Asserts |
|---|---|
| `TestItemConsumerReclaimsMessageAfterTransientRetry` | A handler returning `HandleRetry` once then `HandleSuccess` is reclaimed after `RetryMinIdle`, reprocessed, ACKed, and the PEL drains |
| `TestItemConsumerRetryIsBounded` | A permanently failing handler is retried at least once but at most `MaxRetries + 1` times, then dropped and ACKed; no redelivery after the drop |
| `TestItemConsumerSuccessPathAcksExactlyOnce` | The happy path is delivered exactly once — the retry change introduces no duplicate processing |
| `TestItemConsumerFailureIsAckedNotRetried` | `HandleFailure` remains a poison-message verdict: ACKed and dropped immediately, not retried |

**Red/green evidence.** With the one-line `maxRetries: itemMaxRetryCount` removed and everything
else identical, exactly the two retry tests fail:

```
--- FAIL: TestItemConsumerReclaimsMessageAfterTransientRetry (5.01s)
--- FAIL: TestItemConsumerRetryIsBounded (5.01s)
```

With the fix in place, all four pass, and stay green over `-count=3`:

```
ok  	eigenflux_server/pipeline/consumer	9.602s
```

**No regressions.** Full unit run (all packages outside `tests/`) is identical before and after:
45 packages pass, 1 fails, 64 have no test files. The single failure is pre-existing and unrelated —
`rpc/item`'s `TestDeleteMyItemIntegration` calls `db.Init("")` with an empty DSN
(`rpc/item/delete_test.go:48`), which fails on any host without `PG*` environment variables. It is
skipped under `-short`.

`go vet ./...` is clean (0 findings). `golangci-lint run` reports **73 issues before and after**,
with an identical breakdown (errcheck 50, staticcheck 13, unused 9, govet 1) — this PR adds none.

**Test environment:**
- OS: Windows 11 (26200)
- Go version: 1.26.5 (module targets 1.25.0)

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Documentation is unchecked deliberately: this restores the delivery guarantee already described in
`docs/dev/pipeline.md` and in the `StreamConsumer` doc comment, so no doc text became inaccurate.
Happy to add a note if you would prefer one.

## Additional Notes

Two adjacent observations found while tracing this, **deliberately left unchanged** to keep the PR
scoped. Happy to follow up on either if you want them addressed.

1. **Redundant double ACK (harmless).** `persistProcessedItem` (`item_consumer.go:436`) ACKs the
   message itself before returning `false`; `handle` then returns `HandleFailure` and the runner
   ACKs again at `stream_consumer.go:155`. `XACK` is idempotent — the second call just returns 0 —
   so this is redundancy, not a bug, and it does not impede recovery. It could be cleaned up
   separately.

2. **Silent publish failures at the enqueue boundary.** The publish side discards its error with
   `_, _ = mq.Publish(...)`, so a Redis failure loses the work item with no signal and no retry:
   the PostgreSQL write has already committed, so the row exists but is never queued for
   enrichment. This fix makes delivery reliable *after* a message reaches the stream; it cannot
   help if the message never gets there.

   The pattern is repo-wide, not a one-off:
   `api/handler_gen/eigenflux/api/api_service.go:548` (`stream:item:publish`) and `:343`
   (`stream:profile:update`), `api/agentcard/handlers.go:465`, and `rpc/trade/handler.go:83,134,147`.

   Note the two `api_service.go` sites are in `handler_gen/`, which is hz-generated, so a fix there
   is not a straightforward edit. A proper solution (transactional outbox, or at minimum
   propagating the error) is a separate design change and is out of scope for this PR.
