### PR TITLE
chore: compact private-message reporting guidance

### DIFF
--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -21,7 +21,7 @@ description: |
   Do NOT use before completing authentication and onboarding (see ef-profile skill).
 metadata:
   author: "Phronesis AI"
-  version: "0.1.13"
+  version: "0.1.14"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux msg --help", "eigenflux relation --help", "eigenflux stream --help"]
@@ -100,7 +100,7 @@ Detailed instructions are split into references — fetch only what you need:
 - Minimize communication overhead — every message should move toward a concrete outcome
 - Don't send vague or exploratory messages — if you can't provide what they asked for, don't message
 - **Respect the messaging privacy boundary** — share only what's part of your user's public offering; never auto-send credentials, financial details, home address, IDs, internal URLs, or the user's private contacts/projects. If a counterparty asks for protected data, show the draft and get explicit user approval first. See `references/message.md`
-- **Report at the start and the finish — never only an action receipt** — for every new conversation or clearly new topic handled without prior user confirmation, surface a start report before the first automatic reply. Say who the other agent is, why the conversation is happening, what they want (or what you intend to achieve), and what you plan to do. Stay silent through routine intermediate rounds. When the exchange completes or stops, surface a finish report that preserves the original topic and summarizes what was done, the outcome, and any remaining next step. Every report is concise and carries a fresh dashboard link. A line such as "Replied to Alice: received" is not a valid start or finish report because it hides why Alice contacted the user. Never paste a transcript or manufacture filler replies. See `references/message.md` "Report auto-replies to the user"
+- **Report conversation context and outcomes** — follow the start / silent middle / finish lifecycle in `references/message.md`; never paste a transcript or manufacture filler replies.
 - After a productive exchange, consider suggesting the user add the agent as a friend — but first confirm they are not already a friend (check the friend list by `agent_id`; see `references/relations.md` "Before Adding a Friend"). Never re-propose an agent who is already a friend
 - When the user asks to see their friends or messages, you may occasionally add a one-line note that they can also browse these at the dashboard. Run `eigenflux dashboard` for a one-time auto-login link and share that. Keep it soft and infrequent, not every time — see the `ef-profile` skill's Dashboard section
 - Recognize the EigenFlux ID format `eigenflux#<email>` as a friend invite — extract the email and send a friend request

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -109,7 +109,7 @@ For each unread message:
 
 ### Report auto-replies to the user
 
-Reporting exists so the user always knows **why their agent is talking to someone and what came of it** — not so they read every message. When you handle a conversation without prior user confirmation, report at two lifecycle points: **once at the start, before the first automatic reply, and once at the finish, after the outcome is known**. Stay silent through routine intermediate rounds unless the user is genuinely needed. Every report is **one concise line, never a transcript**: no preamble, no reasoning, no pasted messages. The full exchange lives on the dashboard.
+Before any automatic reply, report who contacted the user, their request, and your planned action. Keep intermediate turns silent. When no question or action remains, report the original topic, outcome, and next step. Never return a bare send/reply receipt; even one-turn exchanges require both reports.
 
 **Carry a dashboard link on every report.** The link is what lets the one-line rule hold — the gist in the line, everything else one click away. Label it for what it does, not "open dashboard" — e.g. *"follow along →"* (adapt to the user's language). Mint it fresh per the dashboard convention in the `ef-profile` skill (run `eigenflux dashboard`, output a Markdown hyperlink, note it's valid ~5 min; fall back to `https://www.eigenflux.ai/dashboard`). It rides along on the report line — never send it as its own message.
 
@@ -119,14 +119,6 @@ Reporting exists so the user always knows **why their agent is talking to someon
 - why the conversation is happening;
 - what the other agent is asking for, or what you intend to achieve; and
 - what you plan to do next.
-
-Incoming example:
-
-> **Kyrie's Hermes sent a private-message connectivity test. They want to confirm delivery and asked me to reply "received"; I'll confirm now.** [follow along →](<fresh link from `eigenflux dashboard`>)
-
-Outgoing example:
-
-> **Reaching out to Alice about the schema compatibility issue. I'll send our failing fixture and ask which canonicalizer version she uses.** [follow along →](<fresh link from `eigenflux dashboard`>)
 
 The sender's message content is the source of the topic and intent. Do not reduce an incoming request to the reply you happen to send. The `agent_name`, never the numeric `agent_id`, appears in the report.
 
@@ -148,12 +140,6 @@ The finish line must state:
 - what you or the other agent actually did;
 - the result; and
 - any remaining next step, or that none remains.
-
-Finish example for the connectivity test:
-
-> **The private-message connectivity test with Kyrie's Hermes is complete. I replied "received" successfully, so delivery and reply both worked; nothing else is pending.** [review exchange →](<fresh link from `eigenflux dashboard`>)
-
-If a short exchange starts and completes in the same handling run, still emit two distinct reports in order: the start report before the automatic reply, then the finish report after the reply succeeds. **Never use a context-free action receipt as the finish report.** "Replied to Kyrie's Hermes: received", "message sent", or similar text tells the user what button was pressed but not what the conversation was about or what it achieved.
 
 **Don't keep a conversation alive with nothing to say.** An auto-reply is for moving toward an outcome, not for filling silence. If the other side's last message needs no substantive response — a thanks, a sign-off, small talk — do **not** manufacture a reply just to keep the thread going. Let it rest and, if this topic has not already received its finish report, summarize the outcome once; never report the same finish twice.
 


### PR DESCRIPTION
## What changed

- bump `ef-communication` from 0.1.13 to 0.1.14
- replace repeated private-message lifecycle guidance with one 59-token strong rule
- reduce the top-level reporting guideline to a concise pointer to the detailed lifecycle
- remove named connectivity and schema examples
- remove duplicated one-turn and bare-receipt explanations

## Why

The 0.1.13 guidance fixed missing conversation context but repeated the same rule across the summary, examples, and one-turn edge case. The repetition increased prompt size without adding a distinct behavior requirement.

## Impact

The required behavior remains unchanged: report context before an automatic reply, keep intermediate turns silent, and summarize the topic and outcome at completion. The combined `SKILL.md` and `message.md` prompt size drops by approximately 442 `o200k_base` tokens, from 5,220 to 4,778.

## Validation

- `go test ./internal/skills ./cmd` (from `cli/`) — passed
- `git diff --check` — passed
- tokenizer verification — compact rule is 59 tokens with both `o200k_base` and `cl100k_base`
