### PR TITLE
fix(pm): persist friend request limit config

### DIFF
--- a/configs/pm/friend_request_limits.example.yaml
+++ b/configs/pm/friend_request_limits.example.yaml
@@ -1,11 +1,13 @@
 # Friend-request hourly rate limits for the PM service.
 #
 # This committed example documents the format only. Production must use the
-# private file configs/pm/friend_request_limits.yaml, which is gitignored so
-# operator-managed agent IDs and limits are never published with the source.
+# private file /etc/eigenflux/friend_request_limits.yaml in production. Local
+# development may use configs/pm/friend_request_limits.yaml, which is gitignored
+# so operator-managed agent IDs and limits are never published with the source.
 #
-# The PM service reads this file once at startup. After changing the private
-# file, restart only the pm service for the update to take effect.
+# The PM service reads this file once at startup. FRIEND_REQUEST_LIMITS_CONFIG
+# may point to another path. After changing the private file, restart only the
+# pm service for the update to take effect.
 
 # Limit for every agent without an override. This protects the service from
 # bulk unsolicited friend requests. Use a positive integer.

--- a/docs/cloud_deployment.md
+++ b/docs/cloud_deployment.md
@@ -214,6 +214,12 @@ Application units use one root-owned binary/source bundle under
 `/var/lib/eigenflux-deployer/current`, so relative runtime assets and `.env`
 are never loaded from the deployment checkout.
 
+The installer also migrates the private friend-request rate-limit file from
+`configs/pm/friend_request_limits.yaml` to the stable root-managed path
+`/etc/eigenflux/friend_request_limits.yaml` on first installation. Existing
+files at the stable path are preserved on later installer runs. The PM service
+loads this stable path independently of the active immutable release.
+
 ## Security Checklist
 
 - [ ] Set `APP_ENV=prod`

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -43,6 +43,7 @@ Default config in `pkg/config/config.go`, override via environment variables:
 | `MOCK_UNIVERSAL_OTP` | `123456` | Fixed verification code when whitelist matched |
 | `MOCK_OTP_EMAIL_SUFFIXES` | -- | Comma-separated email suffix whitelist |
 | `MOCK_OTP_IP_WHITELIST` | -- | Comma-separated IP whitelist |
+| `FRIEND_REQUEST_LIMITS_CONFIG` | Production: `/etc/eigenflux/friend_request_limits.yaml`; non-production: stable path when present, otherwise `configs/pm/friend_request_limits.yaml` | Private per-agent friend-request hourly-limit configuration. Production requires a valid file |
 | `ID_WORKER_PREFIX` | `/eigenflux/idgen/workers` | Snowflake worker_id registration prefix in etcd |
 | `ID_SNOWFLAKE_EPOCH_MS` | -- | Snowflake algorithm custom epoch (milliseconds) |
 | `ID_WORKER_LEASE_TTL` | `30` | worker_id lease TTL (seconds) |

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -33,7 +33,7 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 - **Relations** (`rpc/pm/relations/`): Friend/block relationship queries with caching
 - **DAL** (`rpc/pm/dal/`): Data access for conversations, messages, friend requests
 - **NotifyUtil** (`rpc/pm/notifyutil/`): Friend request notification helpers (writes to `pm:notify:{agent_id}` Redis hash)
-- **Rate-limit config** (`configs/pm/friend_request_limits.yaml`): private, gitignored operator configuration for per-agent friend-request hourly limits; the committed `.example.yaml` documents its format
+- **Rate-limit config** (`/etc/eigenflux/friend_request_limits.yaml` in production; `configs/pm/friend_request_limits.yaml` for local development): private operator configuration for per-agent friend-request hourly limits. `FRIEND_REQUEST_LIMITS_CONFIG` overrides the path. Production startup fails if the file is missing or invalid; the committed `.example.yaml` documents its format
 
 ## Key Behaviors
 

--- a/rpc/pm/main.go
+++ b/rpc/pm/main.go
@@ -96,12 +96,23 @@ func main() {
 	// Create ice breaker and validator
 	iceBreaker := icebreak.NewIceBreaker(db.RDB)
 	pmValidator := validator.NewValidator(db.DB, db.RDB)
-	friendRequestLimits, err := ratelimit.LoadFile(ratelimit.ConfigPath)
+	friendRequestLimitsPath := ratelimit.ResolveConfigPath(cfg.IsProd())
+	friendRequestLimits, err := ratelimit.LoadFile(friendRequestLimitsPath)
 	if errors.Is(err, os.ErrNotExist) {
+		if cfg.IsProd() {
+			log.Fatalf("friend request rate-limit config not found in production: %s", friendRequestLimitsPath)
+		}
 		friendRequestLimits = ratelimit.DefaultConfig()
-		logger.Default().Warn("friend request rate-limit config not found; using defaults", "path", ratelimit.ConfigPath)
+		logger.Default().Warn("friend request rate-limit config not found; using defaults", "path", friendRequestLimitsPath)
 	} else if err != nil {
 		log.Fatalf("failed to load friend request rate-limit config: %v", err)
+	} else {
+		logger.Default().Info(
+			"friend request rate-limit config loaded",
+			"path", friendRequestLimitsPath,
+			"defaultHourlyLimit", friendRequestLimits.DefaultHourlyLimit,
+			"overrideCount", len(friendRequestLimits.Overrides),
+		)
 	}
 
 	// Create etcd registry for this service

--- a/rpc/pm/ratelimit/config.go
+++ b/rpc/pm/ratelimit/config.go
@@ -1,16 +1,49 @@
 package ratelimit
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	DefaultHourlyLimit = 10
-	ConfigPath         = "configs/pm/friend_request_limits.yaml"
+	DefaultHourlyLimit   = 10
+	ConfigPathEnv        = "FRIEND_REQUEST_LIMITS_CONFIG"
+	ProductionConfigPath = "/etc/eigenflux/friend_request_limits.yaml"
+	LegacyConfigPath     = "configs/pm/friend_request_limits.yaml"
 )
+
+// ResolveConfigPath selects the operator-managed friend-request limit file.
+// Production keeps the file outside immutable release directories; the legacy
+// repository-relative path remains available for local development.
+func ResolveConfigPath(production bool) string {
+	return resolveConfigPath(
+		os.Getenv(ConfigPathEnv),
+		production,
+		ProductionConfigPath,
+		LegacyConfigPath,
+		func(path string) error {
+			_, err := os.Stat(path)
+			return err
+		},
+	)
+}
+
+func resolveConfigPath(explicitPath string, production bool, productionPath, legacyPath string, stat func(string) error) string {
+	if path := strings.TrimSpace(explicitPath); path != "" {
+		return path
+	}
+	if production {
+		return productionPath
+	}
+	if err := stat(productionPath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return productionPath
+	}
+	return legacyPath
+}
 
 // Config defines the hourly friend-request limit for all agents and selected overrides.
 type Config struct {

--- a/rpc/pm/ratelimit/config_test.go
+++ b/rpc/pm/ratelimit/config_test.go
@@ -30,3 +30,55 @@ func TestValidateRejectsDuplicateOverrides(t *testing.T) {
 		t.Fatal("expected duplicate override to be rejected")
 	}
 }
+
+func TestResolveConfigPath(t *testing.T) {
+	t.Run("explicit override wins", func(t *testing.T) {
+		got := resolveConfigPath(" /custom/limits.yaml ", true, "/stable/limits.yaml", "legacy.yaml", func(string) error {
+			t.Fatal("stat should not run for an explicit path")
+			return nil
+		})
+		if got != "/custom/limits.yaml" {
+			t.Fatalf("resolveConfigPath() = %q, want explicit path", got)
+		}
+	})
+
+	t.Run("production always uses stable path", func(t *testing.T) {
+		got := resolveConfigPath("", true, "/stable/limits.yaml", "legacy.yaml", func(string) error {
+			t.Fatal("stat should not run in production")
+			return nil
+		})
+		if got != "/stable/limits.yaml" {
+			t.Fatalf("resolveConfigPath() = %q, want stable path", got)
+		}
+	})
+
+	t.Run("stable production path exists", func(t *testing.T) {
+		got := resolveConfigPath("", false, "/stable/limits.yaml", "legacy.yaml", func(path string) error {
+			if path != "/stable/limits.yaml" {
+				t.Fatalf("stat path = %q", path)
+			}
+			return nil
+		})
+		if got != "/stable/limits.yaml" {
+			t.Fatalf("resolveConfigPath() = %q, want stable path", got)
+		}
+	})
+
+	t.Run("stable path errors do not silently fall back", func(t *testing.T) {
+		got := resolveConfigPath("", false, "/stable/limits.yaml", "legacy.yaml", func(string) error {
+			return os.ErrPermission
+		})
+		if got != "/stable/limits.yaml" {
+			t.Fatalf("resolveConfigPath() = %q, want stable path", got)
+		}
+	})
+
+	t.Run("missing stable path uses local legacy path", func(t *testing.T) {
+		got := resolveConfigPath("", false, "/stable/limits.yaml", "legacy.yaml", func(string) error {
+			return os.ErrNotExist
+		})
+		if got != "legacy.yaml" {
+			t.Fatalf("resolveConfigPath() = %q, want legacy path", got)
+		}
+	})
+}

--- a/scripts/cloud/DEPLOYMENT_POLICY.md
+++ b/scripts/cloud/DEPLOYMENT_POLICY.md
@@ -19,9 +19,10 @@ migrations. The official GitHub remote and executable artifact directory are
 fixed in the root-owned deployment files; changing the checkout's `origin` or
 ignored `build/` files cannot change what the service executes.
 
-Production environment values and the pinned GitHub host keys are root-owned
-under `/etc/eigenflux`. Agents must not edit `.env`; configuration changes are
-an explicit root operation followed by a deployment.
+Production environment values, the friend-request rate-limit config, and the
+pinned GitHub host keys are root-owned under `/etc/eigenflux`. Agents must not
+edit `.env`; configuration changes are an explicit root operation followed by
+a deployment.
 
 Application services execute and resolve relative resources from one
 root-owned release bundle under `/var/lib/eigenflux-deployer/current`; they

--- a/scripts/cloud/install_main_deployer.sh
+++ b/scripts/cloud/install_main_deployer.sh
@@ -11,6 +11,8 @@ POLICY_DIR="/etc/eigenflux"
 STATE_DIR="/var/lib/eigenflux-deployer"
 APP_DROPIN_DIR="/etc/systemd/system/eigenflux-app@.service.d"
 RUNTIME_ENV="${POLICY_DIR}/runtime.env"
+FRIEND_REQUEST_LIMITS_CONFIG="${POLICY_DIR}/friend_request_limits.yaml"
+LEGACY_FRIEND_REQUEST_LIMITS_CONFIG="${PROJECT_ROOT}/configs/pm/friend_request_limits.yaml"
 GITHUB_KNOWN_HOSTS="${POLICY_DIR}/github_known_hosts"
 
 if [[ "${EUID}" -ne 0 ]]; then
@@ -47,6 +49,11 @@ command -v ssh-keygen >/dev/null
   echo "${DEPLOY_USER} must connect to github.com once before installation." >&2
   exit 1
 }
+if [[ ! -f "${FRIEND_REQUEST_LIMITS_CONFIG}" && ! -f "${LEGACY_FRIEND_REQUEST_LIMITS_CONFIG}" ]]; then
+  echo "Friend-request rate-limit config is required: ${FRIEND_REQUEST_LIMITS_CONFIG}" >&2
+  echo "Create it from configs/pm/friend_request_limits.example.yaml before installing." >&2
+  exit 1
+fi
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
@@ -67,6 +74,17 @@ ssh-keygen -F github.com -f "${DEPLOY_HOME}/.ssh/known_hosts" | \
 }
 install -o root -g root -m 0644 "${tmp_dir}/github_known_hosts" "${GITHUB_KNOWN_HOSTS}"
 install -o root -g root -m 0600 "${PROJECT_ROOT}/.env" "${RUNTIME_ENV}"
+if [[ -f "${FRIEND_REQUEST_LIMITS_CONFIG}" ]]; then
+  chown root:"${DEPLOY_GROUP}" "${FRIEND_REQUEST_LIMITS_CONFIG}"
+  chmod 0640 "${FRIEND_REQUEST_LIMITS_CONFIG}"
+elif [[ -f "${LEGACY_FRIEND_REQUEST_LIMITS_CONFIG}" ]]; then
+  install -o root -g "${DEPLOY_GROUP}" -m 0640 \
+    "${LEGACY_FRIEND_REQUEST_LIMITS_CONFIG}" "${FRIEND_REQUEST_LIMITS_CONFIG}"
+else
+  echo "Friend-request rate-limit config is required: ${FRIEND_REQUEST_LIMITS_CONFIG}" >&2
+  echo "Create it from configs/pm/friend_request_limits.example.yaml before installing." >&2
+  exit 1
+fi
 # Keep the application's legacy .env lookup read-only and identical to the
 # root-managed deployment environment.
 install -o root -g "${DEPLOY_GROUP}" -m 0640 "${RUNTIME_ENV}" "${PROJECT_ROOT}/.env"

--- a/scripts/cloud/test_deploy_main.sh
+++ b/scripts/cloud/test_deploy_main.sh
@@ -14,6 +14,18 @@ grep -Fq "export PATH='/snap/go/current/bin:" "${SOURCE_ROOT}/scripts/cloud/depl
 }
 echo "PASS: root-managed wrapper includes the production Go toolchain"
 
+grep -Fq 'FRIEND_REQUEST_LIMITS_CONFIG="${POLICY_DIR}/friend_request_limits.yaml"' \
+  "${SOURCE_ROOT}/scripts/cloud/install_main_deployer.sh" || {
+  echo "FAIL: installer does not manage the stable friend-request limit config" >&2
+  exit 1
+}
+grep -Fq 'elif [[ -f "${LEGACY_FRIEND_REQUEST_LIMITS_CONFIG}" ]]' \
+  "${SOURCE_ROOT}/scripts/cloud/install_main_deployer.sh" || {
+  echo "FAIL: installer does not migrate the legacy friend-request limit config" >&2
+  exit 1
+}
+echo "PASS: installer preserves a stable friend-request limit config"
+
 declare -f deploy_main_prepare_source | \
   grep -Fq 'deploy_main_git_as_user "${deploy_user}" "${deploy_home}"' || {
     echo "FAIL: source export bypasses the unprivileged deployment user" >&2


### PR DESCRIPTION
## What changed

- Load the production friend-request limit config from the stable path `/etc/eigenflux/friend_request_limits.yaml`
- Fail production startup when the config is missing or invalid, and log the loaded path and override count
- Migrate and preserve the legacy private config when installing the main deployer
- Add tests and deployment documentation

## Root cause

Immutable releases are assembled with `git archive`. The private, gitignored YAML was therefore absent from the release tree, while PM still resolved it relative to the release working directory. The missing file was treated as non-fatal and PM silently fell back to the default hourly limit of 10, so the existing whitelist never took effect.

## Impact

Whitelisted friend-request quotas now survive immutable release switches. A missing production config fails closed instead of silently reverting to the default.

## Checks

- `env GOCACHE=/private/tmp/eigenflux-friend-limit-go-cache go test ./rpc/pm/ratelimit ./rpc/pm`
- `bash -n scripts/cloud/install_main_deployer.sh scripts/cloud/test_deploy_main.sh`
- `bash scripts/cloud/test_deploy_main.sh`
- `env GOCACHE=/private/tmp/eigenflux-friend-limit-go-cache-build bash scripts/common/build.sh`
