### PR TITLE
fix(deploy): export source as deploy operator

### DIFF
--- a/scripts/cloud/deploy_main_lib.sh
+++ b/scripts/cloud/deploy_main_lib.sh
@@ -113,14 +113,16 @@ deploy_main_prepare_source() {
   local state_dir=$2
   local target=$3
   local runtime_env=$4
+  local deploy_user=$5
+  local deploy_home=$6
   local source_dir
 
   mkdir -p "${state_dir}/work"
   chmod 0755 "${state_dir}" "${state_dir}/work" || return 1
   source_dir="$(mktemp -d "${state_dir}/work/${target}.XXXXXX")" || return 1
   chmod 0755 "${source_dir}" || return 1
-  GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_GLOBAL=/dev/null \
-    GIT_NO_REPLACE_OBJECTS=1 git -C "${project_root}" archive "${target}" | \
+  deploy_main_git_as_user "${deploy_user}" "${deploy_home}" \
+    -C "${project_root}" archive "${target}" | \
     tar -x -C "${source_dir}" || return 1
   [[ -f "${runtime_env}" ]] || {
     echo "Root-managed runtime environment is missing: ${runtime_env}" >&2
@@ -200,7 +202,8 @@ deploy_main_run() {
 
   echo "Deploying ${target} from origin/main (${mode})."
   local source_dir release_dir
-  source_dir="$(deploy_main_prepare_source "${project_root}" "${state_dir}" "${target}" "${runtime_env}")" || return 1
+  source_dir="$(deploy_main_prepare_source "${project_root}" "${state_dir}" "${target}" \
+    "${runtime_env}" "${deploy_user}" "${deploy_home}")" || return 1
   bash "${source_dir}/scripts/common/build.sh" || return 1
   release_dir="$(deploy_main_stage_build "${source_dir}" "${state_dir}" "${target}" "${source_dir}")" || return 1
 

--- a/scripts/cloud/test_deploy_main.sh
+++ b/scripts/cloud/test_deploy_main.sh
@@ -8,6 +8,13 @@ trap 'rm -rf "${TEST_ROOT}"' EXIT
 # shellcheck source=deploy_main_lib.sh
 source "${SOURCE_ROOT}/scripts/cloud/deploy_main_lib.sh"
 
+declare -f deploy_main_prepare_source | \
+  grep -Fq 'deploy_main_git_as_user "${deploy_user}" "${deploy_home}"' || {
+    echo "FAIL: source export bypasses the unprivileged deployment user" >&2
+    exit 1
+  }
+echo "PASS: source export uses the unprivileged deployment user"
+
 REMOTE="${TEST_ROOT}/remote.git"
 REPO="${TEST_ROOT}/prod"
 LOCK="${TEST_ROOT}/deploy.lock"


### PR DESCRIPTION
## Summary
- export the trusted main commit as the unprivileged deployment operator
- avoid Git dubious-ownership rejection when the systemd service itself runs as root
- add a regression assertion that source export cannot bypass the operator wrapper

## Production evidence
The controlled run reached the official main SHA but root-owned `git archive` was rejected because `/data/git/eigenflux` belongs to `ecs-user`. Existing services remained healthy and the release symlink was not activated.

## Verification
- shell syntax checks passed
- all isolated success/failure deployment drills passed
- regression assertion confirms source export uses `deploy_main_git_as_user`