### PR TITLE
fix(install): preserve Ocean Engine entry attribution

### DIFF
--- a/api/install/handlers.go
+++ b/api/install/handlers.go
@@ -50,12 +50,13 @@ func Register(h *server.Hertz, baseURL string) {
 }
 
 type mintBody struct {
-	UTMSource   string `json:"utm_source"`
-	UTMMedium   string `json:"utm_medium"`
-	UTMCampaign string `json:"utm_campaign"`
-	UTMContent  string `json:"utm_content"`
-	UTMTerm     string `json:"utm_term"`
-	Referrer    string `json:"referrer"`
+	UTMSource    string `json:"utm_source"`
+	UTMMedium    string `json:"utm_medium"`
+	UTMCampaign  string `json:"utm_campaign"`
+	UTMContent   string `json:"utm_content"`
+	UTMTerm      string `json:"utm_term"`
+	Referrer     string `json:"referrer"`
+	EntryChannel string `json:"entry_channel"`
 	// Platform click identifiers from the landing URL (paid traffic). Xingtu's
 	// non-app landing page supplies `clickid`; the frontend normalizes it to the
 	// dedicated xingtu_click_id field so it is never confused with Xiaohongshu's
@@ -115,7 +116,7 @@ func mintRef(_ context.Context, c *app.RequestContext) {
 		UTMCampaign:             trunc(body.UTMCampaign, 255),
 		UTMContent:              trunc(body.UTMContent, 255),
 		UTMTerm:                 trunc(body.UTMTerm, 255),
-		Channel:                 deriveChannel(body.UTMSource, body.ClickID, body.Twclid, body.Gclid, xingtuClickID, oceanengineClickID),
+		Channel:                 deriveChannel(body.EntryChannel, body.UTMSource, body.ClickID, body.Twclid, body.Gclid, xingtuClickID, oceanengineClickID),
 		Referrer:                trunc(body.Referrer, 2048),
 		ClickID:                 trunc(body.ClickID, 128),
 		Twclid:                  trunc(body.Twclid, 128),

--- a/api/install/token.go
+++ b/api/install/token.go
@@ -99,10 +99,13 @@ func normalizeChannel(utmSource string) string {
 	return s
 }
 
-// deriveChannel resolves the channel bucket for a mint. An explicit utm_source
-// wins. Otherwise each platform's dedicated click identifier selects its own
-// bucket; Xingtu clickid must not fall through to Xiaohongshu attribution.
-func deriveChannel(utmSource, clickID, twclid, gclid, xingtuClickID, oceanengineClickID string) string {
+// deriveChannel resolves the channel bucket for a mint. A dedicated landing
+// entry is authoritative even when an ad platform drops its dynamic click
+// macros. Otherwise an explicit utm_source wins, followed by platform click IDs.
+func deriveChannel(entryChannel, utmSource, clickID, twclid, gclid, xingtuClickID, oceanengineClickID string) string {
+	if c := normalizeChannel(entryChannel); c != "unknown" {
+		return c
+	}
 	c := normalizeChannel(utmSource)
 	if c == "unknown" {
 		if oceanengineClickID != "" {

--- a/api/install/token_test.go
+++ b/api/install/token_test.go
@@ -6,22 +6,24 @@ import "testing"
 // absent, a platform click identifier determines the paid channel.
 func TestDeriveChannel(t *testing.T) {
 	cases := []struct {
-		name                                           string
-		src, click, twclid, gclid, xingtu, oceanengine string
-		want                                           string
+		name                                                  string
+		entry, src, click, twclid, gclid, xingtu, oceanengine string
+		want                                                  string
 	}{
-		{"explicit xhs", "xiaohongshu", "cid", "", "", "", "", "xiaohongshu"},
-		{"alias xhs", "xhs", "", "", "", "", "", "xiaohongshu"},
-		{"oceanengine clickid infers oceanengine", "", "", "", "", "", "oe123", "oceanengine"},
-		{"xingtu clickid infers xingtu", "", "", "", "", "xt123", "", "xingtu"},
-		{"click id infers xhs", "", "cid123", "", "", "", "", "xiaohongshu"},
-		{"twclid infers twitter", "", "", "tw123", "", "", "", "twitter"},
-		{"gclid infers google", "", "", "", "gcl123", "", "", "google"},
-		{"explicit source wins", "weibo", "cid", "", "gcl123", "xt123", "oe123", "weibo"},
-		{"no signal is unknown", "", "", "", "", "", "", "unknown"},
+		{"dedicated oceanengine entry survives missing macros", "oceanengine", "", "", "", "", "", "", "oceanengine"},
+		{"dedicated entry wins conflicting UTM", "oceanengine", "xiaohongshu", "cid", "", "", "", "", "oceanengine"},
+		{"explicit xhs", "", "xiaohongshu", "cid", "", "", "", "", "xiaohongshu"},
+		{"alias xhs", "", "xhs", "", "", "", "", "", "xiaohongshu"},
+		{"oceanengine clickid infers oceanengine", "", "", "", "", "", "", "oe123", "oceanengine"},
+		{"xingtu clickid infers xingtu", "", "", "", "", "", "xt123", "", "xingtu"},
+		{"click id infers xhs", "", "", "cid123", "", "", "", "", "xiaohongshu"},
+		{"twclid infers twitter", "", "", "", "tw123", "", "", "", "twitter"},
+		{"gclid infers google", "", "", "", "", "gcl123", "", "", "google"},
+		{"explicit source wins", "", "weibo", "cid", "", "gcl123", "xt123", "oe123", "weibo"},
+		{"no signal is unknown", "", "", "", "", "", "", "", "unknown"},
 	}
 	for _, c := range cases {
-		if got := deriveChannel(c.src, c.click, c.twclid, c.gclid, c.xingtu, c.oceanengine); got != c.want {
+		if got := deriveChannel(c.entry, c.src, c.click, c.twclid, c.gclid, c.xingtu, c.oceanengine); got != c.want {
 			t.Errorf("%s: deriveChannel(...)=%q want %q", c.name, got, c.want)
 		}
 	}


### PR DESCRIPTION
## Summary
- preserve Ocean Engine channel attribution through the dedicated landing entry even when ad macros are missing
- keep real Ocean Engine click IDs authoritative for click-level attribution and callbacks
- add coverage for missing macros and conflicting UTM values

## Testing
- [x] /snap/bin/go test ./api/install
- [x] git diff --check