### PR TITLE
fix(deploy): fetch official main over HTTPS

### DIFF
--- a/scripts/cloud/deploy_main.sh
+++ b/scripts/cloud/deploy_main.sh
@@ -7,7 +7,9 @@ PROJECT_ROOT='@@PROJECT_ROOT@@'
 DEPLOY_LIB='@@DEPLOY_LIB@@'
 DEPLOY_USER='@@DEPLOY_USER@@'
 DEPLOY_HOME='@@DEPLOY_HOME@@'
-OFFICIAL_REMOTE='git@github.com:phronesis-io/eigenflux.git'
+# The repository is public, so a fixed HTTPS URL avoids depending on mutable
+# per-user SSH identity configuration while Git config remains fully disabled.
+OFFICIAL_REMOTE='https://github.com/phronesis-io/eigenflux.git'
 LOCK_FILE='/run/lock/eigenflux-deploy-main.lock'
 STATE_DIR='/var/lib/eigenflux-deployer'
 RUNTIME_ENV='/etc/eigenflux/runtime.env'


### PR DESCRIPTION
## Summary
- use the fixed public GitHub HTTPS URL for the root-managed deployer
- avoid dependence on aliap custom SSH IdentityFile configuration
- retain disabled Git config and URL-rewrite protections

## Production evidence
The first controlled run failed with `Permission denied (publickey)` because the wrapper intentionally ignored the deploy user SSH config. The public HTTPS remote resolves the same official repository without credentials.

## Verification
- shell syntax checks passed
- all isolated success/failure deployment drills passed
- production `git ls-remote https://github.com/phronesis-io/eigenflux.git refs/heads/main` already succeeds