### PR TITLE
告警:PGC 判决主模型掉线（备用顶班）——补 8/5 欠费事故的告警盲区

### DIFF
--- a/configs/grafana/alerting/pgc-rules.yml
+++ b/configs/grafana/alerting/pgc-rules.yml
@@ -228,6 +228,39 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [129600] }
 
+      - uid: pgc-primary-llm-down
+        title: PGC 判决主模型掉线（备用顶班）
+        condition: C
+        for: 15m
+        noDataState: NoData
+        execErrState: Alerting
+        annotations:
+          summary: 判决主模型至少 15 分钟基本不可用，内容都靠备用模型顶着——没有丢内容，但备用模型更贵也更慢。去查主模型服务商的账号状态（2026-08-05 这次是阿里云欠费停服，主模型静默断了 6 小时才被巡检发现）。
+        labels:
+          service: pgc
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: pgc-prometheus
+            model:
+              # 近 1 小时判决流量落在备用模型上的比例（0-1）。正常≈0，偶发
+              # 单条重试不超过 0.05；2026-08-05 欠费事故全天=1.0。阈值 0.5=
+              # "主模型已经不是主力"。指标窗口本身 1h + for 15m，足够平滑。
+              # NoData 不告警：指标缺位由"指标刷新停滞"规则负责，管道停摆
+              # 由"管道停摆"规则负责，这条只管"活着但在备胎上"。
+              expr: max(pgc_llm_fallback_share_1h)
+              instant: true
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.5] }
+
       - uid: pgc-verdicts-stale
         title: PGC 判决结果停更
         condition: C


### PR DESCRIPTION
## 背景
8/5 阿里云欠费，主判决模型静默断 6 小时，备用模型接住全部流量，现有 8 条规则一条没响（它们只盯「判决停了没」，不盯「谁在服务」）。

## 改动
新增第 9 条规则 `pgc-primary-llm-down`：近 1 小时备用承载率 `pgc_llm_fallback_share_1h` > 0.5 且持续 15 分钟即告警。正常基线 ≈0（偶发单条重试 <0.05），事故当天 =1.0。NoData 不告警——指标缺位归「指标刷新停滞」管，管道死归「管道停摆」管，这条只管「活着但在备胎上」。

指标端已随 eigenflux-pgc#116 部署上线（当前值 =1.0，合并部署后这条规则会立刻开始响，符合现状）。

⚠️ 合并后需要部署到监控机 Grafana 生效（我下轮巡检跟进）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)