### PR TITLE
feat(deploy): add minimal main-only production gate

### DIFF
--- a/cloud/systemd/eigenflux-app-deployer.conf.tpl
+++ b/cloud/systemd/eigenflux-app-deployer.conf.tpl
@@ -1,0 +1,7 @@
+[Service]
+WorkingDirectory=/var/lib/eigenflux-deployer/current/source
+EnvironmentFile=/etc/eigenflux/runtime.env
+ExecStartPre=
+ExecStart=
+ExecStartPre=/usr/bin/test -x /var/lib/eigenflux-deployer/current/bin/%i
+ExecStart=/var/lib/eigenflux-deployer/current/bin/%i

--- a/cloud/systemd/eigenflux-deploy-main.service.tpl
+++ b/cloud/systemd/eigenflux-deploy-main.service.tpl
@@ -1,0 +1,18 @@
+[Unit]
+Description=Deploy EigenFlux from the latest origin/main
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+WorkingDirectory=/
+Environment=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin
+ExecStart=/usr/local/sbin/eigenflux-deploy-main
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=eigenflux-deploy-main
+NoNewPrivileges=true
+PrivateTmp=true
+TimeoutStartSec=infinity

--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -180,18 +180,39 @@ sudo systemctl restart eigenflux-app@api
 
 ### Deploy Updates
 
-If there are database changes:
+Production updates must use the root-managed deployment service. It refuses a
+dirty checkout, fetches the latest `origin/main`, builds, migrates, restarts,
+checks health, and writes the complete log to the systemd journal.
+
+Install the entrypoint once as root, naming the operator allowed to deploy the
+latest main commit:
+
 ```bash
-./scripts/common/migrate_up.sh
+sudo DEPLOY_USER=ecs-user ./scripts/cloud/install_main_deployer.sh
 ```
 
+Deploy and inspect its log:
 
 ```bash
-git pull
-./scripts/common/build.sh
-sudo ./scripts/cloud/restart_all_services.sh
+sudo systemctl start eigenflux-deploy-main.service
+journalctl -u eigenflux-deploy-main.service
 ```
 
+Do not run `git pull`, builds, migrations, or service restarts manually on the
+production host. Rollback is root-only and may target only a full commit SHA
+contained in `origin/main`; it rolls back application code but never reverses
+database migrations. The installer also redirects application units to
+root-owned artifacts under `/var/lib/eigenflux-deployer`; build all production
+services once before running the installer.
+
+The installer copies `.env` and the deployment user's existing `github.com`
+known-host entry into root-owned files under `/etc/eigenflux`. Verify the SSH
+host key and production environment before installation; later configuration
+changes require a root operator.
+
+Application units use one root-owned binary/source bundle under
+`/var/lib/eigenflux-deployer/current`, so relative runtime assets and `.env`
+are never loaded from the deployment checkout.
 
 ## Security Checklist
 

--- a/scripts/cloud/DEPLOYMENT_POLICY.md
+++ b/scripts/cloud/DEPLOYMENT_POLICY.md
@@ -1,0 +1,28 @@
+# EigenFlux Production Deployment Policy
+
+The production checkout is deployment-only. Do not edit files, create commits,
+branches or stashes, or push from the production server.
+
+All changes must be developed locally, reviewed in a pull request, and merged
+to `main`. Production deployment is performed only through the root-managed
+systemd service:
+
+```bash
+sudo systemctl start eigenflux-deploy-main.service
+journalctl -u eigenflux-deploy-main.service
+```
+
+The service refuses a dirty worktree and always fetches and deploys the latest
+`origin/main`. A rollback is a root-only code rollback and accepts only a full
+commit SHA contained in the current `origin/main`; it does not reverse database
+migrations. The official GitHub remote and executable artifact directory are
+fixed in the root-owned deployment files; changing the checkout's `origin` or
+ignored `build/` files cannot change what the service executes.
+
+Production environment values and the pinned GitHub host keys are root-owned
+under `/etc/eigenflux`. Agents must not edit `.env`; configuration changes are
+an explicit root operation followed by a deployment.
+
+Application services execute and resolve relative resources from one
+root-owned release bundle under `/var/lib/eigenflux-deployer/current`; they
+never load runtime files from the writable production checkout.

--- a/scripts/cloud/deploy_main.sh
+++ b/scripts/cloud/deploy_main.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# This source template is rendered by install_main_deployer.sh. The installed
+# copy is root-owned and points to one fixed production checkout.
+PROJECT_ROOT='@@PROJECT_ROOT@@'
+DEPLOY_LIB='@@DEPLOY_LIB@@'
+DEPLOY_USER='@@DEPLOY_USER@@'
+DEPLOY_HOME='@@DEPLOY_HOME@@'
+OFFICIAL_REMOTE='git@github.com:phronesis-io/eigenflux.git'
+LOCK_FILE='/run/lock/eigenflux-deploy-main.lock'
+STATE_DIR='/var/lib/eigenflux-deployer'
+RUNTIME_ENV='/etc/eigenflux/runtime.env'
+export PATH='/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin'
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This command is managed by root. Use the systemd deployment service." >&2
+  exit 1
+fi
+
+if [[ "${PROJECT_ROOT}" == *'@@'* || "${DEPLOY_LIB}" == *'@@'* || "${DEPLOY_USER}" == *'@@'* || "${DEPLOY_HOME}" == *'@@'* ]]; then
+  echo "Run the installed root-managed copy, not this source template." >&2
+  exit 1
+fi
+
+# shellcheck source=deploy_main_lib.sh
+source "${DEPLOY_LIB}"
+deploy_main_run "${PROJECT_ROOT}" "${LOCK_FILE}" "${DEPLOY_USER}" "${DEPLOY_HOME}" \
+  "${OFFICIAL_REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" "$@"

--- a/scripts/cloud/deploy_main_lib.sh
+++ b/scripts/cloud/deploy_main_lib.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# Shared implementation for the root-owned production deploy wrapper.
+# This file is installed under /usr/local/libexec/eigenflux and is not sourced
+# from the production checkout.
+
+deploy_main_as_user() {
+  local deploy_user=$1
+  local deploy_home=$2
+  shift 2
+  if [[ -n "${deploy_user}" ]]; then
+    runuser -u "${deploy_user}" -- env -i \
+      HOME="${deploy_home}" USER="${deploy_user}" LOGNAME="${deploy_user}" \
+      PATH="${PATH}" TMPDIR="${TMPDIR:-/tmp}" "$@"
+  else
+    env -i HOME="${HOME:-/}" USER="${USER:-}" LOGNAME="${LOGNAME:-}" \
+      PATH="${PATH}" TMPDIR="${TMPDIR:-/tmp}" "$@"
+  fi
+}
+
+deploy_main_git_as_user() {
+  local deploy_user=$1
+  local deploy_home=$2
+  shift 2
+  deploy_main_as_user "${deploy_user}" "${deploy_home}" env \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_SYSTEM=/dev/null \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_SSH_COMMAND='/usr/bin/ssh -F /dev/null -o HostName=github.com -o User=git -o IdentitiesOnly=yes -o UserKnownHostsFile=/etc/eigenflux/github_known_hosts -o GlobalKnownHostsFile=/dev/null -o StrictHostKeyChecking=yes' \
+    git "$@"
+}
+
+deploy_main_assert_clean() {
+  local project_root=$1
+  local phase=$2
+  local deploy_user=$3
+  local deploy_home=$4
+  local dirty
+
+  dirty="$(deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" status --porcelain --untracked-files=all)" || return 1
+  if [[ -n "${dirty}" ]]; then
+    echo "Refusing deployment: production worktree is dirty (${phase})." >&2
+    printf '%s\n' "${dirty}" >&2
+    return 1
+  fi
+}
+
+deploy_main_restart_services() {
+  local units=(
+    eigenflux-etcd
+    eigenflux-app@profile
+    eigenflux-app@item
+    eigenflux-app@sort
+    eigenflux-app@feed
+    eigenflux-app@pm
+    eigenflux-app@auth
+    eigenflux-app@notification
+    eigenflux-app@trade
+    eigenflux-app@api
+    eigenflux-app@ws
+    eigenflux-app@pipeline
+    eigenflux-app@cron
+  )
+  local unit
+  for unit in "${units[@]}"; do
+    echo "Restarting ${unit}"
+    systemctl restart "${unit}" || return 1
+    systemctl is-active --quiet "${unit}" || return 1
+  done
+}
+
+deploy_main_stage_build() {
+  local project_root=$1
+  local state_dir=$2
+  local target=$3
+  local source_dir=$4
+  local binaries=(profile item sort feed pm auth notification trade api ws pipeline cron)
+  local release_dir
+  local binary
+
+  mkdir -p "${state_dir}/releases"
+  chmod 0755 "${state_dir}" "${state_dir}/releases" || return 1
+  release_dir="$(mktemp -d "${state_dir}/releases/${target}.XXXXXX")" || return 1
+  mkdir -p "${release_dir}/bin"
+  chmod 0755 "${release_dir}" "${release_dir}/bin" || return 1
+  for binary in "${binaries[@]}"; do
+    [[ -f "${project_root}/build/${binary}" && -x "${project_root}/build/${binary}" ]] || {
+      echo "Missing build artifact: build/${binary}" >&2
+      return 1
+    }
+    install -m 0755 "${project_root}/build/${binary}" "${release_dir}/bin/${binary}" || return 1
+  done
+  ln -s "${source_dir}" "${release_dir}/source" || return 1
+  printf '%s\n' "${release_dir}"
+}
+
+deploy_main_activate_build() {
+  local state_dir=$1
+  local release_dir=$2
+  local next_link="${state_dir}/.current.$$"
+
+  ln -s "${release_dir}" "${next_link}" || return 1
+  if mv --help >/dev/null 2>&1; then
+    mv -Tf "${next_link}" "${state_dir}/current" || return 1
+  else
+    mv -fh "${next_link}" "${state_dir}/current" || return 1
+  fi
+}
+
+deploy_main_prepare_source() {
+  local project_root=$1
+  local state_dir=$2
+  local target=$3
+  local runtime_env=$4
+  local source_dir
+
+  mkdir -p "${state_dir}/work"
+  chmod 0755 "${state_dir}" "${state_dir}/work" || return 1
+  source_dir="$(mktemp -d "${state_dir}/work/${target}.XXXXXX")" || return 1
+  chmod 0755 "${source_dir}" || return 1
+  GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_NO_REPLACE_OBJECTS=1 git -C "${project_root}" archive "${target}" | \
+    tar -x -C "${source_dir}" || return 1
+  [[ -f "${runtime_env}" ]] || {
+    echo "Root-managed runtime environment is missing: ${runtime_env}" >&2
+    return 1
+  }
+  install -m 0600 "${runtime_env}" "${source_dir}/.env" || return 1
+  printf '%s\n' "${source_dir}"
+}
+
+deploy_main_run() {
+  local project_root=$1
+  local lock_file=$2
+  local deploy_user=$3
+  local deploy_home=$4
+  local official_remote=$5
+  local state_dir=$6
+  local runtime_env=$7
+  shift 7
+
+  local mode="latest"
+  local requested_sha=""
+  case "${1:-}" in
+    "") ;;
+    --rollback)
+      mode="rollback"
+      requested_sha="${2:-}"
+      [[ $# -eq 2 ]] || {
+        echo "Usage: eigenflux-deploy-main [--rollback <main-commit-sha>]" >&2
+        return 2
+      }
+      [[ "${requested_sha}" =~ ^[0-9a-fA-F]{40}$ ]] || {
+        echo "Rollback requires a full 40-character commit SHA." >&2
+        return 2
+      }
+      ;;
+    *)
+      echo "Usage: eigenflux-deploy-main [--rollback <main-commit-sha>]" >&2
+      return 2
+      ;;
+  esac
+
+  deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+    echo "Production repository not found: ${project_root}" >&2
+    return 1
+  }
+
+  exec 9>"${lock_file}"
+  flock -n 9 || {
+    echo "Another EigenFlux deployment is already running." >&2
+    return 1
+  }
+
+  deploy_main_assert_clean "${project_root}" "before fetch" "${deploy_user}" "${deploy_home}" || return 1
+  local remote_line origin_main target
+  remote_line="$(deploy_main_git_as_user "${deploy_user}" "${deploy_home}" ls-remote \
+    "${official_remote}" refs/heads/main)" || return 1
+  origin_main="${remote_line%%[[:space:]]*}"
+  [[ "${origin_main}" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "Official main did not resolve to one full commit SHA." >&2
+    return 1
+  }
+  deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" fetch --no-tags \
+    "${official_remote}" "${origin_main}" || return 1
+  deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" cat-file -e "${origin_main}^{commit}" || return 1
+
+  target="${origin_main}"
+
+  if [[ "${mode}" == "rollback" ]]; then
+    deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" fetch --no-tags \
+      "${official_remote}" "${requested_sha}" || return 1
+    target="$(deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" rev-parse --verify "${requested_sha}^{commit}")" || return 1
+    deploy_main_git_as_user "${deploy_user}" "${deploy_home}" -C "${project_root}" merge-base --is-ancestor "${target}" "${origin_main}" || {
+      echo "Refusing rollback: ${target} is not contained in origin/main." >&2
+      return 1
+    }
+  fi
+
+  echo "Deploying ${target} from origin/main (${mode})."
+  local source_dir release_dir
+  source_dir="$(deploy_main_prepare_source "${project_root}" "${state_dir}" "${target}" "${runtime_env}")" || return 1
+  bash "${source_dir}/scripts/common/build.sh" || return 1
+  release_dir="$(deploy_main_stage_build "${source_dir}" "${state_dir}" "${target}" "${source_dir}")" || return 1
+
+  if [[ "${mode}" == "latest" ]]; then
+    bash "${source_dir}/scripts/common/migrate_up.sh" || return 1
+  else
+    echo "Rollback mode: database migrations are intentionally unchanged."
+  fi
+
+  deploy_main_assert_clean "${project_root}" "before restart" "${deploy_user}" "${deploy_home}" || return 1
+  deploy_main_activate_build "${state_dir}" "${release_dir}" || return 1
+  deploy_main_restart_services || return 1
+  bash "${source_dir}/scripts/cloud/check_services.sh" || return 1
+
+  deploy_main_assert_clean "${project_root}" "after deployment" "${deploy_user}" "${deploy_home}" || return 1
+  printf '%s\n' "${target}" > "${state_dir}/deployed-sha"
+
+  echo "EigenFlux deployment completed: ${target}"
+}

--- a/scripts/cloud/install_main_deployer.sh
+++ b/scripts/cloud/install_main_deployer.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+DEPLOY_USER="${DEPLOY_USER:-${SUDO_USER:-}}"
+LIB_DIR="/usr/local/libexec/eigenflux"
+BIN_PATH="/usr/local/sbin/eigenflux-deploy-main"
+UNIT_PATH="/etc/systemd/system/eigenflux-deploy-main.service"
+SUDOERS_PATH="/etc/sudoers.d/eigenflux-deploy-main"
+POLICY_DIR="/etc/eigenflux"
+STATE_DIR="/var/lib/eigenflux-deployer"
+APP_DROPIN_DIR="/etc/systemd/system/eigenflux-app@.service.d"
+RUNTIME_ENV="${POLICY_DIR}/runtime.env"
+GITHUB_KNOWN_HOSTS="${POLICY_DIR}/github_known_hosts"
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Please run with sudo: sudo DEPLOY_USER=<operator> $0" >&2
+  exit 1
+fi
+
+if [[ "${PROJECT_ROOT}" != /* ]] || ! git -C "${PROJECT_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Installer must run from an EigenFlux Git worktree." >&2
+  exit 1
+fi
+if [[ -n "$(git -C "${PROJECT_ROOT}" status --porcelain --untracked-files=all)" ]]; then
+  echo "Refusing installation from a dirty worktree." >&2
+  exit 1
+fi
+[[ "${DEPLOY_USER}" =~ ^[a-z_][a-z0-9_-]*$ ]] || {
+  echo "DEPLOY_USER must name the non-root deployment operator." >&2
+  exit 1
+}
+id "${DEPLOY_USER}" >/dev/null
+DEPLOY_GROUP="$(id -gn "${DEPLOY_USER}")"
+DEPLOY_HOME="$(getent passwd "${DEPLOY_USER}" | cut -d: -f6)"
+[[ "${DEPLOY_HOME}" == /* && -d "${DEPLOY_HOME}" ]] || {
+  echo "Could not determine a valid home directory for ${DEPLOY_USER}." >&2
+  exit 1
+}
+command -v visudo >/dev/null
+command -v ssh-keygen >/dev/null
+[[ -f "${PROJECT_ROOT}/.env" ]] || {
+  echo "Production .env is required before installing the deployment gate." >&2
+  exit 1
+}
+[[ -f "${DEPLOY_HOME}/.ssh/known_hosts" ]] || {
+  echo "${DEPLOY_USER} must connect to github.com once before installation." >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+mkdir -p "${LIB_DIR}" "${POLICY_DIR}" "${STATE_DIR}/releases" "${STATE_DIR}/work" "${APP_DROPIN_DIR}"
+chmod 0755 "${STATE_DIR}" "${STATE_DIR}/releases" "${STATE_DIR}/work"
+for binary in profile item sort feed pm auth notification trade api ws pipeline cron; do
+  [[ -f "${PROJECT_ROOT}/build/${binary}" && -x "${PROJECT_ROOT}/build/${binary}" ]] || {
+    echo "Missing build/${binary}; build all production services before installation." >&2
+    exit 1
+  }
+done
+ssh-keygen -F github.com -f "${DEPLOY_HOME}/.ssh/known_hosts" | \
+  awk '!/^#/' > "${tmp_dir}/github_known_hosts"
+[[ -s "${tmp_dir}/github_known_hosts" ]] || {
+  echo "No trusted github.com host key found for ${DEPLOY_USER}." >&2
+  exit 1
+}
+install -o root -g root -m 0644 "${tmp_dir}/github_known_hosts" "${GITHUB_KNOWN_HOSTS}"
+install -o root -g root -m 0600 "${PROJECT_ROOT}/.env" "${RUNTIME_ENV}"
+# Keep the application's legacy .env lookup read-only and identical to the
+# root-managed deployment environment.
+install -o root -g "${DEPLOY_GROUP}" -m 0640 "${RUNTIME_ENV}" "${PROJECT_ROOT}/.env"
+
+bootstrap_source="${STATE_DIR}/work/bootstrap-$(date +%s)"
+mkdir -p "${bootstrap_source}"
+chmod 0755 "${bootstrap_source}"
+GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
+  GIT_NO_REPLACE_OBJECTS=1 git -C "${PROJECT_ROOT}" archive HEAD | \
+  tar -x -C "${bootstrap_source}"
+install -o root -g root -m 0600 "${RUNTIME_ENV}" "${bootstrap_source}/.env"
+install -o root -g root -m 0644 \
+  "${PROJECT_ROOT}/scripts/cloud/deploy_main_lib.sh" \
+  "${LIB_DIR}/deploy_main_lib.sh"
+
+sed \
+  -e "s#@@PROJECT_ROOT@@#${PROJECT_ROOT}#g" \
+  -e "s#@@DEPLOY_LIB@@#${LIB_DIR}/deploy_main_lib.sh#g" \
+  -e "s#@@DEPLOY_USER@@#${DEPLOY_USER}#g" \
+  -e "s#@@DEPLOY_HOME@@#${DEPLOY_HOME}#g" \
+  "${PROJECT_ROOT}/scripts/cloud/deploy_main.sh" > "${tmp_dir}/eigenflux-deploy-main"
+install -o root -g root -m 0755 "${tmp_dir}/eigenflux-deploy-main" "${BIN_PATH}"
+
+install -o root -g root -m 0644 \
+  "${PROJECT_ROOT}/cloud/systemd/eigenflux-deploy-main.service.tpl" \
+  "${UNIT_PATH}"
+install -o root -g root -m 0644 \
+  "${PROJECT_ROOT}/cloud/systemd/eigenflux-app-deployer.conf.tpl" \
+  "${APP_DROPIN_DIR}/deployer.conf"
+install -o root -g root -m 0644 \
+  "${PROJECT_ROOT}/scripts/cloud/DEPLOYMENT_POLICY.md" \
+  "${POLICY_DIR}/DEPLOYMENT_POLICY.md"
+
+cat > "${tmp_dir}/sudoers" <<EOF
+${DEPLOY_USER} ALL=(root) NOPASSWD: /usr/bin/systemctl start eigenflux-deploy-main.service
+EOF
+visudo -cf "${tmp_dir}/sudoers"
+install -o root -g root -m 0440 "${tmp_dir}/sudoers" "${SUDOERS_PATH}"
+
+# The drop-in points services at a root-owned artifact directory. Bootstrap it
+# from the currently built binaries so installing the gate does not break the
+# next ordinary service restart.
+bootstrap="${STATE_DIR}/releases/bootstrap-$(date +%s)"
+mkdir -p "${bootstrap}/bin"
+chmod 0755 "${bootstrap}" "${bootstrap}/bin"
+for binary in profile item sort feed pm auth notification trade api ws pipeline cron; do
+  [[ -f "${PROJECT_ROOT}/build/${binary}" && -x "${PROJECT_ROOT}/build/${binary}" ]] || {
+    echo "Missing build/${binary}; build all production services before installation." >&2
+    exit 1
+  }
+  install -o root -g root -m 0755 "${PROJECT_ROOT}/build/${binary}" "${bootstrap}/bin/${binary}"
+done
+ln -s "${bootstrap_source}" "${bootstrap}/source"
+bootstrap_link="${STATE_DIR}/.current.$$"
+ln -s "${bootstrap}" "${bootstrap_link}"
+if mv --help >/dev/null 2>&1; then
+  mv -Tf "${bootstrap_link}" "${STATE_DIR}/current"
+else
+  mv -fh "${bootstrap_link}" "${STATE_DIR}/current"
+fi
+
+systemctl daemon-reload
+echo "Installed root-managed EigenFlux deployment entrypoint."
+echo "Deploy latest main: sudo systemctl start eigenflux-deploy-main.service"
+echo "Logs: journalctl -u eigenflux-deploy-main.service"
+echo "Rollback is root-only: ${BIN_PATH} --rollback <full-main-commit-sha>"

--- a/scripts/cloud/test_deploy_main.sh
+++ b/scripts/cloud/test_deploy_main.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+
+SOURCE_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+# shellcheck source=deploy_main_lib.sh
+source "${SOURCE_ROOT}/scripts/cloud/deploy_main_lib.sh"
+
+REMOTE="${TEST_ROOT}/remote.git"
+REPO="${TEST_ROOT}/prod"
+LOCK="${TEST_ROOT}/deploy.lock"
+TRACE="${TEST_ROOT}/trace"
+TEST_BIN="${TEST_ROOT}/bin"
+STATE_DIR="${TEST_ROOT}/state"
+RUNTIME_ENV="${TEST_ROOT}/runtime.env"
+printf 'APP_ENV=test\n' > "${RUNTIME_ENV}"
+
+deploy_main_restart_services() {
+  echo restart >> "${TRACE}"
+}
+
+# macOS does not ship flock; the production unit uses the system flock binary.
+mkdir -p "${TEST_BIN}"
+cat > "${TEST_BIN}/flock" <<'EOF'
+#!/bin/bash
+[[ ! -f "${FLOCK_FAIL_FILE}" ]]
+EOF
+chmod +x "${TEST_BIN}/flock"
+export PATH="${TEST_BIN}:${PATH}"
+export FLOCK_FAIL_FILE="${TEST_ROOT}/flock-fail"
+
+if "${SOURCE_ROOT}/scripts/cloud/deploy_main.sh" >/dev/null 2>&1; then
+  echo "FAIL: uninstalled source template was executable" >&2
+  exit 1
+fi
+echo "PASS: only the rendered root-managed wrapper can deploy"
+
+git init --bare -q "${REMOTE}"
+git init -q -b main "${REPO}"
+git -C "${REPO}" config user.email test@example.com
+git -C "${REPO}" config user.name test
+git -C "${REPO}" remote add origin "${REMOTE}"
+mkdir -p "${REPO}/scripts/common" "${REPO}/scripts/cloud"
+
+write_fixture_scripts() {
+  mkdir -p "${REPO}/scripts/common" "${REPO}/scripts/cloud"
+  cat > "${REPO}/scripts/common/build.sh" <<EOF
+#!/bin/bash
+echo build >> "${TRACE}"
+if [[ -f "${TEST_ROOT}/fail-build" ]]; then
+  exit 1
+fi
+BUILD_ROOT="\$(cd "\$(dirname "\$0")/../.."; pwd)"
+mkdir -p "\${BUILD_ROOT}/build"
+for binary in profile item sort feed pm auth notification trade api ws pipeline cron; do
+  printf '#!/bin/bash\n' > "\${BUILD_ROOT}/build/\${binary}"
+  chmod +x "\${BUILD_ROOT}/build/\${binary}"
+done
+EOF
+  cat > "${REPO}/scripts/common/migrate_up.sh" <<EOF
+#!/bin/bash
+SOURCE_ROOT="\$(cd "\$(dirname "\$0")/../.."; pwd)"
+source "\${SOURCE_ROOT}/.env"
+echo migrate >> "${TRACE}"
+EOF
+  cat > "${REPO}/scripts/cloud/restart_all_services.sh" <<EOF
+#!/bin/bash
+echo restart >> "${TRACE}"
+EOF
+  cat > "${REPO}/scripts/cloud/check_services.sh" <<EOF
+#!/bin/bash
+SOURCE_ROOT="\$(cd "\$(dirname "\$0")/../.."; pwd)"
+source "\${SOURCE_ROOT}/.env"
+echo health >> "${TRACE}"
+EOF
+}
+
+write_fixture_scripts
+printf 'build/\n.env\n' > "${REPO}/.gitignore"
+git -C "${REPO}" add .
+git -C "${REPO}" commit -qm initial
+FIRST_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+git -C "${REPO}" push -qu origin main
+
+echo second > "${REPO}/version"
+git -C "${REPO}" add version
+git -C "${REPO}" commit -qm second
+LATEST_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+git -C "${REPO}" push -qu origin main
+
+run_success() {
+  : > "${TRACE}"
+  deploy_main_run "${REPO}" "${LOCK}" "" "" "${REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" "$@"
+}
+
+run_success
+[[ "$(cat "${STATE_DIR}/deployed-sha")" == "${LATEST_SHA}" ]]
+[[ "$(tr '\n' ' ' < "${TRACE}")" == "build migrate restart health " ]]
+[[ -x "${STATE_DIR}/current/bin/api" ]]
+[[ "$(LC_ALL=C ls -ld "$(readlink "${STATE_DIR}/current")" | awk '{print $1}')" == "drwxr-xr-x" ]]
+[[ -f "${STATE_DIR}/current/source/scripts/cloud/check_services.sh" ]]
+[[ -z "$(find "${STATE_DIR}" -maxdepth 1 -name '.current.*' -print -quit)" ]]
+echo "PASS: latest origin/main deployed"
+
+printf 'touch %q\n' "${TEST_ROOT}/env-pwned" > "${REPO}/.env"
+run_success
+[[ ! -e "${TEST_ROOT}/env-pwned" ]]
+echo "PASS: ignored production .env is never executed as root"
+
+git -C "${REPO}" remote set-url origin "${TEST_ROOT}/untrusted.git"
+run_success
+[[ "$(cat "${STATE_DIR}/deployed-sha")" == "${LATEST_SHA}" ]]
+echo "PASS: mutable origin configuration is ignored"
+
+git clone -q --bare "${REPO}" "${TEST_ROOT}/rewrite.git"
+git -C "${REPO}" config "url.${TEST_ROOT}/rewrite.git.insteadOf" "${REMOTE}"
+run_success
+[[ "$(cat "${STATE_DIR}/deployed-sha")" == "${LATEST_SHA}" ]]
+git -C "${REPO}" config --unset-all "url.${TEST_ROOT}/rewrite.git.insteadOf"
+echo "PASS: URL rewrite cannot change the trusted main SHA"
+
+echo dirty > "${REPO}/dirty.txt"
+if deploy_main_run "${REPO}" "${LOCK}" "" "" "${REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" >/dev/null 2>&1; then
+  echo "FAIL: dirty worktree was accepted" >&2
+  exit 1
+fi
+rm "${REPO}/dirty.txt"
+echo "PASS: dirty worktree rejected"
+
+mkdir -p "${REPO}/build"
+printf '#!/bin/bash\n' > "${REPO}/build/obsolete"
+chmod +x "${REPO}/build/obsolete"
+printf 'MALICIOUS\n' > "${REPO}/build/api"
+chmod +x "${REPO}/build/api"
+run_success --rollback "${FIRST_SHA}"
+[[ "$(cat "${STATE_DIR}/deployed-sha")" == "${FIRST_SHA}" ]]
+[[ "$(tr '\n' ' ' < "${TRACE}")" == "build restart health " ]]
+[[ ! -e "${STATE_DIR}/current/bin/obsolete" ]]
+! grep -q MALICIOUS "${STATE_DIR}/current/bin/api"
+echo "PASS: rollback accepts a commit contained in main and skips migrations"
+
+git -C "${REPO}" checkout -q --orphan outside-main
+git -C "${REPO}" rm -qrf .
+write_fixture_scripts
+git -C "${REPO}" add .
+git -C "${REPO}" commit -qm outside
+OUTSIDE_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+git -C "${REPO}" checkout -q --detach "${LATEST_SHA}"
+if deploy_main_run "${REPO}" "${LOCK}" "" "" "${REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" --rollback "${OUTSIDE_SHA}" >/dev/null 2>&1; then
+  echo "FAIL: non-main rollback target was accepted" >&2
+  exit 1
+fi
+echo "PASS: non-main rollback target rejected"
+
+if deploy_main_run "${REPO}" "${LOCK}" "" "" "${REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" "${FIRST_SHA}" >/dev/null 2>&1; then
+  echo "FAIL: arbitrary deploy target was accepted" >&2
+  exit 1
+fi
+echo "PASS: normal deployment cannot select an arbitrary target"
+
+touch "${FLOCK_FAIL_FILE}"
+if deploy_main_run "${REPO}" "${LOCK}" "" "" "${REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" >/dev/null 2>&1; then
+  echo "FAIL: concurrent deployment lock was ignored" >&2
+  exit 1
+fi
+rm "${FLOCK_FAIL_FILE}"
+echo "PASS: concurrent deployment rejected"
+
+touch "${TEST_ROOT}/fail-build"
+: > "${TRACE}"
+if deploy_main_run "${REPO}" "${LOCK}" "" "" "${REMOTE}" "${STATE_DIR}" "${RUNTIME_ENV}" >/dev/null 2>&1; then
+  echo "FAIL: build failure was accepted" >&2
+  exit 1
+fi
+[[ "$(cat "${TRACE}")" == "build" ]]
+echo "PASS: build failure stops before migration and restart"


### PR DESCRIPTION
## Summary
- install a root-managed systemd deployer that only deploys trusted origin/main commits
- reject dirty production worktrees, arbitrary targets, concurrent releases, and mutable remote rewrites
- document the main-only deployment and rollback policy
- add isolated success and failure drills

## Verification
- `bash -n scripts/cloud/deploy_main.sh scripts/cloud/deploy_main_lib.sh scripts/cloud/install_main_deployer.sh scripts/cloud/test_deploy_main.sh`
- `bash scripts/cloud/test_deploy_main.sh`
- single-agent final review passed