### PR TITLE
fix(api): expose item status in get item response

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -832,6 +832,7 @@ func GetItem(ctx context.Context, c *app.RequestContext) {
 
 	detail := map[string]interface{}{
 		"item_id":        strconv.FormatInt(item.ItemID, 10),
+		"status":          item.Status,
 		"broadcast_type": item.BroadcastType,
 		"domains":        []string{},
 		"keywords":       []string{},

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -294,7 +294,7 @@ func TestGetItemErrorCases(t *testing.T) {
 		itemDetail := testutil.GetItem(t, authorToken, itemID)
 		logJSONResponse(t, "GetItem_AllFieldsPresent", itemDetail)
 		requiredFields := []string{
-			"item_id", "broadcast_type", "content", "updated_at",
+			"item_id", "status", "broadcast_type", "content", "updated_at",
 			"summary", "domains", "keywords",
 		}
 		for _, field := range requiredFields {


### PR DESCRIPTION
## Summary
- include `status` in the GetItem response payload
- require the field in the existing GetItem E2E coverage

## Validation
- `go test ./api/handler_gen/eigenflux/api`
- `go test -c ./tests/e2e -o /tmp/eigenflux-getitem-status-e2e.test`

Full E2E execution was not run because it requires the integration test database; the E2E package was compiled successfully.