### PR TITLE
fix(deploy): bypass snap launcher in sandbox

### DIFF
--- a/scripts/cloud/deploy_main.sh
+++ b/scripts/cloud/deploy_main.sh
@@ -13,7 +13,7 @@ OFFICIAL_REMOTE='https://github.com/phronesis-io/eigenflux.git'
 LOCK_FILE='/run/lock/eigenflux-deploy-main.lock'
 STATE_DIR='/var/lib/eigenflux-deployer'
 RUNTIME_ENV='/etc/eigenflux/runtime.env'
-export PATH='/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin'
+export PATH='/snap/go/current/bin:/snap/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin'
 
 if [[ "${EUID}" -ne 0 ]]; then
   echo "This command is managed by root. Use the systemd deployment service." >&2

--- a/scripts/cloud/test_deploy_main.sh
+++ b/scripts/cloud/test_deploy_main.sh
@@ -8,7 +8,7 @@ trap 'rm -rf "${TEST_ROOT}"' EXIT
 # shellcheck source=deploy_main_lib.sh
 source "${SOURCE_ROOT}/scripts/cloud/deploy_main_lib.sh"
 
-grep -Fq "export PATH='/snap/bin:" "${SOURCE_ROOT}/scripts/cloud/deploy_main.sh" || {
+grep -Fq "export PATH='/snap/go/current/bin:" "${SOURCE_ROOT}/scripts/cloud/deploy_main.sh" || {
   echo "FAIL: root-managed wrapper cannot find the production Go toolchain" >&2
   exit 1
 }


### PR DESCRIPTION
## Summary
- prefer the real Go binary under `/snap/go/current/bin`
- keep `NoNewPrivileges=yes` instead of weakening the systemd sandbox
- update the production toolchain regression assertion

## Production evidence
`/snap/bin/go` is the Snap launcher and fails under `NoNewPrivileges` with `cannot change profile for the next exec call`. `/snap/go/current/bin/go env GOPATH` succeeds in an otherwise identical transient systemd unit.

## Verification
- production-equivalent systemd diagnostic passed
- shell syntax checks passed
- all isolated success/failure deployment drills passed