### PR TITLE
fix(agentcard): project effective feed cadence

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -36,6 +36,7 @@ import (
 	"eigenflux_server/pkg/agentcard"
 	"eigenflux_server/pkg/config"
 	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/feedpoll"
 	"eigenflux_server/pkg/followuplog"
 	"eigenflux_server/pkg/invite"
 	"eigenflux_server/pkg/itemstats"
@@ -2802,9 +2803,9 @@ func ConsoleGetSettings(ctx context.Context, c *app.RequestContext) {
 // feedPollInterval onboarding ramp: brand-new agents poll slowly so their first
 // days aren't flooded, then speed up to the steady cadence automatically.
 const (
-	feedPollRampWindowMs  int64 = 3 * 24 * 60 * 60 * 1000 // first 3 days after registration
-	feedPollRampNewSec    int32 = 3600                    // cadence during the ramp window
-	feedPollRampSteadySec int32 = 300                     // cadence afterward (also the offline fallback)
+	feedPollRampWindowMs  int64 = feedpoll.RampWindowMs
+	feedPollRampNewSec    int32 = feedpoll.RampNewSec
+	feedPollRampSteadySec int32 = feedpoll.RampSteadySec
 )
 
 // feedPollRampSec returns the onboarding-ramp poll interval for an agent that
@@ -2831,13 +2832,7 @@ func feedPollRampSec(ctx context.Context, agentID int64, settings *consoledal.Ag
 // feedPollRampForCreatedAt is the pure ramp decision: 3600s while the agent is
 // within its first 3 days, 300s afterward, and 300s when created_at is unknown.
 func feedPollRampForCreatedAt(createdAtMs, nowMs int64) int32 {
-	if createdAtMs <= 0 {
-		return feedPollRampSteadySec
-	}
-	if nowMs-createdAtMs < feedPollRampWindowMs {
-		return feedPollRampNewSec
-	}
-	return feedPollRampSteadySec
+	return feedpoll.EffectiveInterval(feedPollRampSteadySec, false, createdAtMs, nowMs)
 }
 
 // GetMySettings returns the agent's runtime settings, authenticated via the
@@ -3139,6 +3134,7 @@ func ConsoleUpdateSettings(ctx context.Context, c *app.RequestContext) {
 		writeJSON(c, http.StatusInternalServerError, 500, err.Error(), nil)
 		return
 	}
+	agentcard.PublishRebuild(ctx, agentID, "settings_update")
 
 	writeJSON(c, http.StatusOK, 0, "success", nil)
 }

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -85,6 +85,12 @@ context to the CLI-owned prompt/patch flow. The unavoidable host-only inputs are
   request headers or `settings push`; it is operational telemetry, not a
   cryptographically verified identity claim.
 
+The owner-only Card field `interrupt_threshold` is system-owned and contains
+the effective `feed_poll_interval` in seconds. It follows the same onboarding
+ramp as the settings API (3600 seconds for an unpinned agent's first three days,
+then 300 seconds) and reflects an explicit user override immediately. Clients
+must update `feed_poll_interval` through settings rather than profile patching.
+
 ## Skill Document Structure
 
 Agent-facing skill documentation is served as modular markdown files:

--- a/pkg/agentcard/builder.go
+++ b/pkg/agentcard/builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 
+	"eigenflux_server/pkg/feedpoll"
 	itemdal "eigenflux_server/rpc/item/dal"
 	pmdal "eigenflux_server/rpc/pm/dal"
 	profiledal "eigenflux_server/rpc/profile/dal"
@@ -122,13 +123,16 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 
 	// agent_settings, read without the row-creating GetSettings side effect.
 	var settings struct {
-		ClientHost             string
-		Mode                   string
-		FeedDeliveryPreference string
-		UpdatedAt              int64
+		ClientHost              string
+		Mode                    string
+		FeedDeliveryPreference  string
+		FeedPollInterval        int32
+		FeedPollIntervalUserSet bool
+		AgentCreatedAtMs        int64
+		UpdatedAt               int64
 	}
 	if err := gdb.Table("agent_settings").
-		Select("client_host, mode, feed_delivery_preference, updated_at").
+		Select("client_host, mode, feed_delivery_preference, feed_poll_interval, feed_poll_interval_user_set, agent_created_at_ms, updated_at").
 		Where("agent_id = ?", agentID).
 		Scan(&settings).Error; err != nil {
 		return err
@@ -213,6 +217,10 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 		pub["last_active_at"] = nil
 	}
 
+	pollCreatedAtMs := settings.AgentCreatedAtMs
+	if pollCreatedAtMs <= 0 {
+		pollCreatedAtMs = agent.CreatedAt
+	}
 	priv := map[string]interface{}{
 		"schema_version": SchemaVersion,
 		"geo":            rawOr(profileData, "geo", country),
@@ -228,7 +236,9 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 		// PUT /agents/me/settings); projected here read-only.
 		"delivery_preference": settings.FeedDeliveryPreference,
 		"interests_negative":  rawOr(profileData, "interests_negative", []string{}),
-		"interrupt_threshold": rawOr(profileData, "interrupt_threshold", map[string]interface{}{}),
+		// interrupt_threshold is the effective feed-pull cadence in seconds.
+		// agent_settings is the fact source; clients cannot patch this projection.
+		"interrupt_threshold": feedpoll.EffectiveInterval(settings.FeedPollInterval, settings.FeedPollIntervalUserSet, pollCreatedAtMs, time.Now().UnixMilli()),
 		"relations":           relations,
 		"updated_at":          privateUpdatedAt,
 	}

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SchemaVersion is the Card JSON schema revision served to clients.
-const SchemaVersion int32 = 2
+const SchemaVersion int32 = 3
 
 // FieldStorage says which fact table owns an editable field. The Card itself
 // is never a fact source.
@@ -58,7 +58,6 @@ var EditableFields = []FieldSpec{
 	{Name: "agent_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
 	{Name: "human_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
 	{Name: "interests_negative", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 30},
-	{Name: "interrupt_threshold", Public: false, Storage: StorageProfileData, Kind: "object", MaxLen: 2048},
 }
 
 // ProtectedPaths are Card paths no client may write, whatever the request
@@ -74,6 +73,7 @@ var ProtectedPaths = []string{
 	"relations",
 	"interests_positive",
 	"delivery_preference",
+	"interrupt_threshold",
 	"card_version",
 	"generated_at",
 	"updated_at",

--- a/pkg/agentcard/registry_test.go
+++ b/pkg/agentcard/registry_test.go
@@ -69,17 +69,13 @@ func TestValidateValue(t *testing.T) {
 		t.Error("over-count list accepted")
 	}
 
-	objSpec, _ := LookupField("interrupt_threshold")
-	if _, err := ValidateValue(objSpec, json.RawMessage(`{"level":"normal"}`)); err != nil {
-		t.Errorf("valid object rejected: %v", err)
-	}
-	if _, err := ValidateValue(objSpec, json.RawMessage(`"nope"`)); err == nil {
-		t.Error("string accepted for an object field")
-	}
-	for _, spec := range []FieldSpec{strSpec, listSpec, objSpec} {
+	for _, spec := range []FieldSpec{strSpec, listSpec} {
 		if _, err := ValidateValue(spec, json.RawMessage(`null`)); err == nil {
 			t.Errorf("%s field accepted null", spec.Kind)
 		}
+	}
+	if _, known := LookupField("interrupt_threshold"); known {
+		t.Error("system-owned interrupt_threshold must not be editable")
 	}
 
 	if _, known := LookupField("influence"); known {

--- a/pkg/feedpoll/cadence.go
+++ b/pkg/feedpoll/cadence.go
@@ -1,0 +1,22 @@
+// Package feedpoll owns the effective feed polling cadence shared by the
+// settings API and Agent Card projection.
+package feedpoll
+
+const (
+	RampWindowMs  int64 = 3 * 24 * 60 * 60 * 1000
+	RampNewSec    int32 = 3600
+	RampSteadySec int32 = 300
+)
+
+// EffectiveInterval returns the interval currently applied to feed polling.
+// An explicit user setting always wins; otherwise new agents use the slower
+// onboarding cadence for three days before moving to the steady cadence.
+func EffectiveInterval(stored int32, userSet bool, createdAtMs, nowMs int64) int32 {
+	if userSet {
+		return stored
+	}
+	if createdAtMs > 0 && nowMs-createdAtMs < RampWindowMs {
+		return RampNewSec
+	}
+	return RampSteadySec
+}

--- a/pkg/feedpoll/cadence_test.go
+++ b/pkg/feedpoll/cadence_test.go
@@ -1,0 +1,28 @@
+package feedpoll
+
+import "testing"
+
+func TestEffectiveInterval(t *testing.T) {
+	const nowMs int64 = 1_000_000_000_000
+	day := int64(24 * 60 * 60 * 1000)
+	tests := []struct {
+		name      string
+		stored    int32
+		userSet   bool
+		createdAt int64
+		want      int32
+	}{
+		{"explicit setting", 900, true, nowMs, 900},
+		{"unknown registration", 900, false, 0, RampSteadySec},
+		{"new agent", 300, false, nowMs - day, RampNewSec},
+		{"ramp boundary", 300, false, nowMs - 3*day, RampSteadySec},
+		{"established agent", 300, false, nowMs - 5*day, RampSteadySec},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveInterval(tt.stored, tt.userSet, tt.createdAt, nowMs); got != tt.want {
+				t.Fatalf("EffectiveInterval() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- project the effective feed polling interval into the owner-only Agent Card interrupt_threshold field
- make interrupt_threshold system-owned and bump Card schema to v3
- share onboarding-ramp cadence logic between settings API and Card builder
- rebuild cards after console settings updates

## Verification
- go test ./pkg/feedpoll ./pkg/agentcard ./api/handler_gen/eigenflux/api
- go vet ./pkg/feedpoll ./pkg/agentcard ./api/handler_gen/eigenflux/api
- git diff --check