### PR TITLE
feat(install): add Ocean Engine conversion callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -261,6 +261,9 @@ OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
 # Only used when MONITOR_ENABLED=true.
 LOKI_URL=http://localhost:3122
 
+# Ocean Engine H5 conversion callbacks. Enabled by default and only fires for
+# install tokens carrying the dedicated oceanengine_click_id landing parameter.
+OCEANENGINE_CALLBACK_ENABLED=true
 
 
 # Google Ads offline conversion upload (server-only secrets; do not expose to Vite/browser code)

--- a/api/install/handlers.go
+++ b/api/install/handlers.go
@@ -36,6 +36,7 @@ func Register(h *server.Hertz, baseURL string) {
 	initXHSConfig() // read env here — .env is loaded by the time Register runs
 	initXAdsConfig()
 	initGoogleAdsConfig()
+	initOceanengineConfig()
 	g := h.Group("/api/v1/install")
 	g.POST("/token", mintRef)
 	g.POST("/report", reportInstall)
@@ -59,11 +60,15 @@ type mintBody struct {
 	// non-app landing page supplies `clickid`; the frontend normalizes it to the
 	// dedicated xingtu_click_id field so it is never confused with Xiaohongshu's
 	// click_id even though both platforms use similar names in their URLs.
-	ClickID       string `json:"click_id"`        // Xiaohongshu 聚光
-	Twclid        string `json:"twclid"`          // X (Twitter) Ads
-	Gclid         string `json:"gclid"`           // Google Ads
-	XingtuClickID string `json:"xingtu_click_id"` // Xingtu landing URL clickid
-	Lang          string `json:"lang"`            // entry language shown on the page ('en'/'zh')
+	ClickID                 string `json:"click_id"`             // Xiaohongshu 聚光
+	Twclid                  string `json:"twclid"`               // X (Twitter) Ads
+	Gclid                   string `json:"gclid"`                // Google Ads
+	XingtuClickID           string `json:"xingtu_click_id"`      // Xingtu landing URL clickid
+	OceanengineClickID      string `json:"oceanengine_click_id"` // 巨量营销 clickid
+	OceanengineAdID         string `json:"oceanengine_ad_id"`
+	OceanengineCreativeID   string `json:"oceanengine_creative_id"`
+	OceanengineCreativeType string `json:"oceanengine_creative_type"`
+	Lang                    string `json:"lang"` // entry language shown on the page ('en'/'zh')
 	// InviteCode is the stable KOL/channel code from the landing URL's ?ic=
 	// (see pkg/invite). Malformed or unknown codes degrade to an unattributed
 	// mint rather than an error.
@@ -102,23 +107,28 @@ func mintRef(_ context.Context, c *app.RequestContext) {
 		}
 	}
 	xingtuClickID := normalizeXingtuClickID(body.XingtuClickID)
+	oceanengineClickID := normalizeOceanengineClickID(body.OceanengineClickID)
 	t := &Token{
-		Token:         NewToken(),
-		UTMSource:     trunc(body.UTMSource, 255),
-		UTMMedium:     trunc(body.UTMMedium, 255),
-		UTMCampaign:   trunc(body.UTMCampaign, 255),
-		UTMContent:    trunc(body.UTMContent, 255),
-		UTMTerm:       trunc(body.UTMTerm, 255),
-		Channel:       deriveChannel(body.UTMSource, body.ClickID, body.Twclid, body.Gclid, xingtuClickID),
-		Referrer:      trunc(body.Referrer, 2048),
-		ClickID:       trunc(body.ClickID, 128),
-		Twclid:        trunc(body.Twclid, 128),
-		Gclid:         trunc(body.Gclid, 512),
-		XingtuClickID: xingtuClickID,
-		Lang:          normalizeLang(body.Lang),
-		Status:        StatusPending,
-		ClientIP:      ip,
-		CreatedAt:     time.Now().UnixMilli(),
+		Token:                   NewToken(),
+		UTMSource:               trunc(body.UTMSource, 255),
+		UTMMedium:               trunc(body.UTMMedium, 255),
+		UTMCampaign:             trunc(body.UTMCampaign, 255),
+		UTMContent:              trunc(body.UTMContent, 255),
+		UTMTerm:                 trunc(body.UTMTerm, 255),
+		Channel:                 deriveChannel(body.UTMSource, body.ClickID, body.Twclid, body.Gclid, xingtuClickID, oceanengineClickID),
+		Referrer:                trunc(body.Referrer, 2048),
+		ClickID:                 trunc(body.ClickID, 128),
+		Twclid:                  trunc(body.Twclid, 128),
+		Gclid:                   trunc(body.Gclid, 512),
+		XingtuClickID:           xingtuClickID,
+		OceanengineClickID:      oceanengineClickID,
+		OceanengineAdID:         trunc(body.OceanengineAdID, 128),
+		OceanengineCreativeID:   trunc(body.OceanengineCreativeID, 128),
+		OceanengineCreativeType: trunc(body.OceanengineCreativeType, 64),
+		Lang:                    normalizeLang(body.Lang),
+		Status:                  StatusPending,
+		ClientIP:                ip,
+		CreatedAt:               time.Now().UnixMilli(),
 	}
 	if ic := lookupInviteCode(body.InviteCode); ic != nil {
 		t.InviteCode = ic.Code
@@ -133,7 +143,7 @@ func mintRef(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	event("install_ref_new", t.Token, "channel", t.Channel,
-		"paid", t.ClickID != "" || t.Twclid != "" || t.Gclid != "" || t.XingtuClickID != "", "invite_code", t.InviteCode)
+		"paid", t.ClickID != "" || t.Twclid != "" || t.Gclid != "" || t.XingtuClickID != "" || t.OceanengineClickID != "", "invite_code", t.InviteCode)
 	// The token is now durably created; report this server-confirmed funnel
 	// stage to X when it came from an X ad click.
 	fireXAdsTokenCreatedCallback(t.Token)
@@ -186,6 +196,7 @@ func reportInstall(_ context.Context, c *app.RequestContext) {
 	// per ref; retried by later reports if a prior attempt failed).
 	fireXHSCallback(t.Token, EventInstall)
 	fireXingtuCallback(t.Token, "1") // registration: server-confirmed first report
+	fireOceanengineCallback(t.Token, oceanengineEventRegister)
 	fireXAdsInstallCallback(t.Token)
 	fireGoogleAdsInstallCallback(t.Token)
 	// Registration attribution: the CLI's login-time report carries agent_id,
@@ -241,6 +252,7 @@ func reportCopy(_ context.Context, c *app.RequestContext) {
 		event("install_copy", t.Token, "channel", t.Channel)
 		fireXHSCallback(t.Token, EventCopy) // shallow conversion (101)
 		fireXingtuCallback(t.Token, "0")    // activation: confirmed command copy
+		fireOceanengineCallback(t.Token, oceanengineEventActive)
 		// Copy was confirmed by the server and is idempotent per ref.
 		fireXAdsCopyCommandCallback(t.Token)
 	}

--- a/api/install/models.go
+++ b/api/install/models.go
@@ -29,14 +29,22 @@ type Token struct {
 	// not be confused with Xiaohongshu ClickID. It maps to the existing
 	// xingtu_callback column for schema compatibility; the column now stores the
 	// real landing clickid rather than the obsolete server-monitor macro.
-	ClickID                string `gorm:"column:click_id;not null;default:''"`
-	Twclid                 string `gorm:"column:twclid;not null;default:''"`
-	Gclid                  string `gorm:"column:gclid;not null;default:''"`
-	XingtuClickID          string `gorm:"column:xingtu_callback;type:text;not null;default:''"`
-	XingtuCBActivateCode   int    `gorm:"column:xingtu_cb_activate_code;not null;default:-1"`
-	XingtuCBActivateSentAt int64  `gorm:"column:xingtu_cb_activate_sent_at;not null;default:0"`
-	XingtuCBRegisterCode   int    `gorm:"column:xingtu_cb_register_code;not null;default:-1"`
-	XingtuCBRegisterSentAt int64  `gorm:"column:xingtu_cb_register_sent_at;not null;default:0"`
+	ClickID                     string `gorm:"column:click_id;not null;default:''"`
+	Twclid                      string `gorm:"column:twclid;not null;default:''"`
+	Gclid                       string `gorm:"column:gclid;not null;default:''"`
+	XingtuClickID               string `gorm:"column:xingtu_callback;type:text;not null;default:''"`
+	XingtuCBActivateCode        int    `gorm:"column:xingtu_cb_activate_code;not null;default:-1"`
+	XingtuCBActivateSentAt      int64  `gorm:"column:xingtu_cb_activate_sent_at;not null;default:0"`
+	XingtuCBRegisterCode        int    `gorm:"column:xingtu_cb_register_code;not null;default:-1"`
+	XingtuCBRegisterSentAt      int64  `gorm:"column:xingtu_cb_register_sent_at;not null;default:0"`
+	OceanengineClickID          string `gorm:"column:oceanengine_click_id;type:text;not null;default:''"`
+	OceanengineAdID             string `gorm:"column:oceanengine_ad_id;not null;default:''"`
+	OceanengineCreativeID       string `gorm:"column:oceanengine_creative_id;not null;default:''"`
+	OceanengineCreativeType     string `gorm:"column:oceanengine_creative_type;not null;default:''"`
+	OceanengineCBActiveCode     int    `gorm:"column:oceanengine_cb_active_code;not null;default:-1"`
+	OceanengineCBActiveSentAt   int64  `gorm:"column:oceanengine_cb_active_sent_at;not null;default:0"`
+	OceanengineCBRegisterCode   int    `gorm:"column:oceanengine_cb_register_code;not null;default:-1"`
+	OceanengineCBRegisterSentAt int64  `gorm:"column:oceanengine_cb_register_sent_at;not null;default:0"`
 	// Lang is the entry language the visitor saw on the landing page ('en'/'zh'),
 	// for per-language conversion breakdown.
 	Lang string `gorm:"column:lang;not null;default:''"`

--- a/api/install/oceanengine.go
+++ b/api/install/oceanengine.go
@@ -1,0 +1,114 @@
+package install
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/logger"
+)
+
+const (
+	oceanengineConversionURL    = "https://analytics.oceanengine.com/api/v2/conversion"
+	oceanengineEventActive      = "active"
+	oceanengineEventRegister    = "active_register"
+	oceanengineClickIDMaxLength = 2048
+)
+
+var (
+	oceanengineEnabled bool
+	oceanengineHTTP    = &http.Client{Timeout: 8 * time.Second}
+)
+
+func initOceanengineConfig() {
+	oceanengineEnabled = strings.EqualFold(envStr("OCEANENGINE_CALLBACK_ENABLED", "true"), "true")
+}
+
+func normalizeOceanengineClickID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > oceanengineClickIDMaxLength {
+		return ""
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return ""
+		}
+	}
+	return value
+}
+
+func fireOceanengineCallback(ref, eventType string) {
+	if !oceanengineEnabled {
+		return
+	}
+	go func() {
+		won, tok, err := claimOceanengineCallback(db.DB, ref, eventType)
+		if err != nil {
+			logger.Default().Error("oceanengine callback claim failed", "ref", ref, "event_type", eventType, "err", err)
+			return
+		}
+		if !won || tok.OceanengineClickID == "" {
+			return
+		}
+		code, err := reportOceanengineConversion(tok.OceanengineClickID, eventType, time.Now().UnixMilli())
+		if err != nil {
+			logger.Default().Error("oceanengine callback failed", "ref", ref, "event_type", eventType, "code", code, "err", err)
+		}
+		if err := setOceanengineCallbackCode(db.DB, ref, eventType, code); err != nil {
+			logger.Default().Error("oceanengine callback state update failed", "ref", ref, "event_type", eventType, "err", err)
+		}
+		if code == 0 {
+			event("install_callback_oceanengine", ref, "channel", tok.Channel, "event_type", eventType)
+		}
+	}()
+}
+
+func reportOceanengineConversion(clickID, eventType string, timestamp int64) (int, error) {
+	payload := struct {
+		EventType string `json:"event_type"`
+		Context   struct {
+			Ad struct {
+				Callback string `json:"callback"`
+			} `json:"ad"`
+		} `json:"context"`
+		Timestamp int64 `json:"timestamp"`
+	}{EventType: eventType, Timestamp: timestamp}
+	payload.Context.Ad.Callback = clickID
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return -2, err
+	}
+	req, err := http.NewRequest(http.MethodPost, oceanengineConversionURL, bytes.NewReader(body))
+	if err != nil {
+		return -2, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := oceanengineHTTP.Do(req)
+	if err != nil {
+		return -2, err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return -2, err
+	}
+	var result struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return -2, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resp.StatusCode, fmt.Errorf("oceanengine HTTP %d: %s", resp.StatusCode, result.Message)
+	}
+	if result.Code != 0 {
+		return result.Code, fmt.Errorf("oceanengine code=%d: %s", result.Code, result.Message)
+	}
+	return 0, nil
+}

--- a/api/install/oceanengine.go
+++ b/api/install/oceanengine.go
@@ -55,7 +55,8 @@ func fireOceanengineCallback(ref, eventType string) {
 		if !won || tok.OceanengineClickID == "" {
 			return
 		}
-		code, err := reportOceanengineConversion(tok.OceanengineClickID, eventType, time.Now().UnixMilli())
+		timestamp := oceanengineEventTimestamp(tok, eventType)
+		code, err := reportOceanengineConversion(tok.OceanengineClickID, eventType, timestamp)
 		if err != nil {
 			logger.Default().Error("oceanengine callback failed", "ref", ref, "event_type", eventType, "code", code, "err", err)
 		}
@@ -66,6 +67,13 @@ func fireOceanengineCallback(ref, eventType string) {
 			event("install_callback_oceanengine", ref, "channel", tok.Channel, "event_type", eventType)
 		}
 	}()
+}
+
+func oceanengineEventTimestamp(tok *Token, eventType string) int64 {
+	if eventType == oceanengineEventRegister {
+		return tok.ReportedAt
+	}
+	return tok.CopiedAt
 }
 
 func reportOceanengineConversion(clickID, eventType string, timestamp int64) (int, error) {

--- a/api/install/oceanengine_test.go
+++ b/api/install/oceanengine_test.go
@@ -1,0 +1,66 @@
+package install
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeOceanengineClickID(t *testing.T) {
+	if got := normalizeOceanengineClickID("  oe-click-123  "); got != "oe-click-123" {
+		t.Fatalf("trimmed clickid = %q", got)
+	}
+	if got := normalizeOceanengineClickID("bad\nclick"); got != "" {
+		t.Fatalf("control-character clickid must be rejected, got %q", got)
+	}
+}
+
+func TestReportOceanengineConversion(t *testing.T) {
+	var method, contentType string
+	var payload struct {
+		EventType string `json:"event_type"`
+		Context   struct {
+			Ad struct {
+				Callback string `json:"callback"`
+			} `json:"ad"`
+		} `json:"context"`
+		Timestamp int64 `json:"timestamp"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, contentType = r.Method, r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "message": "success"})
+	}))
+	defer srv.Close()
+
+	oldClient := oceanengineHTTP
+	oceanengineHTTP = srv.Client()
+	defer func() { oceanengineHTTP = oldClient }()
+	oceanengineHTTP.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = "http"
+		req.URL.Host = strings.TrimPrefix(srv.URL, "http://")
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	code, err := reportOceanengineConversion("real-oceanengine-clickid", oceanengineEventActive, 1604888786102)
+	if err != nil || code != 0 {
+		t.Fatalf("code=%d err=%v", code, err)
+	}
+	if method != http.MethodPost || contentType != "application/json" {
+		t.Fatalf("method=%q content-type=%q", method, contentType)
+	}
+	if payload.EventType != "active" || payload.Context.Ad.Callback != "real-oceanengine-clickid" || payload.Timestamp != 1604888786102 {
+		t.Fatalf("payload=%+v", payload)
+	}
+}
+
+func TestOceanengineCallbackCols(t *testing.T) {
+	if code, sent := oceanengineCallbackCols(oceanengineEventActive); code != "oceanengine_cb_active_code" || sent != "oceanengine_cb_active_sent_at" {
+		t.Fatalf("active columns = %s, %s", code, sent)
+	}
+	if code, sent := oceanengineCallbackCols(oceanengineEventRegister); code != "oceanengine_cb_register_code" || sent != "oceanengine_cb_register_sent_at" {
+		t.Fatalf("register columns = %s, %s", code, sent)
+	}
+}

--- a/api/install/oceanengine_test.go
+++ b/api/install/oceanengine_test.go
@@ -17,6 +17,16 @@ func TestNormalizeOceanengineClickID(t *testing.T) {
 	}
 }
 
+func TestOceanengineEventTimestamp(t *testing.T) {
+	tok := &Token{CopiedAt: 1604888786102, ReportedAt: 1604888888000}
+	if got := oceanengineEventTimestamp(tok, oceanengineEventActive); got != tok.CopiedAt {
+		t.Fatalf("active timestamp = %d, want %d", got, tok.CopiedAt)
+	}
+	if got := oceanengineEventTimestamp(tok, oceanengineEventRegister); got != tok.ReportedAt {
+		t.Fatalf("active_register timestamp = %d, want %d", got, tok.ReportedAt)
+	}
+}
+
 func TestReportOceanengineConversion(t *testing.T) {
 	var method, contentType string
 	var payload struct {

--- a/api/install/store.go
+++ b/api/install/store.go
@@ -246,3 +246,32 @@ func setXingtuCallbackCode(db *gorm.DB, ref, eventType string, code int) error {
 	codeCol, _ := xingtuCallbackCols(eventType)
 	return db.Model(&Token{}).Where("token = ?", ref).Update(codeCol, code).Error
 }
+
+const oceanengineCallbackLease = time.Minute
+
+func oceanengineCallbackCols(eventType string) (codeCol, sentCol string) {
+	if eventType == oceanengineEventRegister {
+		return "oceanengine_cb_register_code", "oceanengine_cb_register_sent_at"
+	}
+	return "oceanengine_cb_active_code", "oceanengine_cb_active_sent_at"
+}
+
+func claimOceanengineCallback(db *gorm.DB, ref, eventType string) (bool, *Token, error) {
+	codeCol, sentCol := oceanengineCallbackCols(eventType)
+	now := time.Now().UnixMilli()
+	cutoff := now - oceanengineCallbackLease.Milliseconds()
+	res := db.Model(&Token{}).Where(fmt.Sprintf("token = ? AND %s <> 0 AND oceanengine_click_id <> '' AND (%s = 0 OR %s < ?)", codeCol, sentCol, sentCol), ref, cutoff).Update(sentCol, now)
+	if res.Error != nil || res.RowsAffected == 0 {
+		return false, nil, res.Error
+	}
+	var tok Token
+	if err := db.Where("token = ?", ref).First(&tok).Error; err != nil {
+		return false, nil, err
+	}
+	return true, &tok, nil
+}
+
+func setOceanengineCallbackCode(db *gorm.DB, ref, eventType string, code int) error {
+	codeCol, _ := oceanengineCallbackCols(eventType)
+	return db.Model(&Token{}).Where("token = ?", ref).Update(codeCol, code).Error
+}

--- a/api/install/token.go
+++ b/api/install/token.go
@@ -102,9 +102,12 @@ func normalizeChannel(utmSource string) string {
 // deriveChannel resolves the channel bucket for a mint. An explicit utm_source
 // wins. Otherwise each platform's dedicated click identifier selects its own
 // bucket; Xingtu clickid must not fall through to Xiaohongshu attribution.
-func deriveChannel(utmSource, clickID, twclid, gclid, xingtuClickID string) string {
+func deriveChannel(utmSource, clickID, twclid, gclid, xingtuClickID, oceanengineClickID string) string {
 	c := normalizeChannel(utmSource)
 	if c == "unknown" {
+		if oceanengineClickID != "" {
+			return "oceanengine"
+		}
 		if xingtuClickID != "" {
 			return "xingtu"
 		}

--- a/api/install/token_test.go
+++ b/api/install/token_test.go
@@ -6,22 +6,23 @@ import "testing"
 // absent, a platform click identifier determines the paid channel.
 func TestDeriveChannel(t *testing.T) {
 	cases := []struct {
-		name                              string
-		src, click, twclid, gclid, xingtu string
-		want                              string
+		name                                           string
+		src, click, twclid, gclid, xingtu, oceanengine string
+		want                                           string
 	}{
-		{"explicit xhs", "xiaohongshu", "cid", "", "", "", "xiaohongshu"},
-		{"alias xhs", "xhs", "", "", "", "", "xiaohongshu"},
-		{"xingtu clickid infers xingtu", "", "", "", "", "xt123", "xingtu"},
-		{"click id infers xhs", "", "cid123", "", "", "", "xiaohongshu"},
-		{"twclid infers twitter", "", "", "tw123", "", "", "twitter"},
-		{"gclid infers google", "", "", "", "gcl123", "", "google"},
-		{"explicit source wins", "weibo", "cid", "", "gcl123", "xt123", "weibo"},
-		{"no signal is unknown", "", "", "", "", "", "unknown"},
+		{"explicit xhs", "xiaohongshu", "cid", "", "", "", "", "xiaohongshu"},
+		{"alias xhs", "xhs", "", "", "", "", "", "xiaohongshu"},
+		{"oceanengine clickid infers oceanengine", "", "", "", "", "", "oe123", "oceanengine"},
+		{"xingtu clickid infers xingtu", "", "", "", "", "xt123", "", "xingtu"},
+		{"click id infers xhs", "", "cid123", "", "", "", "", "xiaohongshu"},
+		{"twclid infers twitter", "", "", "tw123", "", "", "", "twitter"},
+		{"gclid infers google", "", "", "", "gcl123", "", "", "google"},
+		{"explicit source wins", "weibo", "cid", "", "gcl123", "xt123", "oe123", "weibo"},
+		{"no signal is unknown", "", "", "", "", "", "", "unknown"},
 	}
 	for _, c := range cases {
-		if got := deriveChannel(c.src, c.click, c.twclid, c.gclid, c.xingtu); got != c.want {
-			t.Errorf("%s: deriveChannel(%q,%q,%q,%q,%q)=%q want %q", c.name, c.src, c.click, c.twclid, c.gclid, c.xingtu, got, c.want)
+		if got := deriveChannel(c.src, c.click, c.twclid, c.gclid, c.xingtu, c.oceanengine); got != c.want {
+			t.Errorf("%s: deriveChannel(...)=%q want %q", c.name, got, c.want)
 		}
 	}
 }

--- a/migrations/000061_oceanengine_callbacks.sql
+++ b/migrations/000061_oceanengine_callbacks.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+ALTER TABLE install_tokens
+    ADD COLUMN IF NOT EXISTS oceanengine_click_id TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS oceanengine_ad_id VARCHAR(128) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS oceanengine_creative_id VARCHAR(128) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS oceanengine_creative_type VARCHAR(64) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS oceanengine_cb_active_code INT NOT NULL DEFAULT -1,
+    ADD COLUMN IF NOT EXISTS oceanengine_cb_active_sent_at BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS oceanengine_cb_register_code INT NOT NULL DEFAULT -1,
+    ADD COLUMN IF NOT EXISTS oceanengine_cb_register_sent_at BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE install_tokens
+    DROP COLUMN IF EXISTS oceanengine_cb_register_sent_at,
+    DROP COLUMN IF EXISTS oceanengine_cb_register_code,
+    DROP COLUMN IF EXISTS oceanengine_cb_active_sent_at,
+    DROP COLUMN IF EXISTS oceanengine_cb_active_code,
+    DROP COLUMN IF EXISTS oceanengine_creative_type,
+    DROP COLUMN IF EXISTS oceanengine_creative_id,
+    DROP COLUMN IF EXISTS oceanengine_ad_id,
+    DROP COLUMN IF EXISTS oceanengine_click_id;


### PR DESCRIPTION
## Description
- capture Ocean Engine H5 attribution separately from Xingtu
- report `active` on confirmed install-command copy
- report `active_register` on the first install report
- persist callback results with retry leases and idempotency
- add database migration for attribution and callback state

## Testing
- [x] Added focused unit tests for payload and attribution behavior
- [x] `git diff --check`
- [ ] Backend unit test execution (dependency downloads timed out before tests started)
- [x] No production conversion test data sent
