### PR TITLE
feat(pm): support per-agent friend request limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ __pycache__
 .sqls
 /build/
 .env
+configs/pm/friend_request_limits.yaml
 .cli.env
 .venv/
 .audit/
@@ -65,4 +66,3 @@ docs/superpowers/
 .agents/
 docs/agents/
 docs/research/
-

--- a/configs/pm/friend_request_limits.example.yaml
+++ b/configs/pm/friend_request_limits.example.yaml
@@ -1,0 +1,20 @@
+# Friend-request hourly rate limits for the PM service.
+#
+# This committed example documents the format only. Production must use the
+# private file configs/pm/friend_request_limits.yaml, which is gitignored so
+# operator-managed agent IDs and limits are never published with the source.
+#
+# The PM service reads this file once at startup. After changing the private
+# file, restart only the pm service for the update to take effect.
+
+# Limit for every agent without an override. This protects the service from
+# bulk unsolicited friend requests. Use a positive integer.
+default_hourly_limit: 10
+
+# Per-agent overrides. Each agent_id may appear only once. An override changes
+# the limit; it does not disable rate limiting. Keep this list short and review
+# it regularly.
+overrides:
+  # Example only: replace with the production agent ID in the private file.
+  - agent_id: 123456789
+    hourly_limit: 200

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -33,6 +33,7 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 - **Relations** (`rpc/pm/relations/`): Friend/block relationship queries with caching
 - **DAL** (`rpc/pm/dal/`): Data access for conversations, messages, friend requests
 - **NotifyUtil** (`rpc/pm/notifyutil/`): Friend request notification helpers (writes to `pm:notify:{agent_id}` Redis hash)
+- **Rate-limit config** (`configs/pm/friend_request_limits.yaml`): private, gitignored operator configuration for per-agent friend-request hourly limits; the committed `.example.yaml` documents its format
 
 ## Key Behaviors
 

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -17,6 +17,7 @@ import (
 	"eigenflux_server/rpc/pm/dal"
 	"eigenflux_server/rpc/pm/icebreak"
 	"eigenflux_server/rpc/pm/notifyutil"
+	"eigenflux_server/rpc/pm/ratelimit"
 	"eigenflux_server/rpc/pm/relations"
 	"eigenflux_server/rpc/pm/validator"
 
@@ -44,8 +45,9 @@ type PMServiceImpl struct {
 	reqIDGen interface {
 		NextID() (int64, error)
 	}
-	iceBreaker *icebreak.IceBreaker
-	validator  *validator.Validator
+	iceBreaker          *icebreak.IceBreaker
+	validator           *validator.Validator
+	friendRequestLimits *ratelimit.Config
 }
 
 func (s *PMServiceImpl) SendPM(ctx context.Context, req *pm.SendPMReq) (*pm.SendPMResp, error) {
@@ -673,8 +675,9 @@ func (s *PMServiceImpl) SendFriendRequest(ctx context.Context, req *pm.SendFrien
 		if count == 1 {
 			db.RDB.Expire(ctx, rateLimitKey, time.Hour)
 		}
-		if count > 10 {
-			logger.Ctx(ctx).Warn("SendFriendRequest rate limited", "fromUID", req.FromUid, "count", count)
+		limit := s.friendRequestLimits.HourlyLimit(req.FromUid)
+		if count > int64(limit) {
+			logger.Ctx(ctx).Warn("SendFriendRequest rate limited", "fromUID", req.FromUid, "count", count, "limit", limit)
 			return &pm.SendFriendRequestResp{BaseResp: &base.BaseResp{Code: 429, Msg: "too many requests, please try again later"}}, nil
 		}
 	}

--- a/rpc/pm/main.go
+++ b/rpc/pm/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net"
+	"os"
 	"strings"
 
 	etcd "github.com/kitex-contrib/registry-etcd"
@@ -18,6 +20,7 @@ import (
 	"eigenflux_server/pkg/rpcx"
 	"eigenflux_server/pkg/telemetry"
 	"eigenflux_server/rpc/pm/icebreak"
+	"eigenflux_server/rpc/pm/ratelimit"
 	"eigenflux_server/rpc/pm/validator"
 )
 
@@ -93,6 +96,13 @@ func main() {
 	// Create ice breaker and validator
 	iceBreaker := icebreak.NewIceBreaker(db.RDB)
 	pmValidator := validator.NewValidator(db.DB, db.RDB)
+	friendRequestLimits, err := ratelimit.LoadFile(ratelimit.ConfigPath)
+	if errors.Is(err, os.ErrNotExist) {
+		friendRequestLimits = ratelimit.DefaultConfig()
+		logger.Default().Warn("friend request rate-limit config not found; using defaults", "path", ratelimit.ConfigPath)
+	} else if err != nil {
+		log.Fatalf("failed to load friend request rate-limit config: %v", err)
+	}
 
 	// Create etcd registry for this service
 	registry, err := etcd.NewEtcdRegistry(etcdEndpoints)
@@ -104,11 +114,12 @@ func main() {
 	addr, _ := net.ResolveTCPAddr("tcp", listenAddr)
 	svr := pmservice.NewServer(
 		&PMServiceImpl{
-			convIDGen:  convIDGen,
-			msgIDGen:   msgIDGen,
-			reqIDGen:   reqIDGen,
-			iceBreaker: iceBreaker,
-			validator:  pmValidator,
+			convIDGen:           convIDGen,
+			msgIDGen:            msgIDGen,
+			reqIDGen:            reqIDGen,
+			iceBreaker:          iceBreaker,
+			validator:           pmValidator,
+			friendRequestLimits: friendRequestLimits,
 		},
 		rpcx.ServerOptions(addr, registry, "PMService", metrics.KitexServerMW())...,
 	)

--- a/rpc/pm/ratelimit/config.go
+++ b/rpc/pm/ratelimit/config.go
@@ -1,0 +1,80 @@
+package ratelimit
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultHourlyLimit = 10
+	ConfigPath         = "configs/pm/friend_request_limits.yaml"
+)
+
+// Config defines the hourly friend-request limit for all agents and selected overrides.
+type Config struct {
+	DefaultHourlyLimit int        `yaml:"default_hourly_limit"`
+	Overrides          []Override `yaml:"overrides"`
+}
+
+// Override replaces the default hourly limit for one agent.
+type Override struct {
+	AgentID     int64 `yaml:"agent_id"`
+	HourlyLimit int   `yaml:"hourly_limit"`
+}
+
+// DefaultConfig returns the limit used when no private production config exists.
+func DefaultConfig() *Config {
+	return &Config{DefaultHourlyLimit: DefaultHourlyLimit}
+}
+
+// LoadFile loads and validates a friend-request rate-limit config.
+func LoadFile(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse friend request rate-limit config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// HourlyLimit returns the configured hourly limit for an agent.
+func (c *Config) HourlyLimit(agentID int64) int {
+	if c == nil {
+		return DefaultHourlyLimit
+	}
+	for _, override := range c.Overrides {
+		if override.AgentID == agentID {
+			return override.HourlyLimit
+		}
+	}
+	return c.DefaultHourlyLimit
+}
+
+// Validate rejects malformed or ambiguous operator configuration.
+func (c *Config) Validate() error {
+	if c.DefaultHourlyLimit <= 0 {
+		return fmt.Errorf("default_hourly_limit must be positive")
+	}
+	seen := make(map[int64]struct{}, len(c.Overrides))
+	for _, override := range c.Overrides {
+		if override.AgentID <= 0 {
+			return fmt.Errorf("override agent_id must be positive")
+		}
+		if override.HourlyLimit <= 0 {
+			return fmt.Errorf("override hourly_limit for agent %d must be positive", override.AgentID)
+		}
+		if _, ok := seen[override.AgentID]; ok {
+			return fmt.Errorf("duplicate override for agent %d", override.AgentID)
+		}
+		seen[override.AgentID] = struct{}{}
+	}
+	return nil
+}

--- a/rpc/pm/ratelimit/config_test.go
+++ b/rpc/pm/ratelimit/config_test.go
@@ -1,0 +1,32 @@
+package ratelimit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFileAndHourlyLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "limits.yaml")
+	if err := os.WriteFile(path, []byte("default_hourly_limit: 10\noverrides:\n  - agent_id: 101\n    hourly_limit: 200\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.HourlyLimit(101); got != 200 {
+		t.Fatalf("HourlyLimit(101) = %d, want 200", got)
+	}
+	if got := cfg.HourlyLimit(202); got != 10 {
+		t.Fatalf("HourlyLimit(202) = %d, want 10", got)
+	}
+}
+
+func TestValidateRejectsDuplicateOverrides(t *testing.T) {
+	cfg := &Config{DefaultHourlyLimit: 10, Overrides: []Override{{AgentID: 101, HourlyLimit: 200}, {AgentID: 101, HourlyLimit: 100}}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected duplicate override to be rejected")
+	}
+}


### PR DESCRIPTION
Adds a gitignored private PM YAML config for per-agent friend-request hourly limits. Defaults to 10/hour; operator overrides remain rate-limited rather than unlimited.