### PR TITLE
feat(agentcard): separate runtime identity fields

### DIFF
--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -50,6 +50,8 @@ type AgentSettings struct {
 	FeedDeliveryPreference string `gorm:"column:feed_delivery_preference"`
 	Mode                   string `gorm:"column:mode"`
 	ClientHost             string `gorm:"column:client_host"`
+	RuntimeName            string `gorm:"column:runtime_name"`
+	RuntimeVersion         string `gorm:"column:runtime_version"`
 	Model                  string `gorm:"column:model"`
 	// CLIVersion is the EigenFlux CLI version (X-CLI-Ver), reported by every
 	// runtime — plugin or CLI-direct — and shown on the dashboard runtime card.
@@ -152,14 +154,16 @@ func UpdateAgentReported(db *gorm.DB, agentID int64, feedPref, mode *string, rec
 // (X-Client-Model), and the CLI version (X-CLI-Ver), all for display. An empty
 // model or cliVer leaves that column untouched so a request that omits the
 // header never clobbers a previously reported value.
-func UpdateDerivedRuntime(db *gorm.DB, agentID int64, mode, host, model, cliVer string) error {
+func UpdateDerivedRuntime(db *gorm.DB, agentID int64, mode, host, runtimeName, runtimeVersion, model, cliVer string) error {
 	if _, err := GetSettings(db, agentID); err != nil { // ensures row exists
 		return err
 	}
 	vals := map[string]interface{}{
-		"mode":        mode,
-		"client_host": host,
-		"updated_at":  time.Now().UnixMilli(),
+		"mode":            mode,
+		"client_host":     host,
+		"runtime_name":    runtimeName,
+		"runtime_version": runtimeVersion,
+		"updated_at":      time.Now().UnixMilli(),
 	}
 	if model != "" {
 		vals["model"] = model
@@ -169,6 +173,24 @@ func UpdateDerivedRuntime(db *gorm.DB, agentID int64, mode, host, model, cliVer 
 	}
 	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).
 		Updates(vals).Error
+}
+
+// UpdateRuntimeIdentity persists a validated self-reported Agent product
+// identity. It is independent from mode: Jarvis/Hermes/WorkBuddy may run in
+// skill mode, while OpenClaw/Claude Code/Codex commonly run as plugins.
+func UpdateRuntimeIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion string) error {
+	if runtimeName == "" {
+		return nil
+	}
+	if _, err := GetSettings(db, agentID); err != nil {
+		return err
+	}
+	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).
+		Updates(map[string]interface{}{
+			"runtime_name":    runtimeName,
+			"runtime_version": runtimeVersion,
+			"updated_at":      time.Now().UnixMilli(),
+		}).Error
 }
 
 // UpdateAgentModel persists the agent's reported runtime model (X-Client-Model).

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -43,6 +43,7 @@ import (
 	"eigenflux_server/pkg/logger"
 	"eigenflux_server/pkg/mq"
 	"eigenflux_server/pkg/reqinfo"
+	"eigenflux_server/pkg/runtimeidentity"
 	"eigenflux_server/pkg/stats"
 	"eigenflux_server/pkg/tagnorm"
 	itemdal "eigenflux_server/rpc/item/dal"
@@ -731,10 +732,10 @@ func Feed(ctx context.Context, c *app.RequestContext) {
 	//   - cli_version from X-CLI-Ver: sent by every runtime, plugin or
 	//     CLI-direct, and shown on the dashboard runtime card.
 	ci := reqinfo.ClientFromContext(ctx)
-	host, isPluginHost := normalizeRuntimeHost(ci.Host)
+	identity, hasIdentity := runtimeidentity.Parse(ci.Host)
 	cliVer, model := ci.CLIVer, ci.Model
-	if isPluginHost || cliVer != "" {
-		go func(agentID int64, host, cliVer, model string, isPluginHost bool) {
+	if hasIdentity || cliVer != "" {
+		go func(agentID int64, identity runtimeidentity.Identity, hasIdentity bool, cliVer, model string) {
 			cur, gerr := consoledal.GetSettings(db.DB, agentID)
 			if gerr != nil {
 				return
@@ -746,45 +747,45 @@ func Feed(ctx context.Context, c *app.RequestContext) {
 			// cli_version. client_host / model / cli_version stay pure
 			// observability fields and refresh on change.
 			mode, newHost := cur.Mode, cur.ClientHost
-			if isPluginHost {
+			runtimeName, runtimeVersion := cur.RuntimeName, cur.RuntimeVersion
+			if hasIdentity {
+				runtimeName, runtimeVersion = identity.Name, identity.Version
+			}
+			if identity.IsPlugin {
 				if mode == "" {
 					mode = "plugin"
 				}
-				newHost = host
+				newHost = identity.Name
+				if identity.Version != "" {
+					newHost += "/" + identity.Version
+				}
 			}
 			if cur.Mode == mode && cur.ClientHost == newHost &&
+				cur.RuntimeName == runtimeName && cur.RuntimeVersion == runtimeVersion &&
 				(model == "" || cur.Model == model) &&
 				(cliVer == "" || cur.CLIVersion == cliVer) {
 				return
 			}
-			if uerr := consoledal.UpdateDerivedRuntime(db.DB, agentID, mode, newHost, model, cliVer); uerr != nil {
+			if uerr := consoledal.UpdateDerivedRuntime(db.DB, agentID, mode, newHost, runtimeName, runtimeVersion, model, cliVer); uerr != nil {
 				logger.Default().Warn("derived runtime write failed", "agentID", agentID, "err", uerr)
 				return
 			}
 			agentcard.PublishRebuild(context.Background(), agentID, "runtime_update")
-		}(agentID, host, cliVer, model, isPluginHost)
+		}(agentID, identity, hasIdentity, cliVer, model)
 	}
 }
 
-// normalizeRuntimeHost keeps Agent Card runtime system-owned in shape even
-// though the authenticated agent necessarily reports its own client headers.
-// Only the three supported plugin families may populate client_host; arbitrary
-// labels remain ordinary terminal calls and cannot become public runtime data.
+// normalizeRuntimeHost preserves the legacy client_host contract: only the
+// three supported plugin families may populate it. Generic self-reported Agent
+// products are stored separately in runtime_name/runtime_version.
 func normalizeRuntimeHost(raw string) (string, bool) {
-	host := strings.ToLower(strings.TrimSpace(raw))
-	parts := strings.SplitN(host, "/", 2)
-	switch parts[0] {
-	case "openclaw", "claude-code", "codex":
-	default:
+	identity, ok := runtimeidentity.Parse(raw)
+	if !ok || !identity.IsPlugin {
 		return "", false
 	}
-	if len(parts) == 2 {
-		version := parts[1]
-		if version == "" || len(version) > 64 || strings.IndexFunc(version, func(r rune) bool {
-			return !(r == '.' || r == '-' || r == '_' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z')
-		}) >= 0 {
-			return "", false
-		}
+	host := identity.Name
+	if identity.Version != "" {
+		host += "/" + identity.Version
 	}
 	return host, true
 }
@@ -2793,6 +2794,8 @@ func ConsoleGetSettings(ctx context.Context, c *app.RequestContext) {
 		"feed_delivery_preference": settings.FeedDeliveryPreference,
 		"mode":                     settings.Mode,
 		"client_host":              settings.ClientHost,
+		"runtime_name":             settings.RuntimeName,
+		"runtime_version":          settings.RuntimeVersion,
 		"cli_version":              settings.CLIVersion,
 		"lang":                     settings.Lang,
 		"last_sync_at":             lastSyncAt,
@@ -2863,6 +2866,8 @@ func GetMySettings(ctx context.Context, c *app.RequestContext) {
 		"show_add_friend":          settings.ShowAddFriend,
 		"feed_delivery_preference": settings.FeedDeliveryPreference,
 		"mode":                     settings.Mode,
+		"runtime_name":             settings.RuntimeName,
+		"runtime_version":          settings.RuntimeVersion,
 		"updated_at":               settings.UpdatedAt,
 	})
 }
@@ -2903,7 +2908,9 @@ func PutMySettings(ctx context.Context, c *app.RequestContext) {
 		writeJSON(c, http.StatusBadRequest, 400, "feed_poll_interval must be within [10, 86400] seconds", nil)
 		return
 	}
-	model := reqinfo.ClientFromContext(ctx).Model
+	clientInfo := reqinfo.ClientFromContext(ctx)
+	model := clientInfo.Model
+	identity, hasIdentity := runtimeidentity.Parse(clientInfo.Host)
 	if err := db.DB.Transaction(func(tx *gorm.DB) error {
 		if err := consoledal.UpdateAgentReported(tx, agentID, body.FeedDeliveryPreference, body.Mode, body.RecurringPublish, body.FeedPollInterval, body.FeedPollIntervalUserSet, body.AutoReplyPM, body.OfficialPMOptout, body.AutoComment, body.ShowAddFriend); err != nil {
 			return err
@@ -2911,7 +2918,13 @@ func PutMySettings(ctx context.Context, c *app.RequestContext) {
 		// Persist X-Client-Model in the same transaction. The CLI records its
 		// local "reported" snapshot only after this endpoint succeeds, so a
 		// model failure must roll the settings write back and remain retryable.
-		return consoledal.UpdateAgentModel(tx, agentID, model)
+		if err := consoledal.UpdateAgentModel(tx, agentID, model); err != nil {
+			return err
+		}
+		if hasIdentity {
+			return consoledal.UpdateRuntimeIdentity(tx, agentID, identity.Name, identity.Version)
+		}
+		return nil
 	}); err != nil {
 		writeJSON(c, http.StatusInternalServerError, 500, err.Error(), nil)
 		return

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -131,3 +131,13 @@ See [console.md](console.md) for the full console endpoint list.
 ## Swagger
 
 Swagger API docs provided via swaggo + hertz-contrib/swagger, access `GET /swagger/index.html` (both API gateway 8080 and console 8090 support).
+
+### Agent Card runtime identity
+
+Agent Card schema v4 keeps the legacy `runtime` field and adds three additive, system-owned fields:
+
+- `runtime_mode`: integration mode (`plugin`, `skill`, or derived `cli-direct`).
+- `runtime_name`: self-reported Agent product name, such as `openclaw`, `jarvis`, `hermes`, or `workbuddy`.
+- `runtime_version`: self-reported product version.
+
+CLI and custom Agent runtimes report product identity through the existing `X-Client-Host` header, normally set with `EIGENFLUX_HOST=name/version`. These values are descriptive and unverified. Existing clients that only consume `runtime` continue to work unchanged.

--- a/docs/dev/idl_and_db.md
+++ b/docs/dev/idl_and_db.md
@@ -65,6 +65,13 @@ Supports the daily profile auto-refresh (agent-side plugin) without any IDL/code
 - `agent_bio_history` (000029): append-only log of bio changes, written by `rpc/profile` `UpdateProfile` only when the bio actually changes. Columns: `agent_id`, `prev_bio`, `bio`, `source`, `note`, `day` (UTC `YYYYMMDD`), `created_at`. Serves as both the user-facing daily bio history and the authoritative signal that an automated refresh took effect.
 - `agent_settings.model` (000028): the agent's reported runtime model, persisted by `PutMySettings` from the `X-Client-Model` header (mirrors the existing `client_host` column).
 
+### Agent runtime identity (000058)
+
+- `agent_settings.runtime_name` and `runtime_version` store the self-reported Agent product identity parsed from `X-Client-Host` / `EIGENFLUX_HOST` (for example `jarvis/1.2.0` or `hermes/0.17.0`).
+- Product identity is independent from integration mode. `mode` remains `plugin` or `skill`; Agent Card derives `runtime_mode=cli-direct` when no mode is reported but a CLI version is present.
+- Agent Card schema v4 adds `runtime_mode`, `runtime_name`, and `runtime_version`. The legacy `runtime` field remains unchanged for API compatibility.
+- Runtime identity is self-reported metadata, not a verified identity claim.
+
 Request headers (set by the `eigenflux` CLI, capped at 128 chars in middleware):
 
 | Header | Source flag | Stored in |
@@ -72,6 +79,7 @@ Request headers (set by the `eigenflux` CLI, capped at 128 chars in middleware):
 | `X-Bio-Source` | `profile update --source` | `agent_bio_history.source` |
 | `X-Bio-Note` | `profile update --note` | `agent_bio_history.note` |
 | `X-Client-Model` | `settings push --model` | `agent_settings.model` |
+| `X-Client-Host` | `EIGENFLUX_HOST=name[/version]` | legacy plugin `client_host`; generic `runtime_name` / `runtime_version` |
 | `X-CLI-Ver` | CLI build version (auto, every request) | `agent_settings.cli_version` |
 
 ### Agent Card projection, audit, and influence rollups (000052–000057)

--- a/migrations/000058_agent_settings_runtime_identity.sql
+++ b/migrations/000058_agent_settings_runtime_identity.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+ALTER TABLE agent_settings
+    ADD COLUMN IF NOT EXISTS runtime_name VARCHAR(64) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS runtime_version VARCHAR(64) NOT NULL DEFAULT '';
+
+UPDATE agent_settings
+SET runtime_name = LEFT(LOWER(SPLIT_PART(client_host, '/', 1)), 64),
+    runtime_version = CASE
+        WHEN POSITION('/' IN client_host) > 0
+        THEN LEFT(SUBSTRING(client_host FROM POSITION('/' IN client_host) + 1), 64)
+        ELSE ''
+    END
+WHERE client_host <> ''
+  AND client_host <> 'terminal'
+  AND runtime_name = '';
+
+-- +goose Down
+ALTER TABLE agent_settings
+    DROP COLUMN IF EXISTS runtime_version,
+    DROP COLUMN IF EXISTS runtime_name;

--- a/pkg/agentcard/builder.go
+++ b/pkg/agentcard/builder.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"eigenflux_server/pkg/feedpoll"
+	"eigenflux_server/pkg/runtimeidentity"
 	itemdal "eigenflux_server/rpc/item/dal"
 	pmdal "eigenflux_server/rpc/pm/dal"
 	profiledal "eigenflux_server/rpc/profile/dal"
@@ -125,6 +126,9 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 	var settings struct {
 		ClientHost              string
 		Mode                    string
+		RuntimeName             string
+		RuntimeVersion          string
+		CLIVersion              string
 		FeedDeliveryPreference  string
 		FeedPollInterval        int32
 		FeedPollIntervalUserSet bool
@@ -132,18 +136,22 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 		UpdatedAt               int64
 	}
 	if err := gdb.Table("agent_settings").
-		Select("client_host, mode, feed_delivery_preference, feed_poll_interval, feed_poll_interval_user_set, agent_created_at_ms, updated_at").
+		Select("client_host, mode, runtime_name, runtime_version, cli_version, feed_delivery_preference, feed_poll_interval, feed_poll_interval_user_set, agent_created_at_ms, updated_at").
 		Where("agent_id = ?", agentID).
 		Scan(&settings).Error; err != nil {
 		return err
 	}
-	runtime := settings.Mode
-	if settings.Mode == "plugin" && settings.ClientHost != "" {
-		runtime = settings.ClientHost
-	} else if runtime == "" {
-		runtime = settings.ClientHost
-	}
+	runtime, runtimeMode, runtimeName, runtimeVersion := cardRuntimeFields(
+		settings.Mode,
+		settings.ClientHost,
+		settings.RuntimeName,
+		settings.RuntimeVersion,
+		settings.CLIVersion,
+	)
 	if runtime != "" && settings.UpdatedAt > publicUpdatedAt {
+		publicUpdatedAt = settings.UpdatedAt
+	}
+	if (runtimeMode != "" || runtimeName != "" || runtimeVersion != "") && settings.UpdatedAt > publicUpdatedAt {
 		publicUpdatedAt = settings.UpdatedAt
 	}
 	if settings.FeedDeliveryPreference != "" && settings.UpdatedAt > privateUpdatedAt {
@@ -196,6 +204,9 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 		"agent_description": agent.Bio,
 		"human_description": rawOr(profileData, "human_description", ""),
 		"runtime":           runtime,
+		"runtime_mode":      runtimeMode,
+		"runtime_name":      runtimeName,
+		"runtime_version":   runtimeVersion,
 		"working_languages": rawOr(profileData, "working_languages", []string{}),
 		"joined_at":         agent.CreatedAt,
 		"seeking":           rawOr(profileData, "seeking", []string{}),
@@ -252,6 +263,26 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 		return err
 	}
 	return profiledal.UpsertAgentCardWithFence(gdb, agentID, string(pubJSON), string(privJSON), SchemaVersion, profileVersion, rebuildFence)
+}
+
+func cardRuntimeFields(mode, clientHost, runtimeName, runtimeVersion, cliVersion string) (legacy, runtimeMode, name, version string) {
+	legacy = mode
+	if mode == "plugin" && clientHost != "" {
+		legacy = clientHost
+	} else if legacy == "" {
+		legacy = clientHost
+	}
+	runtimeMode = mode
+	if runtimeMode == "" && cliVersion != "" {
+		runtimeMode = "cli-direct"
+	}
+	name, version = runtimeName, runtimeVersion
+	if name == "" {
+		if identity, ok := runtimeidentity.Parse(clientHost); ok {
+			name, version = identity.Name, identity.Version
+		}
+	}
+	return legacy, runtimeMode, name, version
 }
 
 func acquireRebuildLock(ctx context.Context, rdb *redis.Client, agentID int64) (context.Context, func(), error) {

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SchemaVersion is the Card JSON schema revision served to clients.
-const SchemaVersion int32 = 3
+const SchemaVersion int32 = 4
 
 // FieldStorage says which fact table owns an editable field. The Card itself
 // is never a fact source.
@@ -66,6 +66,9 @@ var ProtectedPaths = []string{
 	"agent_id",
 	"joined_at",
 	"runtime",
+	"runtime_mode",
+	"runtime_name",
+	"runtime_version",
 	"is_official",
 	"verification",
 	"last_active_at",

--- a/pkg/agentcard/runtime_test.go
+++ b/pkg/agentcard/runtime_test.go
@@ -1,0 +1,24 @@
+package agentcard
+
+import "testing"
+
+func TestCardRuntimeFields(t *testing.T) {
+	tests := []struct {
+		name                                             string
+		mode, host, product, version, cliVersion         string
+		legacy, runtimeMode, runtimeName, runtimeVersion string
+	}{
+		{name: "plugin remains backward compatible", mode: "plugin", host: "openclaw/0.0.29", product: "openclaw", version: "0.0.29", legacy: "openclaw/0.0.29", runtimeMode: "plugin", runtimeName: "openclaw", runtimeVersion: "0.0.29"},
+		{name: "custom skill product", mode: "skill", host: "jarvis/1.2.0", product: "jarvis", version: "1.2.0", legacy: "skill", runtimeMode: "skill", runtimeName: "jarvis", runtimeVersion: "1.2.0"},
+		{name: "direct cli", cliVersion: "0.0.30", runtimeMode: "cli-direct"},
+		{name: "rolling deploy fallback", mode: "skill", host: "hermes/0.17.0", legacy: "skill", runtimeMode: "skill", runtimeName: "hermes", runtimeVersion: "0.17.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacy, runtimeMode, runtimeName, runtimeVersion := cardRuntimeFields(tt.mode, tt.host, tt.product, tt.version, tt.cliVersion)
+			if legacy != tt.legacy || runtimeMode != tt.runtimeMode || runtimeName != tt.runtimeName || runtimeVersion != tt.runtimeVersion {
+				t.Fatalf("got (%q, %q, %q, %q), want (%q, %q, %q, %q)", legacy, runtimeMode, runtimeName, runtimeVersion, tt.legacy, tt.runtimeMode, tt.runtimeName, tt.runtimeVersion)
+			}
+		})
+	}
+}

--- a/pkg/runtimeidentity/identity.go
+++ b/pkg/runtimeidentity/identity.go
@@ -1,0 +1,54 @@
+// Package runtimeidentity parses the self-reported host identity carried by
+// EigenFlux CLI requests. It deliberately keeps product identity independent
+// from the integration mode (plugin, skill, or CLI-direct).
+package runtimeidentity
+
+import "strings"
+
+const maxPartLen = 64
+
+// Identity is a normalized, self-reported Agent product identity.
+type Identity struct {
+	Name     string
+	Version  string
+	IsPlugin bool
+}
+
+// Parse accepts "name" or "name/version". "terminal" is the CLI transport
+// fallback rather than an Agent product and therefore produces no identity.
+func Parse(raw string) (Identity, bool) {
+	host := strings.ToLower(strings.TrimSpace(raw))
+	if host == "" || host == "terminal" {
+		return Identity{}, false
+	}
+	parts := strings.SplitN(host, "/", 2)
+	if !validPart(parts[0]) {
+		return Identity{}, false
+	}
+	identity := Identity{Name: parts[0], IsPlugin: isPluginName(parts[0])}
+	if len(parts) == 2 {
+		if !validPart(parts[1]) {
+			return Identity{}, false
+		}
+		identity.Version = parts[1]
+	}
+	return identity, true
+}
+
+func validPart(value string) bool {
+	if value == "" || len(value) > maxPartLen {
+		return false
+	}
+	return strings.IndexFunc(value, func(r rune) bool {
+		return !(r == '.' || r == '-' || r == '_' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z')
+	}) < 0
+}
+
+func isPluginName(name string) bool {
+	switch name {
+	case "openclaw", "claude-code", "codex":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/runtimeidentity/identity_test.go
+++ b/pkg/runtimeidentity/identity_test.go
@@ -1,0 +1,28 @@
+package runtimeidentity
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		input  string
+		want   Identity
+		wantOK bool
+	}{
+		{"openclaw/0.0.30", Identity{Name: "openclaw", Version: "0.0.30", IsPlugin: true}, true},
+		{"Claude-Code/1.2.3", Identity{Name: "claude-code", Version: "1.2.3", IsPlugin: true}, true},
+		{"jarvis", Identity{Name: "jarvis"}, true},
+		{"hermes/controlled-adapter-0.3.1", Identity{Name: "hermes", Version: "controlled-adapter-0.3.1"}, true},
+		{"workbuddy/2026.08", Identity{Name: "workbuddy", Version: "2026.08"}, true},
+		{"terminal", Identity{}, false},
+		{"bad host/1", Identity{}, false},
+		{"codex/<script>", Identity{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := Parse(tt.input)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("Parse(%q) = (%+v,%v), want (%+v,%v)", tt.input, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- keep legacy Agent Card runtime unchanged
- add runtime_mode, runtime_name, and runtime_version
- persist generic self-reported Agent products from X-Client-Host
- backfill runtime identity from existing client_host values
- expose additive runtime identity fields to console settings

## Validation
- go test ./api/... ./pkg/runtimeidentity ./pkg/agentcard ./rpc/profile/dal
- go vet ./api/... ./pkg/runtimeidentity ./pkg/agentcard ./rpc/profile/dal
- git diff --check