### PR TITLE
feat(install): ship Google Ads and Xingtu attribution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,3 +270,20 @@ PROMETHEUS_PORT=9090
 # Prometheus scrape target host (default: host.docker.internal for local dev)
 # On cloud: set to the app server's internal IP so Prometheus can reach metrics endpoints
 METRICS_HOST=host.docker.internal
+
+
+# Google Ads offline conversion upload (server-only secrets; do not expose to Vite/browser code)
+# Enable only after the OAuth refresh token and numeric conversion action ID are set.
+GOOGLE_ADS_ENABLED=false
+GOOGLE_ADS_DEVELOPER_TOKEN=
+GOOGLE_ADS_CLIENT_ID=
+GOOGLE_ADS_CLIENT_SECRET=
+GOOGLE_ADS_REFRESH_TOKEN=
+GOOGLE_ADS_CUSTOMER_ID=4514335848
+GOOGLE_ADS_LOGIN_CUSTOMER_ID=4293944125
+GOOGLE_ADS_CONVERSION_ACTION_ID=
+GOOGLE_ADS_API_VERSION=v22
+# Optional override; must exactly match the Web OAuth client's registered redirect URI.
+GOOGLE_ADS_OAUTH_REDIRECT_URI=https://www.eigenflux.ai/api/v1/install/google-ads/oauth/callback
+# Random admin-only value required as Bearer auth to start one-time OAuth authorization.
+GOOGLE_ADS_OAUTH_ADMIN_TOKEN=

--- a/api/install/google_ads_callback.go
+++ b/api/install/google_ads_callback.go
@@ -1,0 +1,187 @@
+package install
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/logger"
+)
+
+// Google Ads offline conversion upload through the Google Data Manager API.
+// A landing gclid is retained with the ref and sent only after installation is
+// confirmed. New Google Ads integrations cannot use ConversionUploadService;
+// Data Manager is the supported replacement.
+var (
+	googleAdsEnabled            bool
+	googleAdsDeveloperToken     string // Retained for existing configuration compatibility; Data Manager does not use it.
+	googleAdsClientID           string
+	googleAdsClientSecret       string
+	googleAdsRefreshToken       string
+	googleAdsCustomerID         string
+	googleAdsLoginCustomerID    string
+	googleAdsConversionActionID string
+	googleAdsAPIVersion         string
+)
+
+var googleAdsHTTP = &http.Client{Timeout: 10 * time.Second}
+
+func initGoogleAdsConfig() {
+	googleAdsEnabled = envBool("GOOGLE_ADS_ENABLED", false)
+	googleAdsDeveloperToken = envStr("GOOGLE_ADS_DEVELOPER_TOKEN", "")
+	googleAdsClientID = envStr("GOOGLE_ADS_CLIENT_ID", "")
+	googleAdsClientSecret = envStr("GOOGLE_ADS_CLIENT_SECRET", "")
+	googleAdsRefreshToken = envStr("GOOGLE_ADS_REFRESH_TOKEN", "")
+	googleAdsCustomerID = digitsOnly(envStr("GOOGLE_ADS_CUSTOMER_ID", ""))
+	googleAdsLoginCustomerID = digitsOnly(envStr("GOOGLE_ADS_LOGIN_CUSTOMER_ID", ""))
+	googleAdsConversionActionID = digitsOnly(envStr("GOOGLE_ADS_CONVERSION_ACTION_ID", ""))
+	googleAdsAPIVersion = strings.Trim(envStr("GOOGLE_ADS_API_VERSION", "v22"), "/")
+	if googleAdsEnabled && !googleAdsConfigured() {
+		logger.Default().Error("GOOGLE_ADS_ENABLED=true but Google Ads Data Manager config is incomplete; callbacks skipped")
+	}
+}
+
+func googleAdsConfigured() bool {
+	return googleAdsClientID != "" && googleAdsClientSecret != "" && googleAdsRefreshToken != "" && googleAdsCustomerID != "" && googleAdsConversionActionID != ""
+}
+
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func fireGoogleAdsInstallCallback(ref string) {
+	if !googleAdsEnabled || !googleAdsConfigured() {
+		return
+	}
+	go func() {
+		won, tok, err := ClaimGoogleAdsInstallCallback(db.DB, ref)
+		if err != nil {
+			logger.Default().Error("Google Ads callback claim failed", "ref", ref, "err", err)
+			return
+		}
+		if !won || tok.Gclid == "" {
+			return
+		}
+		code, err := reportGoogleAdsInstallConversion(tok.Token, tok.Gclid, tok.ReportedAt)
+		if err != nil {
+			logger.Default().Error("Google Ads Data Manager callback failed", "ref", ref, "code", code, "err", err)
+		}
+		if err := SetGoogleAdsInstallCallbackCode(db.DB, ref, code); err != nil {
+			logger.Default().Error("Google Ads callback set code failed", "ref", ref, "err", err)
+		}
+		if code == 0 {
+			event("install_callback_google_ads", ref, "channel", tok.Channel, "conversion_action_id", googleAdsConversionActionID)
+		}
+	}()
+}
+
+func googleAdsAccessToken() (string, error) {
+	form := url.Values{
+		"client_id":     {googleAdsClientID},
+		"client_secret": {googleAdsClientSecret},
+		"refresh_token": {googleAdsRefreshToken},
+		"grant_type":    {"refresh_token"},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := googleAdsHTTP.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var body struct {
+		AccessToken string `json:"access_token"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || body.AccessToken == "" {
+		return "", fmt.Errorf("Google OAuth token refresh failed: %s", body.Error)
+	}
+	return body.AccessToken, nil
+}
+
+// reportGoogleAdsInstallConversion sends a single confirmed install through
+// Data Manager's events:ingest API. transactionId is stable per ref, so Google
+// and our callback lease both receive an idempotency key.
+func reportGoogleAdsInstallConversion(ref, gclid string, reportedAt int64) (int, error) {
+	accessToken, err := googleAdsAccessToken()
+	if err != nil {
+		return -2, err
+	}
+	at := time.Now().UTC()
+	if reportedAt > 0 {
+		at = time.UnixMilli(reportedAt).UTC()
+	}
+
+	destination := map[string]interface{}{
+		"reference": "google_ads_install",
+		"operatingAccount": map[string]string{
+			"accountType": "GOOGLE_ADS",
+			"accountId":   googleAdsCustomerID,
+		},
+		"productDestinationId": googleAdsConversionActionID,
+	}
+	if googleAdsLoginCustomerID != "" {
+		destination["loginAccount"] = map[string]string{
+			"accountType": "GOOGLE_ADS",
+			"accountId":   googleAdsLoginCustomerID,
+		}
+	}
+	payload := map[string]interface{}{
+		"destinations": []map[string]interface{}{destination},
+		"events": []map[string]interface{}{{
+			"eventTimestamp":        at.Format(time.RFC3339),
+			"transactionId":         "install:" + ref,
+			"eventSource":           "WEB",
+			"destinationReferences": []string{"google_ads_install"},
+			"adIdentifiers":         map[string]string{"gclid": gclid},
+		}},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return -2, err
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://datamanager.googleapis.com/v1/events:ingest", bytes.NewReader(data))
+	if err != nil {
+		return -2, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := googleAdsHTTP.Do(req)
+	if err != nil {
+		return -2, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, fmt.Errorf("Google Data Manager ingest HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var result struct {
+		RequestID string `json:"requestId"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return -2, err
+	}
+	if result.RequestID == "" {
+		return -2, fmt.Errorf("Google Data Manager response has no requestId")
+	}
+	logger.Default().Info("Google Ads Data Manager accepted install conversion", "ref", ref, "request_id", result.RequestID)
+	return 0, nil
+}

--- a/api/install/google_ads_callback_test.go
+++ b/api/install/google_ads_callback_test.go
@@ -1,0 +1,80 @@
+package install
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReportGoogleAdsInstallConversion(t *testing.T) {
+	oldClient := googleAdsHTTP
+	oldClientID, oldClientSecret := googleAdsClientID, googleAdsClientSecret
+	oldRefreshToken, oldCustomerID := googleAdsRefreshToken, googleAdsCustomerID
+	oldLoginCustomerID, oldActionID := googleAdsLoginCustomerID, googleAdsConversionActionID
+	t.Cleanup(func() {
+		googleAdsHTTP = oldClient
+		googleAdsClientID, googleAdsClientSecret = oldClientID, oldClientSecret
+		googleAdsRefreshToken, googleAdsCustomerID = oldRefreshToken, oldCustomerID
+		googleAdsLoginCustomerID, googleAdsConversionActionID = oldLoginCustomerID, oldActionID
+	})
+
+	googleAdsClientID = "client"
+	googleAdsClientSecret = "secret"
+	googleAdsRefreshToken = "refresh"
+	googleAdsCustomerID = "4514335848"
+	googleAdsLoginCustomerID = "4293944125"
+	googleAdsConversionActionID = "987654321"
+
+	var ingest map[string]interface{}
+	googleAdsHTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"access_token":"access"}`
+		if req.URL.Host == "datamanager.googleapis.com" {
+			if got := req.Header.Get("Authorization"); got != "Bearer access" {
+				t.Fatalf("Authorization = %q", got)
+			}
+			if err := json.NewDecoder(req.Body).Decode(&ingest); err != nil {
+				t.Fatalf("decode ingest body: %v", err)
+			}
+			body = `{"requestId":"request-1"}`
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})}
+
+	code, err := reportGoogleAdsInstallConversion("EF-test", "gclid-1", time.Date(2026, 8, 6, 1, 2, 3, 0, time.UTC).UnixMilli())
+	if err != nil || code != 0 {
+		t.Fatalf("report conversion code=%d err=%v", code, err)
+	}
+	events, ok := ingest["events"].([]interface{})
+	if !ok || len(events) != 1 {
+		t.Fatalf("events = %#v", ingest["events"])
+	}
+	event := events[0].(map[string]interface{})
+	if event["transactionId"] != "install:EF-test" || event["eventSource"] != "WEB" {
+		t.Fatalf("event = %#v", event)
+	}
+	ids := event["adIdentifiers"].(map[string]interface{})
+	if ids["gclid"] != "gclid-1" {
+		t.Fatalf("adIdentifiers = %#v", ids)
+	}
+}
+
+func TestGoogleAdsOAuthState(t *testing.T) {
+	state, err := makeGoogleAdsOAuthState("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validGoogleAdsOAuthState(state, "secret") {
+		t.Fatal("fresh state must validate")
+	}
+	if validGoogleAdsOAuthState(state, "different-secret") {
+		t.Fatal("state signed by another secret must fail")
+	}
+}

--- a/api/install/google_ads_oauth.go
+++ b/api/install/google_ads_oauth.go
@@ -1,0 +1,138 @@
+package install
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+const googleAdsOAuthCallbackPath = "/api/v1/install/google-ads/oauth/callback"
+
+func googleAdsOAuthRedirectURI() string {
+	return envStr("GOOGLE_ADS_OAUTH_REDIRECT_URI", "https://www.eigenflux.ai"+googleAdsOAuthCallbackPath)
+}
+
+// googleAdsOAuthAuthorize starts a one-time, administrator-protected OAuth flow.
+func googleAdsOAuthAuthorize(_ context.Context, c *app.RequestContext) {
+	adminToken := envStr("GOOGLE_ADS_OAUTH_ADMIN_TOKEN", "")
+	if adminToken == "" || !secureBearerMatch(string(c.GetHeader("Authorization")), adminToken) {
+		c.String(http.StatusUnauthorized, "authorization required")
+		return
+	}
+	if googleAdsClientID == "" || googleAdsClientSecret == "" {
+		c.String(http.StatusServiceUnavailable, "Google OAuth client is not configured")
+		return
+	}
+	state, err := makeGoogleAdsOAuthState(adminToken)
+	if err != nil {
+		c.String(http.StatusInternalServerError, "unable to start authorization")
+		return
+	}
+	q := url.Values{
+		"client_id":     {googleAdsClientID},
+		"redirect_uri":  {googleAdsOAuthRedirectURI()},
+		"response_type": {"code"},
+		// adwords preserves Google Ads administration access; datamanager is
+		// required by the current Google replacement for offline conversions.
+		"scope":       {"https://www.googleapis.com/auth/adwords https://www.googleapis.com/auth/datamanager"},
+		"access_type": {"offline"},
+		"prompt":      {"consent"},
+		"state":       {state},
+	}
+	c.Redirect(http.StatusFound, []byte("https://accounts.google.com/o/oauth2/v2/auth?"+q.Encode()))
+}
+
+func googleAdsOAuthCallback(_ context.Context, c *app.RequestContext) {
+	adminToken := envStr("GOOGLE_ADS_OAUTH_ADMIN_TOKEN", "")
+	if adminToken == "" || !validGoogleAdsOAuthState(c.Query("state"), adminToken) {
+		c.String(http.StatusBadRequest, "invalid or expired OAuth state")
+		return
+	}
+	if e := c.Query("error"); e != "" {
+		c.String(http.StatusBadRequest, "Google authorization was not granted: "+e)
+		return
+	}
+	code := c.Query("code")
+	if code == "" {
+		c.String(http.StatusBadRequest, "authorization code is missing")
+		return
+	}
+	form := url.Values{
+		"code":          {code},
+		"client_id":     {googleAdsClientID},
+		"client_secret": {googleAdsClientSecret},
+		"redirect_uri":  {googleAdsOAuthRedirectURI()},
+		"grant_type":    {"authorization_code"},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		c.String(http.StatusInternalServerError, "unable to exchange authorization code")
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := googleAdsHTTP.Do(req)
+	if err != nil {
+		c.String(http.StatusBadGateway, "Google token exchange failed")
+		return
+	}
+	defer resp.Body.Close()
+	var result struct {
+		RefreshToken string `json:"refresh_token"`
+		Error        string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 || result.RefreshToken == "" {
+		c.String(http.StatusBadGateway, "Google did not return a refresh token; revoke this app authorization and retry")
+		return
+	}
+	// This value is intentionally not persisted or logged. The authenticated
+	// administrator copies it once into the protected server environment.
+	c.Header("Cache-Control", "no-store")
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte("<!doctype html><title>Google authorized</title><h1>Google Data Manager authorized</h1><p>Copy this once into the protected server environment as <code>GOOGLE_ADS_REFRESH_TOKEN</code>, then close this page:</p><pre>"+html.EscapeString(result.RefreshToken)+"</pre><p>This value is not stored by the server.</p>"))
+}
+
+func secureBearerMatch(header, expected string) bool {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return false
+	}
+	return hmac.Equal([]byte(strings.TrimSpace(strings.TrimPrefix(header, prefix))), []byte(expected))
+}
+
+func makeGoogleAdsOAuthState(secret string) (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	payload := fmt.Sprintf("%d.%s", time.Now().Add(10*time.Minute).Unix(), base64.RawURLEncoding.EncodeToString(raw))
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return payload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+func validGoogleAdsOAuthState(state, secret string) bool {
+	parts := strings.Split(state, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	expires, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || time.Now().Unix() > expires {
+		return false
+	}
+	payload := parts[0] + "." + parts[1]
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	got, err := base64.RawURLEncoding.DecodeString(parts[2])
+	return err == nil && hmac.Equal(got, mac.Sum(nil))
+}

--- a/api/install/handlers.go
+++ b/api/install/handlers.go
@@ -35,10 +35,13 @@ func Register(h *server.Hertz, baseURL string) {
 	publicBaseURL = strings.TrimRight(baseURL, "/")
 	initXHSConfig() // read env here — .env is loaded by the time Register runs
 	initXAdsConfig()
+	initGoogleAdsConfig()
 	g := h.Group("/api/v1/install")
 	g.POST("/token", mintRef)
 	g.POST("/report", reportInstall)
 	g.POST("/copy", reportCopy)
+	g.GET("/google-ads/oauth/authorize", googleAdsOAuthAuthorize)
+	g.GET("/google-ads/oauth/callback", googleAdsOAuthCallback)
 	// Agent join entry: the /install page hands the user a command pointing here
 	// (not raw GitHub), so the instruction the agent reads is one we control and
 	// the fetch is the earliest post-click attribution signal.
@@ -52,10 +55,15 @@ type mintBody struct {
 	UTMContent  string `json:"utm_content"`
 	UTMTerm     string `json:"utm_term"`
 	Referrer    string `json:"referrer"`
-	// Platform click identifiers from the landing URL (paid traffic).
-	ClickID string `json:"click_id"` // Xiaohongshu 聚光
-	Twclid  string `json:"twclid"`   // X (Twitter) Ads
-	Lang    string `json:"lang"`     // entry language shown on the page ('en'/'zh')
+	// Platform click identifiers from the landing URL (paid traffic). Xingtu's
+	// non-app landing page supplies `clickid`; the frontend normalizes it to the
+	// dedicated xingtu_click_id field so it is never confused with Xiaohongshu's
+	// click_id even though both platforms use similar names in their URLs.
+	ClickID       string `json:"click_id"`        // Xiaohongshu 聚光
+	Twclid        string `json:"twclid"`          // X (Twitter) Ads
+	Gclid         string `json:"gclid"`           // Google Ads
+	XingtuClickID string `json:"xingtu_click_id"` // Xingtu landing URL clickid
+	Lang          string `json:"lang"`            // entry language shown on the page ('en'/'zh')
 	// InviteCode is the stable KOL/channel code from the landing URL's ?ic=
 	// (see pkg/invite). Malformed or unknown codes degrade to an unattributed
 	// mint rather than an error.
@@ -93,21 +101,24 @@ func mintRef(_ context.Context, c *app.RequestContext) {
 			return
 		}
 	}
+	xingtuClickID := normalizeXingtuClickID(body.XingtuClickID)
 	t := &Token{
-		Token:       NewToken(),
-		UTMSource:   trunc(body.UTMSource, 255),
-		UTMMedium:   trunc(body.UTMMedium, 255),
-		UTMCampaign: trunc(body.UTMCampaign, 255),
-		UTMContent:  trunc(body.UTMContent, 255),
-		UTMTerm:     trunc(body.UTMTerm, 255),
-		Channel:     deriveChannel(body.UTMSource, body.ClickID, body.Twclid),
-		Referrer:    trunc(body.Referrer, 2048),
-		ClickID:     trunc(body.ClickID, 128),
-		Twclid:      trunc(body.Twclid, 128),
-		Lang:        normalizeLang(body.Lang),
-		Status:      StatusPending,
-		ClientIP:    ip,
-		CreatedAt:   time.Now().UnixMilli(),
+		Token:         NewToken(),
+		UTMSource:     trunc(body.UTMSource, 255),
+		UTMMedium:     trunc(body.UTMMedium, 255),
+		UTMCampaign:   trunc(body.UTMCampaign, 255),
+		UTMContent:    trunc(body.UTMContent, 255),
+		UTMTerm:       trunc(body.UTMTerm, 255),
+		Channel:       deriveChannel(body.UTMSource, body.ClickID, body.Twclid, body.Gclid, xingtuClickID),
+		Referrer:      trunc(body.Referrer, 2048),
+		ClickID:       trunc(body.ClickID, 128),
+		Twclid:        trunc(body.Twclid, 128),
+		Gclid:         trunc(body.Gclid, 512),
+		XingtuClickID: xingtuClickID,
+		Lang:          normalizeLang(body.Lang),
+		Status:        StatusPending,
+		ClientIP:      ip,
+		CreatedAt:     time.Now().UnixMilli(),
 	}
 	if ic := lookupInviteCode(body.InviteCode); ic != nil {
 		t.InviteCode = ic.Code
@@ -122,7 +133,7 @@ func mintRef(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	event("install_ref_new", t.Token, "channel", t.Channel,
-		"paid", t.ClickID != "" || t.Twclid != "", "invite_code", t.InviteCode)
+		"paid", t.ClickID != "" || t.Twclid != "" || t.Gclid != "" || t.XingtuClickID != "", "invite_code", t.InviteCode)
 	// The token is now durably created; report this server-confirmed funnel
 	// stage to X when it came from an X ad click.
 	fireXAdsTokenCreatedCallback(t.Token)
@@ -174,7 +185,9 @@ func reportInstall(_ context.Context, c *app.RequestContext) {
 	// Deep conversion: install success fires 聚光 event_type 102 (exactly-once
 	// per ref; retried by later reports if a prior attempt failed).
 	fireXHSCallback(t.Token, EventInstall)
+	fireXingtuCallback(t.Token, "1") // registration: server-confirmed first report
 	fireXAdsInstallCallback(t.Token)
+	fireGoogleAdsInstallCallback(t.Token)
 	// Registration attribution: the CLI's login-time report carries agent_id,
 	// which pins the acquisition channel — and for an invite-coded ref, 被谁邀请
 	// — onto the agent (first-wins). Runs on every report, not just the
@@ -195,6 +208,7 @@ func reportInstall(_ context.Context, c *app.RequestContext) {
 			"referrer":     t.Referrer,
 			"click_id":     t.ClickID,
 			"twclid":       t.Twclid,
+			"gclid":        t.Gclid,
 			"lang":         t.Lang,
 			"report_count": t.ReportCount,
 			"created_at":   t.CreatedAt,
@@ -226,6 +240,7 @@ func reportCopy(_ context.Context, c *app.RequestContext) {
 	if t != nil {
 		event("install_copy", t.Token, "channel", t.Channel)
 		fireXHSCallback(t.Token, EventCopy) // shallow conversion (101)
+		fireXingtuCallback(t.Token, "0")    // activation: confirmed command copy
 		// Copy was confirmed by the server and is idempotent per ref.
 		fireXAdsCopyCommandCallback(t.Token)
 	}

--- a/api/install/models.go
+++ b/api/install/models.go
@@ -24,10 +24,19 @@ type Token struct {
 	FetchedAt int64 `gorm:"column:fetched_at;not null;default:0"`
 	// Platform click identifiers captured from the landing URL, kept so a later
 	// (cross-device) conversion can be reported back to the ad platform's
-	// optimizer keyed by the original click. ClickID = Xiaohongshu 聚光; Twclid =
-	// X (Twitter) Ads. Exactly one is set for paid traffic; both empty otherwise.
-	ClickID string `gorm:"column:click_id;not null;default:''"`
-	Twclid  string `gorm:"column:twclid;not null;default:''"`
+	// optimizer keyed by the original click. Each platform has a dedicated field;
+	// in particular XingtuClickID is the non-app landing URL's `clickid` and must
+	// not be confused with Xiaohongshu ClickID. It maps to the existing
+	// xingtu_callback column for schema compatibility; the column now stores the
+	// real landing clickid rather than the obsolete server-monitor macro.
+	ClickID                string `gorm:"column:click_id;not null;default:''"`
+	Twclid                 string `gorm:"column:twclid;not null;default:''"`
+	Gclid                  string `gorm:"column:gclid;not null;default:''"`
+	XingtuClickID          string `gorm:"column:xingtu_callback;type:text;not null;default:''"`
+	XingtuCBActivateCode   int    `gorm:"column:xingtu_cb_activate_code;not null;default:-1"`
+	XingtuCBActivateSentAt int64  `gorm:"column:xingtu_cb_activate_sent_at;not null;default:0"`
+	XingtuCBRegisterCode   int    `gorm:"column:xingtu_cb_register_code;not null;default:-1"`
+	XingtuCBRegisterSentAt int64  `gorm:"column:xingtu_cb_register_sent_at;not null;default:0"`
 	// Lang is the entry language the visitor saw on the landing page ('en'/'zh'),
 	// for per-language conversion breakdown.
 	Lang string `gorm:"column:lang;not null;default:''"`
@@ -55,6 +64,9 @@ type Token struct {
 	XCbCopySentAt  int64 `gorm:"column:x_cb_copy_sent_at;not null;default:0"`
 	XCb102Code     int   `gorm:"column:x_cb102_code;not null;default:-1"`
 	XCb102SentAt   int64 `gorm:"column:x_cb102_sent_at;not null;default:0"`
+	// Google Ads install-complete offline conversion callback state.
+	GoogleAdsCBInstallCode   int   `gorm:"column:google_ads_cb_install_code;not null;default:-1"`
+	GoogleAdsCBInstallSentAt int64 `gorm:"column:google_ads_cb_install_sent_at;not null;default:0"`
 	// CallbackSentAt / CallbackCode are the legacy single-event callback columns,
 	// superseded by the cb101/cb102 pair above; kept for backward compatibility.
 	CallbackSentAt int64 `gorm:"column:callback_sent_at;not null;default:0"`

--- a/api/install/store.go
+++ b/api/install/store.go
@@ -190,3 +190,59 @@ func ClaimXInstallCallback(db *gorm.DB, ref string) (won bool, t *Token, err err
 func SetXInstallCallbackCode(db *gorm.DB, ref string, code int) error {
 	return SetXAdsCallbackCode(db, ref, xAdsInstall, code)
 }
+
+const googleAdsCallbackLease = time.Minute
+
+func googleAdsCallbackClaimable(sentAt, now int64) bool {
+	return sentAt == 0 || sentAt < now-googleAdsCallbackLease.Milliseconds()
+}
+
+func ClaimGoogleAdsInstallCallback(db *gorm.DB, ref string) (won bool, t *Token, err error) {
+	now := time.Now().UnixMilli()
+	leaseCutoff := now - googleAdsCallbackLease.Milliseconds()
+	res := db.Model(&Token{}).Where("token = ? AND google_ads_cb_install_code <> 0 AND gclid <> '' AND (google_ads_cb_install_sent_at = 0 OR google_ads_cb_install_sent_at < ?)", ref, leaseCutoff).Update("google_ads_cb_install_sent_at", now)
+	if res.Error != nil {
+		return false, nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return false, nil, nil
+	}
+	var tok Token
+	if err := db.Where("token = ?", ref).First(&tok).Error; err != nil {
+		return false, nil, err
+	}
+	return true, &tok, nil
+}
+
+func SetGoogleAdsInstallCallbackCode(db *gorm.DB, ref string, code int) error {
+	return db.Model(&Token{}).Where("token = ?", ref).Update("google_ads_cb_install_code", code).Error
+}
+
+const xingtuCallbackLease = time.Minute
+
+func xingtuCallbackCols(eventType string) (codeCol, sentCol string) {
+	if eventType == "1" {
+		return "xingtu_cb_register_code", "xingtu_cb_register_sent_at"
+	}
+	return "xingtu_cb_activate_code", "xingtu_cb_activate_sent_at"
+}
+
+func claimXingtuCallback(db *gorm.DB, ref, eventType string) (bool, *Token, error) {
+	codeCol, sentCol := xingtuCallbackCols(eventType)
+	now := time.Now().UnixMilli()
+	cutoff := now - xingtuCallbackLease.Milliseconds()
+	res := db.Model(&Token{}).Where(fmt.Sprintf("token = ? AND %s <> 0 AND xingtu_callback <> '' AND (%s = 0 OR %s < ?)", codeCol, sentCol, sentCol), ref, cutoff).Update(sentCol, now)
+	if res.Error != nil || res.RowsAffected == 0 {
+		return false, nil, res.Error
+	}
+	var tok Token
+	if err := db.Where("token = ?", ref).First(&tok).Error; err != nil {
+		return false, nil, err
+	}
+	return true, &tok, nil
+}
+
+func setXingtuCallbackCode(db *gorm.DB, ref, eventType string, code int) error {
+	codeCol, _ := xingtuCallbackCols(eventType)
+	return db.Model(&Token{}).Where("token = ?", ref).Update(codeCol, code).Error
+}

--- a/api/install/token.go
+++ b/api/install/token.go
@@ -100,18 +100,22 @@ func normalizeChannel(utmSource string) string {
 }
 
 // deriveChannel resolves the channel bucket for a mint. An explicit utm_source
-// wins; but 聚光 auto-appends only click_id (not utm_source) to the landing URL,
-// so when the source is missing/unknown a platform click id is decisive —
-// click_id ⇒ xiaohongshu, twclid ⇒ twitter — rather than logging the paid click
-// as "unknown".
-func deriveChannel(utmSource, clickID, twclid string) string {
+// wins. Otherwise each platform's dedicated click identifier selects its own
+// bucket; Xingtu clickid must not fall through to Xiaohongshu attribution.
+func deriveChannel(utmSource, clickID, twclid, gclid, xingtuClickID string) string {
 	c := normalizeChannel(utmSource)
 	if c == "unknown" {
+		if xingtuClickID != "" {
+			return "xingtu"
+		}
 		if clickID != "" {
 			return "xiaohongshu"
 		}
 		if twclid != "" {
 			return "twitter"
+		}
+		if gclid != "" {
+			return "google"
 		}
 	}
 	return c

--- a/api/install/token_test.go
+++ b/api/install/token_test.go
@@ -2,27 +2,26 @@ package install
 
 import "testing"
 
-// TestDeriveChannel: an explicit utm_source wins; when it's missing/unknown a
-// platform click id is decisive (click_id ⇒ xiaohongshu, twclid ⇒ twitter), so
-// 聚光 traffic that only carries a click_id is not logged as "unknown".
+// TestDeriveChannel verifies explicit UTM attribution takes precedence; when
+// absent, a platform click identifier determines the paid channel.
 func TestDeriveChannel(t *testing.T) {
 	cases := []struct {
-		name              string
-		src, click, twcid string
-		want              string
+		name                              string
+		src, click, twclid, gclid, xingtu string
+		want                              string
 	}{
-		{"explicit xhs", "xiaohongshu", "cid", "", "xiaohongshu"},
-		{"alias xhs", "xhs", "", "", "xiaohongshu"},
-		{"alias redbook", "redbook", "", "", "xiaohongshu"},
-		{"alias 小红书", "小红书", "", "", "xiaohongshu"},
-		{"clickid infers xhs when source empty", "", "cid123", "", "xiaohongshu"},
-		{"twclid infers twitter when source empty", "", "", "tw123", "twitter"},
-		{"explicit source beats click inference", "weibo", "cid", "", "weibo"},
-		{"no signal is unknown", "", "", "", "unknown"},
+		{"explicit xhs", "xiaohongshu", "cid", "", "", "", "xiaohongshu"},
+		{"alias xhs", "xhs", "", "", "", "", "xiaohongshu"},
+		{"xingtu clickid infers xingtu", "", "", "", "", "xt123", "xingtu"},
+		{"click id infers xhs", "", "cid123", "", "", "", "xiaohongshu"},
+		{"twclid infers twitter", "", "", "tw123", "", "", "twitter"},
+		{"gclid infers google", "", "", "", "gcl123", "", "google"},
+		{"explicit source wins", "weibo", "cid", "", "gcl123", "xt123", "weibo"},
+		{"no signal is unknown", "", "", "", "", "", "unknown"},
 	}
 	for _, c := range cases {
-		if got := deriveChannel(c.src, c.click, c.twcid); got != c.want {
-			t.Errorf("%s: deriveChannel(%q,%q,%q)=%q want %q", c.name, c.src, c.click, c.twcid, got, c.want)
+		if got := deriveChannel(c.src, c.click, c.twclid, c.gclid, c.xingtu); got != c.want {
+			t.Errorf("%s: deriveChannel(%q,%q,%q,%q,%q)=%q want %q", c.name, c.src, c.click, c.twclid, c.gclid, c.xingtu, got, c.want)
 		}
 	}
 }

--- a/api/install/xhs_callback_test.go
+++ b/api/install/xhs_callback_test.go
@@ -138,3 +138,16 @@ func TestXInstallCallbackClaimable(t *testing.T) {
 		})
 	}
 }
+
+func TestGoogleAdsCallbackClaimable(t *testing.T) {
+	now := int64(10 * 60 * 1000)
+	if !googleAdsCallbackClaimable(0, now) {
+		t.Fatal("never claimed must be claimable")
+	}
+	if googleAdsCallbackClaimable(now-googleAdsCallbackLease.Milliseconds(), now) {
+		t.Fatal("lease boundary must not be claimable")
+	}
+	if !googleAdsCallbackClaimable(now-googleAdsCallbackLease.Milliseconds()-1, now) {
+		t.Fatal("expired lease must be claimable")
+	}
+}

--- a/api/install/xingtu.go
+++ b/api/install/xingtu.go
@@ -1,0 +1,85 @@
+package install
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/logger"
+)
+
+const (
+	xingtuCallbackURL = "https://ad.oceanengine.com/track/activate/"
+	// Xingtu clickid is opaque. Keep a generous but bounded size and reject
+	// control characters before persisting it or placing it in the callback URL.
+	xingtuClickIDMaxLength = 2048
+)
+
+func normalizeXingtuClickID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > xingtuClickIDMaxLength {
+		return ""
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return ""
+		}
+	}
+	return value
+}
+
+func fireXingtuCallback(ref, eventType string) {
+	go func() {
+		won, tok, err := claimXingtuCallback(db.DB, ref, eventType)
+		if err != nil {
+			logger.Default().Error("xingtu callback claim failed", "ref", ref, "event_type", eventType, "err", err)
+			return
+		}
+		if !won || tok.XingtuClickID == "" {
+			return
+		}
+		code, err := reportXingtuConversion(tok.XingtuClickID, eventType)
+		if err != nil {
+			logger.Default().Error("xingtu callback failed", "ref", ref, "event_type", eventType, "code", code, "err", err)
+		}
+		if err := setXingtuCallbackCode(db.DB, ref, eventType, code); err != nil {
+			logger.Default().Error("xingtu callback state update failed", "ref", ref, "event_type", eventType, "err", err)
+		}
+		if code == 0 {
+			event("install_callback_xingtu", ref, "channel", tok.Channel, "event_type", eventType)
+		}
+	}()
+}
+
+func reportXingtuConversion(clickID, eventType string) (int, error) {
+	q := url.Values{"callback": {clickID}, "event_type": {eventType}}
+	req, err := http.NewRequest(http.MethodGet, xingtuCallbackURL+"?"+q.Encode(), nil)
+	if err != nil {
+		return -2, err
+	}
+	resp, err := xingtuHTTP.Do(req)
+	if err != nil {
+		return -2, err
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return -2, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, fmt.Errorf("xingtu HTTP %d: %s", resp.StatusCode, body.Msg)
+	}
+	if body.Code != 0 {
+		return body.Code, fmt.Errorf("xingtu code=%d: %s", body.Code, body.Msg)
+	}
+	return 0, nil
+}
+
+var xingtuHTTP = &http.Client{Timeout: 8 * time.Second}

--- a/api/install/xingtu_test.go
+++ b/api/install/xingtu_test.go
@@ -1,0 +1,64 @@
+package install
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeXingtuClickID(t *testing.T) {
+	if got := normalizeXingtuClickID("  xt-click-123  "); got != "xt-click-123" {
+		t.Fatalf("trimmed clickid = %q", got)
+	}
+	if got := normalizeXingtuClickID("bad\nclick"); got != "" {
+		t.Fatalf("control-character clickid must be rejected, got %q", got)
+	}
+	if got := normalizeXingtuClickID(strings.Repeat("x", xingtuClickIDMaxLength+1)); got != "" {
+		t.Fatal("oversized clickid must be rejected")
+	}
+}
+
+func TestReportXingtuConversionUsesLandingClickID(t *testing.T) {
+	var callback, eventType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callback = r.URL.Query().Get("callback")
+		eventType = r.URL.Query().Get("event_type")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "msg": "success"})
+	}))
+	defer srv.Close()
+
+	oldClient := xingtuHTTP
+	xingtuHTTP = srv.Client()
+	defer func() { xingtuHTTP = oldClient }()
+
+	// Redirect callback requests to the mock while preserving the production
+	// function's query construction.
+	xingtuHTTP.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = "http"
+		req.URL.Host = strings.TrimPrefix(srv.URL, "http://")
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	code, err := reportXingtuConversion("real-landing-clickid", "0")
+	if err != nil || code != 0 {
+		t.Fatalf("reportXingtuConversion code=%d err=%v", code, err)
+	}
+	if callback != "real-landing-clickid" || eventType != "0" {
+		t.Fatalf("callback=%q event_type=%q", callback, eventType)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestXingtuCallbackCols(t *testing.T) {
+	if code, sent := xingtuCallbackCols("0"); code != "xingtu_cb_activate_code" || sent != "xingtu_cb_activate_sent_at" {
+		t.Fatalf("activation columns = %s, %s", code, sent)
+	}
+	if code, sent := xingtuCallbackCols("1"); code != "xingtu_cb_register_code" || sent != "xingtu_cb_register_sent_at" {
+		t.Fatalf("registration columns = %s, %s", code, sent)
+	}
+}


### PR DESCRIPTION
## Summary
- ship Google Ads gclid capture, OAuth bootstrap, and Data Manager install conversion callbacks
- ship Xingtu landing clickid attribution and activation/registration callbacks
- connect the existing 000050 and 000051 production migrations to the API models and handlers
- preserve injected database handles in callback DAL operations for transaction/test correctness

## Verification
- go test ./api/install
- go test ./api/...
- go vet ./api/install
- git diff --check

## Migrations
- 000050_install_google_ads_callback.sql is already tracked on main
- 000051_xingtu_callbacks.sql is already tracked on main