### PR TITLE
chore(deploy): enforce main-only production releases

### DIFF
--- a/scripts/cloud/DEPLOY_MAIN.md
+++ b/scripts/cloud/DEPLOY_MAIN.md
@@ -1,0 +1,62 @@
+# Main-only production deployment
+
+The root-managed deployer makes `/data/git/eigenflux` a deployment checkout,
+not a development workspace. It accepts no user-supplied branch, commit, or
+service arguments.
+
+## Production prerequisites
+
+- `/data/git/eigenflux` and its `.git` directory are owned by `root`.
+- The worktree is on `main` and is clean.
+- The checked-out commit equals the locally fetched `origin/main` when the
+  deployer is first installed.
+- `git`, `curl`, `jq`, `tar`, `install`, `flock`, and `systemd-run` are installed.
+- GitHub branch protection requires changes to `main` to arrive through pull
+  requests. The deployer independently verifies that the target commit is
+  associated with a merged pull request whose base is `main`.
+
+Install the version-controlled script after its pull request has merged and
+the production checkout has been fast-forwarded to that main commit:
+
+```bash
+sudo /data/git/eigenflux/scripts/cloud/install_main_deployer.sh
+```
+
+Future deployments use the no-argument command:
+
+```bash
+sudo /usr/local/sbin/eigenflux-deploy-main
+```
+
+The command re-executes itself as a transient systemd service. List and inspect
+deployment logs with:
+
+```bash
+journalctl --list-boots
+journalctl -t eigenflux-deploy-main
+journalctl -u 'eigenflux-deploy-*'
+```
+
+## Failure behavior
+
+- Dirty worktree, non-`main` branch, divergent/ahead production commit, missing
+  merged PR, or a rollback target: stop before build or mutation.
+- Build failure: stop before moving production `HEAD`.
+- If `origin/main` advances while the isolated build is running, stop before
+  moving production `HEAD`; rerun against the new latest commit.
+- Migration failure: keep the new `main` checkout, but do not install new
+  artifacts or restart services. Fix through another PR and rerun the deployer.
+- Restart failure: stop before the aggregate health check; systemd reports the
+  exact failed service.
+- Health-check failure: return a non-zero deployment status and retain all
+  evidence in journald.
+
+The deployer never runs `git reset`, `git clean`, `git stash`, migration down,
+or an automatic code rollback. A rollback is a new revert pull request merged
+into `main`, followed by another normal deployment.
+
+Run the isolated success and failure drills locally with:
+
+```bash
+bash scripts/cloud/test_deploy_main.sh
+```

--- a/scripts/cloud/deploy_main.sh
+++ b/scripts/cloud/deploy_main.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Production entry point for EigenFlux backend deployments.
+#
+# Public invocation (no arguments):
+#   sudo /usr/local/sbin/eigenflux-deploy-main
+#
+# The public invocation re-executes itself as a transient systemd service so
+# every line is retained in journald. The internal argument is accepted only
+# from a systemd service invocation.
+
+readonly PROJECT_ROOT="/data/git/eigenflux"
+readonly REMOTE_URL="https://github.com/phronesis-io/eigenflux.git"
+readonly REMOTE_MAIN_REF="refs/remotes/origin/main"
+readonly GITHUB_API_URL="https://api.github.com"
+readonly GITHUB_REPOSITORY="phronesis-io/eigenflux"
+readonly INSTALL_PATH="/usr/local/sbin/eigenflux-deploy-main"
+readonly LOCK_PATH="/run/lock/eigenflux-deploy-main.lock"
+readonly REQUIRED_REPO_OWNER="root"
+readonly REQUIRED_REPO_GROUP="root"
+readonly ALLOW_NON_ROOT_INTERNAL=0
+readonly INTERNAL_ARGUMENT="--systemd-internal"
+readonly BUILD_SERVICES=(profile item sort feed pm auth notification trade api ws pipeline cron replay)
+DEPLOY_STAGE_DIR=""
+
+log() {
+  printf '[eigenflux-deploy] %s\n' "$*"
+}
+
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+file_owner() {
+  stat -c %U "$1" 2>/dev/null || stat -f %Su "$1"
+}
+
+git_safe() {
+  git -c core.hooksPath=/dev/null "$@"
+}
+
+require_clean_worktree() {
+  local phase="$1"
+  local dirty
+
+  dirty="$(git_safe -C "${PROJECT_ROOT}" status --porcelain=v1 --untracked-files=all)"
+  if [[ -n "${dirty}" ]]; then
+    log "worktree is dirty during ${phase}:" >&2
+    printf '%s\n' "${dirty}" >&2
+    die "refusing to deploy a dirty worktree"
+  fi
+}
+
+require_managed_repository() {
+  local mismatch
+
+  [[ "$(file_owner "${PROJECT_ROOT}")" == "${REQUIRED_REPO_OWNER}" ]] ||
+    die "project root must be owned by ${REQUIRED_REPO_OWNER}"
+  [[ "$(file_owner "${PROJECT_ROOT}/.git")" == "${REQUIRED_REPO_OWNER}" ]] ||
+    die ".git must be owned by ${REQUIRED_REPO_OWNER}"
+
+  mismatch="$(find "${PROJECT_ROOT}" -xdev \
+    \( ! -user "${REQUIRED_REPO_OWNER}" -o ! -group "${REQUIRED_REPO_GROUP}" \) \
+    -print -quit)"
+  [[ -z "${mismatch}" ]] ||
+    die "repository contains a path not managed by ${REQUIRED_REPO_OWNER}:${REQUIRED_REPO_GROUP}: ${mismatch}"
+}
+
+verify_merged_pull_request() {
+  local target="$1"
+  local response_file="$2"
+  local url
+
+  url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits/${target}/pulls"
+  curl --fail --silent --show-error \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    "${url}" >"${response_file}"
+
+  jq --exit-status \
+    --arg target "${target}" \
+    'any(.[]; .merged_at != null and .base.ref == "main" and
+      ((.merge_commit_sha // "") == $target or (.head.sha // "") == $target))' \
+    "${response_file}" >/dev/null ||
+    die "target ${target} is not associated with a merged pull request into main"
+}
+
+run_deployment() {
+  local started_at run_id stage_dir pr_response target latest_target before after service
+
+  export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+  umask 022
+
+  require_command git
+  require_command curl
+  require_command jq
+  require_command tar
+  require_command install
+  require_command find
+  require_command flock
+
+  [[ "${EUID}" -eq 0 || "${ALLOW_NON_ROOT_INTERNAL}" -eq 1 ]] ||
+    die "deployment body must run as root"
+  [[ -d "${PROJECT_ROOT}/.git" ]] || die "not a Git worktree: ${PROJECT_ROOT}"
+  require_managed_repository
+
+  exec 9>"${LOCK_PATH}"
+  flock --nonblock 9 || die "another EigenFlux deployment is already running"
+
+  started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  stage_dir="$(mktemp -d "/var/tmp/eigenflux-deploy-${run_id}.XXXXXX")"
+  DEPLOY_STAGE_DIR="${stage_dir}"
+  pr_response="${stage_dir}/pulls.json"
+
+  cleanup() {
+    local exit_code=$?
+    trap - EXIT
+    [[ -z "${DEPLOY_STAGE_DIR}" ]] || rm -rf -- "${DEPLOY_STAGE_DIR}"
+    if [[ "${exit_code}" -eq 0 ]]; then
+      log "completed successfully"
+    else
+      log "failed with exit code ${exit_code}"
+    fi
+    exit "${exit_code}"
+  }
+  trap cleanup EXIT
+  trap 'die "command failed at line ${LINENO}: ${BASH_COMMAND}"' ERR
+
+  log "run_id=${run_id} operator=${SUDO_USER:-${USER:-unknown}} started_at=${started_at}"
+  log "project_root=${PROJECT_ROOT}"
+
+  require_clean_worktree "preflight"
+
+  [[ "$(git_safe -C "${PROJECT_ROOT}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)" == "main" ]] ||
+    die "production worktree must be on branch main"
+
+  before="$(git_safe -C "${PROJECT_ROOT}" rev-parse HEAD)"
+  log "before_sha=${before}"
+  log "fetching main from fixed HTTPS remote"
+  git_safe -C "${PROJECT_ROOT}" fetch --no-tags "${REMOTE_URL}" \
+    "+refs/heads/main:${REMOTE_MAIN_REF}"
+  target="$(git_safe -C "${PROJECT_ROOT}" rev-parse "${REMOTE_MAIN_REF}^{commit}")"
+  log "target_sha=${target}"
+
+  git_safe -C "${PROJECT_ROOT}" merge-base --is-ancestor "${before}" "${target}" ||
+    die "target is behind or divergent from the production HEAD; rollback and branch deployments are forbidden"
+
+  verify_merged_pull_request "${target}" "${pr_response}"
+  log "merged pull request verification passed"
+
+  log "exporting target into isolated build directory"
+  git_safe -C "${PROJECT_ROOT}" archive --format=tar "${target}" |
+    tar -xf - -C "${stage_dir}"
+
+  if ! cmp -s \
+    "${stage_dir}/skills/ef-broadcast/references/contract.md" \
+    "${stage_dir}/static/feed_contract.md"; then
+    die "static/feed_contract.md is not synchronized in the target commit"
+  fi
+
+  log "building all backend services from target_sha=${target}"
+  bash "${stage_dir}/scripts/common/build.sh" "${BUILD_SERVICES[@]}"
+  for service in "${BUILD_SERVICES[@]}"; do
+    [[ -x "${stage_dir}/build/${service}" ]] || die "missing build artifact: ${service}"
+  done
+
+  require_managed_repository
+  require_clean_worktree "before fast-forward"
+  log "confirming origin/main did not advance during the build"
+  git_safe -C "${PROJECT_ROOT}" fetch --no-tags "${REMOTE_URL}" \
+    "+refs/heads/main:${REMOTE_MAIN_REF}"
+  latest_target="$(git_safe -C "${PROJECT_ROOT}" rev-parse "${REMOTE_MAIN_REF}^{commit}")"
+  [[ "${latest_target}" == "${target}" ]] ||
+    die "origin/main advanced during the build; rerun to deploy the new latest commit"
+
+  log "fast-forwarding production main"
+  git_safe -C "${PROJECT_ROOT}" merge --ff-only "${target}"
+  [[ "$(git_safe -C "${PROJECT_ROOT}" rev-parse HEAD)" == "${target}" ]] ||
+    die "production HEAD does not equal target after fast-forward"
+  require_clean_worktree "after fast-forward"
+
+  log "running database migrations"
+  bash "${PROJECT_ROOT}/scripts/common/migrate_up.sh"
+  require_clean_worktree "after migrations"
+
+  log "installing verified build artifacts"
+  mkdir -p "${PROJECT_ROOT}/build"
+  for service in "${BUILD_SERVICES[@]}"; do
+    install -m 0755 "${stage_dir}/build/${service}" "${PROJECT_ROOT}/build/${service}"
+  done
+
+  log "restarting all backend services"
+  bash "${PROJECT_ROOT}/scripts/cloud/restart_all_services.sh"
+
+  log "running service health checks"
+  bash "${PROJECT_ROOT}/scripts/cloud/check_services.sh"
+
+  after="$(git_safe -C "${PROJECT_ROOT}" rev-parse HEAD)"
+  [[ "${after}" == "${target}" ]] || die "deployed SHA changed during deployment"
+  require_clean_worktree "final verification"
+  log "deployed_sha=${after}"
+}
+
+main() {
+  local unit
+
+  if [[ "${INVOCATION_ID:-}" != "" ]]; then
+    [[ "$#" -eq 1 && "$1" == "${INTERNAL_ARGUMENT}" ]] ||
+      die "invalid internal invocation"
+    run_deployment
+    return
+  fi
+
+  [[ "$#" -eq 0 ]] || die "this command accepts no arguments"
+  [[ "${EUID}" -eq 0 ]] || die "run with sudo: sudo ${INSTALL_PATH}"
+  [[ "$(readlink -f "$0")" == "${INSTALL_PATH}" ]] ||
+    die "run the root-managed installed copy: sudo ${INSTALL_PATH}"
+  require_command systemd-run
+
+  unit="eigenflux-deploy-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  exec systemd-run \
+    --unit="${unit}" \
+    --description="EigenFlux origin/main deployment" \
+    --collect \
+    --wait \
+    --pipe \
+    --service-type=exec \
+    "${INSTALL_PATH}" "${INTERNAL_ARGUMENT}"
+}
+
+main "$@"

--- a/scripts/cloud/install_main_deployer.sh
+++ b/scripts/cloud/install_main_deployer.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly INSTALL_PATH="/usr/local/sbin/eigenflux-deploy-main"
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+SOURCE_PATH="${PROJECT_ROOT}/scripts/cloud/deploy_main.sh"
+
+die() {
+  printf 'install_main_deployer: %s\n' "$*" >&2
+  exit 1
+}
+
+file_owner() {
+  stat -c %U "$1" 2>/dev/null || stat -f %Su "$1"
+}
+
+[[ "${EUID}" -eq 0 ]] || die "run this installer as root"
+[[ "$#" -eq 0 ]] || die "this installer accepts no arguments"
+[[ "$(file_owner "${PROJECT_ROOT}")" == "root" ]] || die "project root must be owned by root"
+[[ "$(file_owner "${PROJECT_ROOT}/.git")" == "root" ]] || die ".git must be owned by root"
+ownership_mismatch="$(find "${PROJECT_ROOT}" -xdev \( ! -user root -o ! -group root \) -print -quit)"
+[[ -z "${ownership_mismatch}" ]] ||
+  die "repository contains a path not managed by root:root: ${ownership_mismatch}"
+[[ "$(git -c core.hooksPath=/dev/null -C "${PROJECT_ROOT}" symbolic-ref --quiet --short HEAD 2>/dev/null || true)" == "main" ]] ||
+  die "installer must run from the production main worktree"
+[[ -z "$(git -c core.hooksPath=/dev/null -C "${PROJECT_ROOT}" status --porcelain=v1 --untracked-files=all)" ]] ||
+  die "production worktree is dirty"
+[[ "$(git -c core.hooksPath=/dev/null -C "${PROJECT_ROOT}" rev-parse HEAD)" == \
+   "$(git -c core.hooksPath=/dev/null -C "${PROJECT_ROOT}" rev-parse refs/remotes/origin/main)" ]] ||
+  die "production HEAD must equal origin/main before installation"
+
+bash -n "${SOURCE_PATH}"
+install -o root -g root -m 0755 "${SOURCE_PATH}" "${INSTALL_PATH}.new"
+mv -f "${INSTALL_PATH}.new" "${INSTALL_PATH}"
+
+printf 'Installed %s\n' "${INSTALL_PATH}"
+printf 'Run deployments with: sudo %s\n' "${INSTALL_PATH}"

--- a/scripts/cloud/test_deploy_main.sh
+++ b/scripts/cloud/test_deploy_main.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
+SOURCE_SCRIPT="${SCRIPT_DIR}/deploy_main.sh"
+TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/eigenflux-deploy-test.XXXXXX")"
+
+cleanup() {
+  rm -rf -- "${TEMP_ROOT}"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1" expected="$2"
+  grep -Fq -- "${expected}" "${file}" || {
+    sed -n '1,220p' "${file}" >&2
+    fail "expected output to contain: ${expected}"
+  }
+}
+
+create_fixture() {
+  local name="$1"
+  local root="${TEMP_ROOT}/${name}"
+  local seed="${root}/seed"
+
+  mkdir -p "${root}/api/repos/test/eigenflux/commits" "${root}/bin"
+  cat >"${root}/bin/flock" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "${root}/bin/flock"
+  git init --bare -q "${root}/remote.git"
+  git init -q -b main "${seed}"
+  git -C "${seed}" config user.name "Deploy Test"
+  git -C "${seed}" config user.email "deploy-test@example.invalid"
+  mkdir -p "${seed}/scripts/common" "${seed}/scripts/cloud" \
+    "${seed}/skills/ef-broadcast/references" "${seed}/static"
+  printf 'contract\n' >"${seed}/skills/ef-broadcast/references/contract.md"
+  printf 'contract\n' >"${seed}/static/feed_contract.md"
+  printf 'build/\n' >"${seed}/.gitignore"
+
+  cat >"${seed}/scripts/common/build.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'build\n' >>"${TRACE_FILE}"
+[[ "${FAIL_STAGE:-}" != "build" ]] || exit 41
+ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+mkdir -p "${ROOT}/build"
+for service in "$@"; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"${ROOT}/build/${service}"
+  chmod +x "${ROOT}/build/${service}"
+done
+if [[ -n "${ADVANCE_REMOTE_URL:-}" ]]; then
+  ADVANCE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/advance-main.XXXXXX")"
+  git -c core.hooksPath=/dev/null clone -q "${ADVANCE_REMOTE_URL}" "${ADVANCE_DIR}/repo"
+  git -C "${ADVANCE_DIR}/repo" config user.name "Deploy Test"
+  git -C "${ADVANCE_DIR}/repo" config user.email "deploy-test@example.invalid"
+  printf 'advanced\n' >"${ADVANCE_DIR}/repo/advanced.txt"
+  git -C "${ADVANCE_DIR}/repo" add advanced.txt
+  git -c core.hooksPath=/dev/null -C "${ADVANCE_DIR}/repo" commit -qm "advance main"
+  git -c core.hooksPath=/dev/null -C "${ADVANCE_DIR}/repo" push -q origin main
+  rm -rf -- "${ADVANCE_DIR}"
+fi
+EOF
+  cat >"${seed}/scripts/common/migrate_up.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'migrate\n' >>"${TRACE_FILE}"
+[[ "${FAIL_STAGE:-}" != "migrate" ]] || exit 42
+if [[ "${DIRTY_STAGE:-}" == "migrate" ]]; then
+  ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+  printf 'unexpected\n' >"${ROOT}/unexpected-migration-output.txt"
+fi
+EOF
+  cat >"${seed}/scripts/cloud/restart_all_services.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'restart\n' >>"${TRACE_FILE}"
+[[ "${FAIL_STAGE:-}" != "restart" ]] || exit 43
+EOF
+  cat >"${seed}/scripts/cloud/check_services.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'health\n' >>"${TRACE_FILE}"
+[[ "${FAIL_STAGE:-}" != "health" ]] || exit 44
+EOF
+  chmod +x "${seed}/scripts/common/"*.sh "${seed}/scripts/cloud/"*.sh
+  git -C "${seed}" add .
+  git -C "${seed}" commit -qm "base"
+  git -C "${seed}" remote add origin "${root}/remote.git"
+  git -C "${seed}" push -q -u origin main
+  git clone -q "${root}/remote.git" "${root}/prod"
+  git -C "${root}/prod" config user.name "Deploy Test"
+  git -C "${root}/prod" config user.email "deploy-test@example.invalid"
+
+  printf 'target\n' >"${seed}/release.txt"
+  git -C "${seed}" add release.txt
+  git -C "${seed}" commit -qm "release"
+  git -C "${seed}" push -q origin main
+
+  FIXTURE_ROOT="${root}"
+  FIXTURE_PROD="${root}/prod"
+  FIXTURE_TARGET="$(git -C "${seed}" rev-parse HEAD)"
+  FIXTURE_BASE="$(git -C "${root}/prod" rev-parse HEAD)"
+  FIXTURE_TRACE="${root}/trace.log"
+  FIXTURE_OUTPUT="${root}/output.log"
+  : >"${FIXTURE_TRACE}"
+  write_pr_response "${FIXTURE_TARGET}" true
+  make_test_script
+}
+
+write_pr_response() {
+  local target="$1" merged="$2"
+  local path="${FIXTURE_ROOT}/api/repos/test/eigenflux/commits/${target}"
+  mkdir -p "${path}"
+  if [[ "${merged}" == true ]]; then
+    printf '[{"merged_at":"2026-08-06T00:00:00Z","base":{"ref":"main"},"merge_commit_sha":"%s","head":{"sha":"unused"}}]\n' \
+      "${target}" >"${path}/pulls"
+  else
+    printf '[]\n' >"${path}/pulls"
+  fi
+}
+
+make_test_script() {
+  cp "${SOURCE_SCRIPT}" "${FIXTURE_ROOT}/deploy-test.sh"
+  sed -i.bak \
+    -e "s|readonly PROJECT_ROOT=\"/data/git/eigenflux\"|readonly PROJECT_ROOT=\"${FIXTURE_PROD}\"|" \
+    -e "s|readonly REMOTE_URL=\"https://github.com/phronesis-io/eigenflux.git\"|readonly REMOTE_URL=\"${FIXTURE_ROOT}/remote.git\"|" \
+    -e "s|readonly GITHUB_API_URL=\"https://api.github.com\"|readonly GITHUB_API_URL=\"file://${FIXTURE_ROOT}/api\"|" \
+    -e 's|readonly GITHUB_REPOSITORY="phronesis-io/eigenflux"|readonly GITHUB_REPOSITORY="test/eigenflux"|' \
+    -e "s|readonly LOCK_PATH=\"/run/lock/eigenflux-deploy-main.lock\"|readonly LOCK_PATH=\"${FIXTURE_ROOT}/deploy.lock\"|" \
+    -e "s|readonly REQUIRED_REPO_OWNER=\"root\"|readonly REQUIRED_REPO_OWNER=\"$(id -un)\"|" \
+    -e "s|readonly REQUIRED_REPO_GROUP=\"root\"|readonly REQUIRED_REPO_GROUP=\"$(id -gn)\"|" \
+    -e 's|readonly ALLOW_NON_ROOT_INTERNAL=0|readonly ALLOW_NON_ROOT_INTERNAL=1|' \
+    -e "s|export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'|export PATH='${FIXTURE_ROOT}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'|" \
+    -e "s|/var/tmp/eigenflux-deploy-|${FIXTURE_ROOT}/stage-|" \
+    "${FIXTURE_ROOT}/deploy-test.sh"
+  rm -f "${FIXTURE_ROOT}/deploy-test.sh.bak"
+  chmod +x "${FIXTURE_ROOT}/deploy-test.sh"
+}
+
+run_deploy() {
+  local expected_status="$1"
+  shift
+  local status=0
+
+  INVOCATION_ID=test TRACE_FILE="${FIXTURE_TRACE}" "$@" \
+    "${FIXTURE_ROOT}/deploy-test.sh" --systemd-internal \
+    >"${FIXTURE_OUTPUT}" 2>&1 || status=$?
+  if [[ "${expected_status}" == success && "${status}" -ne 0 ]]; then
+    sed -n '1,240p' "${FIXTURE_OUTPUT}" >&2
+    fail "deployment unexpectedly failed with ${status}"
+  fi
+  if [[ "${expected_status}" == failure && "${status}" -eq 0 ]]; then
+    fail "deployment unexpectedly succeeded"
+  fi
+}
+
+test_success() {
+  create_fixture success
+  run_deploy success env
+  [[ "$(git -C "${FIXTURE_PROD}" rev-parse HEAD)" == "${FIXTURE_TARGET}" ]] || fail "target was not deployed"
+  [[ "$(cat "${FIXTURE_TRACE}")" == $'build\nmigrate\nrestart\nhealth' ]] || fail "unexpected success trace"
+  [[ -z "$(git -C "${FIXTURE_PROD}" status --porcelain=v1 --untracked-files=all)" ]] || fail "worktree dirty after success"
+  printf 'PASS: success path\n'
+}
+
+test_dirty_tracked() {
+  create_fixture dirty-tracked
+  printf 'dirty\n' >>"${FIXTURE_PROD}/scripts/common/migrate_up.sh"
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "refusing to deploy a dirty worktree"
+  [[ ! -s "${FIXTURE_TRACE}" ]] || fail "dirty worktree reached build"
+  printf 'PASS: dirty tracked file rejected\n'
+}
+
+test_dirty_untracked() {
+  create_fixture dirty-untracked
+  printf 'dirty\n' >"${FIXTURE_PROD}/unexpected.txt"
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "refusing to deploy a dirty worktree"
+  printf 'PASS: untracked file rejected\n'
+}
+
+test_wrong_branch() {
+  create_fixture wrong-branch
+  git -C "${FIXTURE_PROD}" switch -q -c feature
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "production worktree must be on branch main"
+  printf 'PASS: non-main branch rejected\n'
+}
+
+test_divergent_head() {
+  create_fixture divergent
+  printf 'local\n' >"${FIXTURE_PROD}/local.txt"
+  git -C "${FIXTURE_PROD}" add local.txt
+  git -C "${FIXTURE_PROD}" commit -qm "local commit"
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "behind or divergent"
+  [[ ! -s "${FIXTURE_TRACE}" ]] || fail "divergent HEAD reached build"
+  printf 'PASS: divergent/ahead HEAD rejected\n'
+}
+
+test_missing_pr() {
+  create_fixture missing-pr
+  write_pr_response "${FIXTURE_TARGET}" false
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "not associated with a merged pull request"
+  [[ ! -s "${FIXTURE_TRACE}" ]] || fail "missing PR reached build"
+  printf 'PASS: target without merged PR rejected\n'
+}
+
+test_unmanaged_repository() {
+  create_fixture unmanaged-repository
+  sed -i.bak \
+    "s|readonly REQUIRED_REPO_OWNER=\"$(id -un)\"|readonly REQUIRED_REPO_OWNER=\"owner-that-does-not-exist\"|" \
+    "${FIXTURE_ROOT}/deploy-test.sh"
+  rm -f "${FIXTURE_ROOT}/deploy-test.sh.bak"
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "project root must be owned"
+  [[ ! -s "${FIXTURE_TRACE}" ]] || fail "unmanaged repository reached build"
+  printf 'PASS: unmanaged repository rejected\n'
+}
+
+test_build_failure() {
+  create_fixture build-failure
+  run_deploy failure env FAIL_STAGE=build
+  [[ "$(git -C "${FIXTURE_PROD}" rev-parse HEAD)" == "${FIXTURE_BASE}" ]] || fail "build failure moved production HEAD"
+  [[ "$(cat "${FIXTURE_TRACE}")" == "build" ]] || fail "build failure continued"
+  printf 'PASS: build failure stops before fast-forward\n'
+}
+
+test_main_advances_during_build() {
+  create_fixture main-advances
+  run_deploy failure env ADVANCE_REMOTE_URL="${FIXTURE_ROOT}/remote.git"
+  assert_contains "${FIXTURE_OUTPUT}" "origin/main advanced during the build"
+  [[ "$(git -C "${FIXTURE_PROD}" rev-parse HEAD)" == "${FIXTURE_BASE}" ]] || fail "advanced main moved production HEAD"
+  [[ "$(cat "${FIXTURE_TRACE}")" == "build" ]] || fail "advanced main continued past build"
+  printf 'PASS: main advancing during build aborts before fast-forward\n'
+}
+
+test_migration_failure() {
+  create_fixture migration-failure
+  run_deploy failure env FAIL_STAGE=migrate
+  [[ "$(git -C "${FIXTURE_PROD}" rev-parse HEAD)" == "${FIXTURE_TARGET}" ]] || fail "migration failure did not preserve target HEAD"
+  [[ "$(cat "${FIXTURE_TRACE}")" == $'build\nmigrate' ]] || fail "migration failure continued to restart"
+  [[ ! -e "${FIXTURE_PROD}/build/profile" ]] || fail "migration failure installed new artifacts"
+  printf 'PASS: migration failure stops before restart\n'
+}
+
+test_migration_dirties_worktree() {
+  create_fixture migration-dirties
+  run_deploy failure env DIRTY_STAGE=migrate
+  assert_contains "${FIXTURE_OUTPUT}" "refusing to deploy a dirty worktree"
+  [[ "$(cat "${FIXTURE_TRACE}")" == $'build\nmigrate' ]] || fail "dirty migration continued to restart"
+  printf 'PASS: migration-created dirt rejected before restart\n'
+}
+
+test_restart_failure() {
+  create_fixture restart-failure
+  run_deploy failure env FAIL_STAGE=restart
+  [[ "$(cat "${FIXTURE_TRACE}")" == $'build\nmigrate\nrestart' ]] || fail "restart failure continued to health check"
+  printf 'PASS: restart failure stops before health check\n'
+}
+
+test_health_failure() {
+  create_fixture health-failure
+  run_deploy failure env FAIL_STAGE=health
+  [[ "$(cat "${FIXTURE_TRACE}")" == $'build\nmigrate\nrestart\nhealth' ]] || fail "health failure trace mismatch"
+  assert_contains "${FIXTURE_OUTPUT}" "failed with exit code"
+  printf 'PASS: health failure returns failure\n'
+}
+
+test_rollback_target() {
+  create_fixture rollback
+  git -C "${FIXTURE_PROD}" fetch -q origin main
+  git -C "${FIXTURE_PROD}" merge -q --ff-only origin/main
+  git --git-dir="${FIXTURE_ROOT}/remote.git" update-ref refs/heads/main "${FIXTURE_BASE}"
+  write_pr_response "${FIXTURE_BASE}" true
+  run_deploy failure env
+  assert_contains "${FIXTURE_OUTPUT}" "rollback and branch deployments are forbidden"
+  printf 'PASS: rollback target rejected\n'
+}
+
+bash -n "${SOURCE_SCRIPT}"
+test_success
+test_dirty_tracked
+test_dirty_untracked
+test_wrong_branch
+test_divergent_head
+test_missing_pr
+test_unmanaged_repository
+test_build_failure
+test_main_advances_during_build
+test_migration_failure
+test_migration_dirties_worktree
+test_restart_failure
+test_health_failure
+test_rollback_target
+printf 'All deploy-main safety drills passed.\n'


### PR DESCRIPTION
## Summary
- add a root-managed, no-argument production deployer fixed to HTTPS `origin/main`
- require a clean root-owned checkout and a merged PR targeting `main`
- build from an isolated archive, reject a moving `main`, run migrations, restart, and health-check
- execute through a transient systemd unit for journald audit logs
- add a guarded installer and operational documentation

## Safety drills
- success path
- dirty tracked and untracked worktrees
- non-main branch and divergent/ahead HEAD
- target without a merged PR
- repository not managed by root
- build failure before fast-forward
- origin/main advancing during build
- migration failure and migration-created dirt
- restart and health-check failures
- rollback target

## Verification
- `bash -n scripts/cloud/deploy_main.sh scripts/cloud/install_main_deployer.sh scripts/cloud/test_deploy_main.sh`
- `bash scripts/cloud/test_deploy_main.sh`
- real GitHub associated-PR response verified against current main commit
- aliap prerequisites checked read-only (clean main, systemd 255, required commands present)