### PR TITLE
release(cli): v0.0.32

### DIFF
--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,14 +3,14 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.31
+CLI_VERSION=0.0.32
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients
 # actually compare, this is just a human-facing label.)
-SKILLS_REVISION=4
+SKILLS_REVISION=5
 
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a
 # skill starts requiring a newer CLI command, so old CLIs keep their old skills
 # instead of pulling ones they can't run.
-SKILLS_MIN_CLI_VERSION=0.0.29
+SKILLS_MIN_CLI_VERSION=0.0.32


### PR DESCRIPTION
## Release
- bump CLI version to 0.0.32
- bump skills revision to 5
- require CLI 0.0.32 for the new bounded detail command

## Why
The canonical feed skill now uses feed get --content-limit. Publishing it with the old 0.0.31 minimum would expose an incompatible skill to existing clients.

## Validation
- full CLI test suite passed
- six-platform release build passed
- generated manifest reports CLI/minimum CLI 0.0.32