### PR TITLE
fix(deploy): include snap Go toolchain

### DIFF
--- a/scripts/cloud/deploy_main.sh
+++ b/scripts/cloud/deploy_main.sh
@@ -13,7 +13,7 @@ OFFICIAL_REMOTE='https://github.com/phronesis-io/eigenflux.git'
 LOCK_FILE='/run/lock/eigenflux-deploy-main.lock'
 STATE_DIR='/var/lib/eigenflux-deployer'
 RUNTIME_ENV='/etc/eigenflux/runtime.env'
-export PATH='/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin'
+export PATH='/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin'
 
 if [[ "${EUID}" -ne 0 ]]; then
   echo "This command is managed by root. Use the systemd deployment service." >&2

--- a/scripts/cloud/test_deploy_main.sh
+++ b/scripts/cloud/test_deploy_main.sh
@@ -8,6 +8,12 @@ trap 'rm -rf "${TEST_ROOT}"' EXIT
 # shellcheck source=deploy_main_lib.sh
 source "${SOURCE_ROOT}/scripts/cloud/deploy_main_lib.sh"
 
+grep -Fq "export PATH='/snap/bin:" "${SOURCE_ROOT}/scripts/cloud/deploy_main.sh" || {
+  echo "FAIL: root-managed wrapper cannot find the production Go toolchain" >&2
+  exit 1
+}
+echo "PASS: root-managed wrapper includes the production Go toolchain"
+
 declare -f deploy_main_prepare_source | \
   grep -Fq 'deploy_main_git_as_user "${deploy_user}" "${deploy_home}"' || {
     echo "FAIL: source export bypasses the unprivileged deployment user" >&2


### PR DESCRIPTION
## Summary
- include `/snap/bin` in the root-managed deploy wrapper PATH
- keep the systemd build environment deterministic while allowing aliap's installed Go toolchain
- add a regression assertion for the production Go path

## Production evidence
The controlled service reached source build, then failed before migrations with `go: command not found`. On aliap, `go` is `/snap/bin/go`; it succeeds under a clean root environment when `/snap/bin` is included.

## Verification
- `sudo env -i PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin go version` => go1.26.5
- shell syntax checks passed
- all isolated success/failure deployment drills passed