### PR TITLE
fix(install): use Ocean Engine lead events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,9 @@ LOKI_URL=http://localhost:3122
 # Ocean Engine H5 conversion callbacks. Enabled by default and only fires for
 # install tokens carrying the dedicated oceanengine_click_id landing parameter.
 OCEANENGINE_CALLBACK_ENABLED=true
+# Required for the separate omnichannel attribution callback. Obtain this
+# server-only token from Ocean Engine's omnichannel attribution workspace.
+OCEANENGINE_OMNICHANNEL_AUTH_TOKEN=
 
 
 # Google Ads offline conversion upload (server-only secrets; do not expose to Vite/browser code)

--- a/api/install/handlers.go
+++ b/api/install/handlers.go
@@ -196,7 +196,7 @@ func reportInstall(_ context.Context, c *app.RequestContext) {
 	// per ref; retried by later reports if a prior attempt failed).
 	fireXHSCallback(t.Token, EventInstall)
 	fireXingtuCallback(t.Token, "1") // registration: server-confirmed first report
-	fireOceanengineCallback(t.Token, oceanengineEventRegister)
+	fireOceanengineCallbacks(t.Token, oceanengineEventCustomerEffective)
 	fireXAdsInstallCallback(t.Token)
 	fireGoogleAdsInstallCallback(t.Token)
 	// Registration attribution: the CLI's login-time report carries agent_id,
@@ -252,7 +252,7 @@ func reportCopy(_ context.Context, c *app.RequestContext) {
 		event("install_copy", t.Token, "channel", t.Channel)
 		fireXHSCallback(t.Token, EventCopy) // shallow conversion (101)
 		fireXingtuCallback(t.Token, "0")    // activation: confirmed command copy
-		fireOceanengineCallback(t.Token, oceanengineEventActive)
+		fireOceanengineCallbacks(t.Token, oceanengineEventForm)
 		// Copy was confirmed by the server and is idempotent per ref.
 		fireXAdsCopyCommandCallback(t.Token)
 	}

--- a/api/install/models.go
+++ b/api/install/models.go
@@ -29,22 +29,26 @@ type Token struct {
 	// not be confused with Xiaohongshu ClickID. It maps to the existing
 	// xingtu_callback column for schema compatibility; the column now stores the
 	// real landing clickid rather than the obsolete server-monitor macro.
-	ClickID                     string `gorm:"column:click_id;not null;default:''"`
-	Twclid                      string `gorm:"column:twclid;not null;default:''"`
-	Gclid                       string `gorm:"column:gclid;not null;default:''"`
-	XingtuClickID               string `gorm:"column:xingtu_callback;type:text;not null;default:''"`
-	XingtuCBActivateCode        int    `gorm:"column:xingtu_cb_activate_code;not null;default:-1"`
-	XingtuCBActivateSentAt      int64  `gorm:"column:xingtu_cb_activate_sent_at;not null;default:0"`
-	XingtuCBRegisterCode        int    `gorm:"column:xingtu_cb_register_code;not null;default:-1"`
-	XingtuCBRegisterSentAt      int64  `gorm:"column:xingtu_cb_register_sent_at;not null;default:0"`
-	OceanengineClickID          string `gorm:"column:oceanengine_click_id;type:text;not null;default:''"`
-	OceanengineAdID             string `gorm:"column:oceanengine_ad_id;not null;default:''"`
-	OceanengineCreativeID       string `gorm:"column:oceanengine_creative_id;not null;default:''"`
-	OceanengineCreativeType     string `gorm:"column:oceanengine_creative_type;not null;default:''"`
-	OceanengineCBActiveCode     int    `gorm:"column:oceanengine_cb_active_code;not null;default:-1"`
-	OceanengineCBActiveSentAt   int64  `gorm:"column:oceanengine_cb_active_sent_at;not null;default:0"`
-	OceanengineCBRegisterCode   int    `gorm:"column:oceanengine_cb_register_code;not null;default:-1"`
-	OceanengineCBRegisterSentAt int64  `gorm:"column:oceanengine_cb_register_sent_at;not null;default:0"`
+	ClickID                       string `gorm:"column:click_id;not null;default:''"`
+	Twclid                        string `gorm:"column:twclid;not null;default:''"`
+	Gclid                         string `gorm:"column:gclid;not null;default:''"`
+	XingtuClickID                 string `gorm:"column:xingtu_callback;type:text;not null;default:''"`
+	XingtuCBActivateCode          int    `gorm:"column:xingtu_cb_activate_code;not null;default:-1"`
+	XingtuCBActivateSentAt        int64  `gorm:"column:xingtu_cb_activate_sent_at;not null;default:0"`
+	XingtuCBRegisterCode          int    `gorm:"column:xingtu_cb_register_code;not null;default:-1"`
+	XingtuCBRegisterSentAt        int64  `gorm:"column:xingtu_cb_register_sent_at;not null;default:0"`
+	OceanengineClickID            string `gorm:"column:oceanengine_click_id;type:text;not null;default:''"`
+	OceanengineAdID               string `gorm:"column:oceanengine_ad_id;not null;default:''"`
+	OceanengineCreativeID         string `gorm:"column:oceanengine_creative_id;not null;default:''"`
+	OceanengineCreativeType       string `gorm:"column:oceanengine_creative_type;not null;default:''"`
+	OceanengineH5FormCode         int    `gorm:"column:oceanengine_h5_form_code;not null;default:-1"`
+	OceanengineH5FormSentAt       int64  `gorm:"column:oceanengine_h5_form_sent_at;not null;default:0"`
+	OceanengineH5CustomerCode     int    `gorm:"column:oceanengine_h5_customer_code;not null;default:-1"`
+	OceanengineH5CustomerSentAt   int64  `gorm:"column:oceanengine_h5_customer_sent_at;not null;default:0"`
+	OceanengineOmniFormCode       int    `gorm:"column:oceanengine_omni_form_code;not null;default:-1"`
+	OceanengineOmniFormSentAt     int64  `gorm:"column:oceanengine_omni_form_sent_at;not null;default:0"`
+	OceanengineOmniCustomerCode   int    `gorm:"column:oceanengine_omni_customer_code;not null;default:-1"`
+	OceanengineOmniCustomerSentAt int64  `gorm:"column:oceanengine_omni_customer_sent_at;not null;default:0"`
 	// Lang is the entry language the visitor saw on the landing page ('en'/'zh'),
 	// for per-language conversion breakdown.
 	Lang string `gorm:"column:lang;not null;default:''"`

--- a/api/install/oceanengine.go
+++ b/api/install/oceanengine.go
@@ -14,19 +14,24 @@ import (
 )
 
 const (
-	oceanengineConversionURL    = "https://analytics.oceanengine.com/api/v2/conversion"
-	oceanengineEventActive      = "active"
-	oceanengineEventRegister    = "active_register"
-	oceanengineClickIDMaxLength = 2048
+	oceanengineH5ConversionURL        = "https://analytics.oceanengine.com/api/v2/conversion"
+	oceanengineOmnichannelURL         = "https://analytics.oceanengine.com/api/v1/attribution"
+	oceanengineEventForm              = "form"
+	oceanengineEventCustomerEffective = "customer_effective"
+	oceanengineDestinationH5          = "h5"
+	oceanengineDestinationOmnichannel = "omnichannel"
+	oceanengineClickIDMaxLength       = 2048
 )
 
 var (
-	oceanengineEnabled bool
-	oceanengineHTTP    = &http.Client{Timeout: 8 * time.Second}
+	oceanengineEnabled              bool
+	oceanengineOmnichannelAuthToken string
+	oceanengineHTTP                 = &http.Client{Timeout: 8 * time.Second}
 )
 
 func initOceanengineConfig() {
 	oceanengineEnabled = strings.EqualFold(envStr("OCEANENGINE_CALLBACK_ENABLED", "true"), "true")
+	oceanengineOmnichannelAuthToken = strings.TrimSpace(envStr("OCEANENGINE_OMNICHANNEL_AUTH_TOKEN", ""))
 }
 
 func normalizeOceanengineClickID(value string) string {
@@ -42,41 +47,53 @@ func normalizeOceanengineClickID(value string) string {
 	return value
 }
 
-func fireOceanengineCallback(ref, eventType string) {
+func fireOceanengineCallbacks(ref, eventType string) {
 	if !oceanengineEnabled {
 		return
 	}
+	fireOceanengineCallback(ref, oceanengineDestinationH5, eventType)
+	if oceanengineOmnichannelAuthToken != "" {
+		fireOceanengineCallback(ref, oceanengineDestinationOmnichannel, eventType)
+	}
+}
+
+func fireOceanengineCallback(ref, destination, eventType string) {
 	go func() {
-		won, tok, err := claimOceanengineCallback(db.DB, ref, eventType)
+		won, tok, err := claimOceanengineCallback(db.DB, ref, destination, eventType)
 		if err != nil {
-			logger.Default().Error("oceanengine callback claim failed", "ref", ref, "event_type", eventType, "err", err)
+			logger.Default().Error("oceanengine callback claim failed", "ref", ref, "destination", destination, "event_type", eventType, "err", err)
 			return
 		}
 		if !won || tok.OceanengineClickID == "" {
 			return
 		}
 		timestamp := oceanengineEventTimestamp(tok, eventType)
-		code, err := reportOceanengineConversion(tok.OceanengineClickID, eventType, timestamp)
-		if err != nil {
-			logger.Default().Error("oceanengine callback failed", "ref", ref, "event_type", eventType, "code", code, "err", err)
+		var code int
+		if destination == oceanengineDestinationOmnichannel {
+			code, err = reportOceanengineOmnichannelConversion(tok.OceanengineClickID, eventType, timestamp, oceanengineOmnichannelAuthToken)
+		} else {
+			code, err = reportOceanengineH5Conversion(tok.OceanengineClickID, eventType, timestamp)
 		}
-		if err := setOceanengineCallbackCode(db.DB, ref, eventType, code); err != nil {
-			logger.Default().Error("oceanengine callback state update failed", "ref", ref, "event_type", eventType, "err", err)
+		if err != nil {
+			logger.Default().Error("oceanengine callback failed", "ref", ref, "destination", destination, "event_type", eventType, "code", code, "err", err)
+		}
+		if err := setOceanengineCallbackCode(db.DB, ref, destination, eventType, code); err != nil {
+			logger.Default().Error("oceanengine callback state update failed", "ref", ref, "destination", destination, "event_type", eventType, "err", err)
 		}
 		if code == 0 {
-			event("install_callback_oceanengine", ref, "channel", tok.Channel, "event_type", eventType)
+			event("install_callback_oceanengine", ref, "channel", tok.Channel, "destination", destination, "event_type", eventType)
 		}
 	}()
 }
 
 func oceanengineEventTimestamp(tok *Token, eventType string) int64 {
-	if eventType == oceanengineEventRegister {
+	if eventType == oceanengineEventCustomerEffective {
 		return tok.ReportedAt
 	}
 	return tok.CopiedAt
 }
 
-func reportOceanengineConversion(clickID, eventType string, timestamp int64) (int, error) {
+func reportOceanengineH5Conversion(clickID, eventType string, timestamp int64) (int, error) {
 	payload := struct {
 		EventType string `json:"event_type"`
 		Context   struct {
@@ -87,11 +104,49 @@ func reportOceanengineConversion(clickID, eventType string, timestamp int64) (in
 		Timestamp int64 `json:"timestamp"`
 	}{EventType: eventType, Timestamp: timestamp}
 	payload.Context.Ad.Callback = clickID
+	return postOceanengineJSON(oceanengineH5ConversionURL, payload)
+}
+
+func reportOceanengineOmnichannelConversion(clickID, eventType string, timestampMS int64, authToken string) (int, error) {
+	timestampSeconds := timestampMS / 1000
+	payload := struct {
+		EventType string `json:"event_type"`
+		BizType   int    `json:"biz_type"`
+		Context   struct {
+			Ad struct {
+				ClickID   string `json:"clickid"`
+				AuthToken string `json:"auth_token"`
+			} `json:"ad"`
+		} `json:"context"`
+		Properties struct {
+			AuthToken string `json:"auth_token"`
+			EventTime int64  `json:"event_time"`
+			ClickID   string `json:"clickid"`
+		} `json:"properties"`
+		AttributeLabel string `json:"attribute_label"`
+		Source         string `json:"source"`
+		Timestamp      int64  `json:"timestamp"`
+	}{
+		EventType:      eventType,
+		BizType:        23,
+		AttributeLabel: "convert",
+		Source:         "oto",
+		Timestamp:      timestampSeconds,
+	}
+	payload.Context.Ad.ClickID = clickID
+	payload.Context.Ad.AuthToken = authToken
+	payload.Properties.AuthToken = authToken
+	payload.Properties.EventTime = timestampSeconds
+	payload.Properties.ClickID = clickID
+	return postOceanengineJSON(oceanengineOmnichannelURL, payload)
+}
+
+func postOceanengineJSON(url string, payload interface{}) (int, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return -2, err
 	}
-	req, err := http.NewRequest(http.MethodPost, oceanengineConversionURL, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return -2, err
 	}

--- a/api/install/oceanengine_test.go
+++ b/api/install/oceanengine_test.go
@@ -19,16 +19,16 @@ func TestNormalizeOceanengineClickID(t *testing.T) {
 
 func TestOceanengineEventTimestamp(t *testing.T) {
 	tok := &Token{CopiedAt: 1604888786102, ReportedAt: 1604888888000}
-	if got := oceanengineEventTimestamp(tok, oceanengineEventActive); got != tok.CopiedAt {
-		t.Fatalf("active timestamp = %d, want %d", got, tok.CopiedAt)
+	if got := oceanengineEventTimestamp(tok, oceanengineEventForm); got != tok.CopiedAt {
+		t.Fatalf("form timestamp = %d, want %d", got, tok.CopiedAt)
 	}
-	if got := oceanengineEventTimestamp(tok, oceanengineEventRegister); got != tok.ReportedAt {
-		t.Fatalf("active_register timestamp = %d, want %d", got, tok.ReportedAt)
+	if got := oceanengineEventTimestamp(tok, oceanengineEventCustomerEffective); got != tok.ReportedAt {
+		t.Fatalf("customer_effective timestamp = %d, want %d", got, tok.ReportedAt)
 	}
 }
 
-func TestReportOceanengineConversion(t *testing.T) {
-	var method, contentType string
+func TestReportOceanengineH5Conversion(t *testing.T) {
+	var method, contentType, path string
 	var payload struct {
 		EventType string `json:"event_type"`
 		Context   struct {
@@ -38,13 +38,86 @@ func TestReportOceanengineConversion(t *testing.T) {
 		} `json:"context"`
 		Timestamp int64 `json:"timestamp"`
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		method, contentType = r.Method, r.Header.Get("Content-Type")
+	withOceanengineServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method, contentType, path = r.Method, r.Header.Get("Content-Type"), r.URL.Path
 		_ = json.NewDecoder(r.Body).Decode(&payload)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "message": "success"})
-	}))
-	defer srv.Close()
+	}, func() {
+		code, err := reportOceanengineH5Conversion("real-oceanengine-clickid", oceanengineEventForm, 1604888786102)
+		if err != nil || code != 0 {
+			t.Fatalf("code=%d err=%v", code, err)
+		}
+	})
+	if method != http.MethodPost || contentType != "application/json" || path != "/api/v2/conversion" {
+		t.Fatalf("method=%q content-type=%q path=%q", method, contentType, path)
+	}
+	if payload.EventType != "form" || payload.Context.Ad.Callback != "real-oceanengine-clickid" || payload.Timestamp != 1604888786102 {
+		t.Fatalf("payload=%+v", payload)
+	}
+}
 
+func TestReportOceanengineOmnichannelConversion(t *testing.T) {
+	var path string
+	var payload struct {
+		EventType string `json:"event_type"`
+		BizType   int    `json:"biz_type"`
+		Context   struct {
+			Ad struct {
+				ClickID   string `json:"clickid"`
+				AuthToken string `json:"auth_token"`
+			} `json:"ad"`
+		} `json:"context"`
+		Properties struct {
+			AuthToken string `json:"auth_token"`
+			EventTime int64  `json:"event_time"`
+			ClickID   string `json:"clickid"`
+		} `json:"properties"`
+		AttributeLabel string `json:"attribute_label"`
+		Source         string `json:"source"`
+		Timestamp      int64  `json:"timestamp"`
+	}
+	withOceanengineServer(t, func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "message": "success"})
+	}, func() {
+		code, err := reportOceanengineOmnichannelConversion("oe-click", oceanengineEventCustomerEffective, 1604888786102, "server-secret")
+		if err != nil || code != 0 {
+			t.Fatalf("code=%d err=%v", code, err)
+		}
+	})
+	if path != "/api/v1/attribution" || payload.EventType != "customer_effective" || payload.BizType != 23 {
+		t.Fatalf("path=%q payload=%+v", path, payload)
+	}
+	if payload.Context.Ad.ClickID != "oe-click" || payload.Context.Ad.AuthToken != "server-secret" || payload.Properties.AuthToken != "server-secret" || payload.Properties.ClickID != "oe-click" {
+		t.Fatalf("attribution payload=%+v", payload)
+	}
+	if payload.Timestamp != 1604888786 || payload.Properties.EventTime != 1604888786 || payload.AttributeLabel != "convert" || payload.Source != "oto" {
+		t.Fatalf("timestamps and fixed fields=%+v", payload)
+	}
+}
+
+func TestOceanengineCallbackCols(t *testing.T) {
+	cases := []struct {
+		destination, eventType, code, sent string
+	}{
+		{oceanengineDestinationH5, oceanengineEventForm, "oceanengine_h5_form_code", "oceanengine_h5_form_sent_at"},
+		{oceanengineDestinationH5, oceanengineEventCustomerEffective, "oceanengine_h5_customer_code", "oceanengine_h5_customer_sent_at"},
+		{oceanengineDestinationOmnichannel, oceanengineEventForm, "oceanengine_omni_form_code", "oceanengine_omni_form_sent_at"},
+		{oceanengineDestinationOmnichannel, oceanengineEventCustomerEffective, "oceanengine_omni_customer_code", "oceanengine_omni_customer_sent_at"},
+	}
+	for _, tc := range cases {
+		code, sent := oceanengineCallbackCols(tc.destination, tc.eventType)
+		if code != tc.code || sent != tc.sent {
+			t.Fatalf("%s/%s columns = %s, %s", tc.destination, tc.eventType, code, sent)
+		}
+	}
+}
+
+func withOceanengineServer(t *testing.T, handler http.HandlerFunc, run func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
 	oldClient := oceanengineHTTP
 	oceanengineHTTP = srv.Client()
 	defer func() { oceanengineHTTP = oldClient }()
@@ -53,24 +126,5 @@ func TestReportOceanengineConversion(t *testing.T) {
 		req.URL.Host = strings.TrimPrefix(srv.URL, "http://")
 		return http.DefaultTransport.RoundTrip(req)
 	})
-
-	code, err := reportOceanengineConversion("real-oceanengine-clickid", oceanengineEventActive, 1604888786102)
-	if err != nil || code != 0 {
-		t.Fatalf("code=%d err=%v", code, err)
-	}
-	if method != http.MethodPost || contentType != "application/json" {
-		t.Fatalf("method=%q content-type=%q", method, contentType)
-	}
-	if payload.EventType != "active" || payload.Context.Ad.Callback != "real-oceanengine-clickid" || payload.Timestamp != 1604888786102 {
-		t.Fatalf("payload=%+v", payload)
-	}
-}
-
-func TestOceanengineCallbackCols(t *testing.T) {
-	if code, sent := oceanengineCallbackCols(oceanengineEventActive); code != "oceanengine_cb_active_code" || sent != "oceanengine_cb_active_sent_at" {
-		t.Fatalf("active columns = %s, %s", code, sent)
-	}
-	if code, sent := oceanengineCallbackCols(oceanengineEventRegister); code != "oceanengine_cb_register_code" || sent != "oceanengine_cb_register_sent_at" {
-		t.Fatalf("register columns = %s, %s", code, sent)
-	}
+	run()
 }

--- a/api/install/store.go
+++ b/api/install/store.go
@@ -249,15 +249,20 @@ func setXingtuCallbackCode(db *gorm.DB, ref, eventType string, code int) error {
 
 const oceanengineCallbackLease = time.Minute
 
-func oceanengineCallbackCols(eventType string) (codeCol, sentCol string) {
-	if eventType == oceanengineEventRegister {
-		return "oceanengine_cb_register_code", "oceanengine_cb_register_sent_at"
+func oceanengineCallbackCols(destination, eventType string) (codeCol, sentCol string) {
+	prefix := "oceanengine_h5"
+	if destination == oceanengineDestinationOmnichannel {
+		prefix = "oceanengine_omni"
 	}
-	return "oceanengine_cb_active_code", "oceanengine_cb_active_sent_at"
+	suffix := "form"
+	if eventType == oceanengineEventCustomerEffective {
+		suffix = "customer"
+	}
+	return prefix + "_" + suffix + "_code", prefix + "_" + suffix + "_sent_at"
 }
 
-func claimOceanengineCallback(db *gorm.DB, ref, eventType string) (bool, *Token, error) {
-	codeCol, sentCol := oceanengineCallbackCols(eventType)
+func claimOceanengineCallback(db *gorm.DB, ref, destination, eventType string) (bool, *Token, error) {
+	codeCol, sentCol := oceanengineCallbackCols(destination, eventType)
 	now := time.Now().UnixMilli()
 	cutoff := now - oceanengineCallbackLease.Milliseconds()
 	res := db.Model(&Token{}).Where(fmt.Sprintf("token = ? AND %s <> 0 AND oceanengine_click_id <> '' AND (%s = 0 OR %s < ?)", codeCol, sentCol, sentCol), ref, cutoff).Update(sentCol, now)
@@ -271,7 +276,7 @@ func claimOceanengineCallback(db *gorm.DB, ref, eventType string) (bool, *Token,
 	return true, &tok, nil
 }
 
-func setOceanengineCallbackCode(db *gorm.DB, ref, eventType string, code int) error {
-	codeCol, _ := oceanengineCallbackCols(eventType)
+func setOceanengineCallbackCode(db *gorm.DB, ref, destination, eventType string, code int) error {
+	codeCol, _ := oceanengineCallbackCols(destination, eventType)
 	return db.Model(&Token{}).Where("token = ?", ref).Update(codeCol, code).Error
 }

--- a/migrations/000062_oceanengine_lead_callbacks.sql
+++ b/migrations/000062_oceanengine_lead_callbacks.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_cb_active_code TO oceanengine_h5_form_code;
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_cb_active_sent_at TO oceanengine_h5_form_sent_at;
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_cb_register_code TO oceanengine_h5_customer_code;
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_cb_register_sent_at TO oceanengine_h5_customer_sent_at;
+
+UPDATE install_tokens
+SET oceanengine_h5_form_code = -1,
+    oceanengine_h5_form_sent_at = 0,
+    oceanengine_h5_customer_code = -1,
+    oceanengine_h5_customer_sent_at = 0
+WHERE oceanengine_click_id <> '';
+
+ALTER TABLE install_tokens
+    ADD COLUMN IF NOT EXISTS oceanengine_omni_form_code INT NOT NULL DEFAULT -1,
+    ADD COLUMN IF NOT EXISTS oceanengine_omni_form_sent_at BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS oceanengine_omni_customer_code INT NOT NULL DEFAULT -1,
+    ADD COLUMN IF NOT EXISTS oceanengine_omni_customer_sent_at BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE install_tokens
+    DROP COLUMN IF EXISTS oceanengine_omni_customer_sent_at,
+    DROP COLUMN IF EXISTS oceanengine_omni_customer_code,
+    DROP COLUMN IF EXISTS oceanengine_omni_form_sent_at,
+    DROP COLUMN IF EXISTS oceanengine_omni_form_code;
+
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_h5_form_code TO oceanengine_cb_active_code;
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_h5_form_sent_at TO oceanengine_cb_active_sent_at;
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_h5_customer_code TO oceanengine_cb_register_code;
+ALTER TABLE install_tokens
+    RENAME COLUMN oceanengine_h5_customer_sent_at TO oceanengine_cb_register_sent_at;

--- a/migrations/000062_oceanengine_lead_callbacks.sql
+++ b/migrations/000062_oceanengine_lead_callbacks.sql
@@ -36,3 +36,13 @@ ALTER TABLE install_tokens
     RENAME COLUMN oceanengine_h5_customer_code TO oceanengine_cb_register_code;
 ALTER TABLE install_tokens
     RENAME COLUMN oceanengine_h5_customer_sent_at TO oceanengine_cb_register_sent_at;
+
+-- The lead-event success codes do not prove that the legacy activation and
+-- registration events were delivered. Reopen both callbacks so the rolled-back
+-- application can retry the legacy events on the next copy/report trigger.
+UPDATE install_tokens
+SET oceanengine_cb_active_code = -1,
+    oceanengine_cb_active_sent_at = 0,
+    oceanengine_cb_register_code = -1,
+    oceanengine_cb_register_sent_at = 0
+WHERE oceanengine_click_id <> '';


### PR DESCRIPTION
## Description
- replace Ocean Engine activation/registration callbacks with lead events
- map install-command copy to `form`
- map first install report to `customer_effective`
- add the omnichannel attribution callback with a server-only auth token
- migrate and reset the old H5 callback state so the new events are not blocked

## Testing
- [x] `go test ./api/install`
- [x] `git diff --check`
- [x] No production conversion test data sent
