### PR TITLE
feat: add rate-limited public Agent registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,7 @@ ENABLE_CONSOLE_V2=false
 ENABLE_FEED_V2=false
 ENABLE_CONTROL_CHANNEL_V2=false
 ENABLE_COMMUNICATION_V2=false
+ENABLE_PUBLIC_AGENT_REGISTRATION=false
 # Required by the controlled installation broker when Console V2 is enabled.
 CONSOLE_V2_BOOTSTRAP_SECRET=
 # Independent pepper used to HMAC V2 OTP values. Do not reuse an API key.
@@ -157,6 +158,13 @@ CONSOLE_V2_OTP_PEPPER=
 CONSOLE_V2_PUBLIC_URL=http://localhost:5173
 # Comma-separated ingress/LB CIDRs allowed to provide X-Forwarded-For.
 CONSOLE_V2_TRUSTED_PROXY_CIDRS=
+# Automatic Agent registration uses one atomic 24-hour Redis window. The
+# database still enforces one stable Agent per Ed25519 public key for all time.
+CONSOLE_V2_REGISTRATION_WINDOW_SEC=86400
+CONSOLE_V2_REGISTRATION_IP_LIMIT=500
+CONSOLE_V2_REGISTRATION_SUBNET_LIMIT=500
+CONSOLE_V2_REGISTRATION_KEY_LIMIT=5
+CONSOLE_V2_REGISTRATION_GLOBAL_LIMIT=1000
 
 # Resend API for sending OTP emails (required only when ENABLE_EMAIL_VERIFICATION=true)
 # Get your API key from https://resend.com/api-keys

--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -26,6 +26,27 @@ type issueGrantRequest struct {
 	PublicKey      string `json:"public_key"`
 }
 
+type bootstrapGrantResult struct {
+	BootstrapGrant string
+	Nonce          string
+	ExpiresAt      int64
+	KeyFingerprint string
+}
+
+func (result bootstrapGrantResult) response() map[string]interface{} {
+	return map[string]interface{}{
+		"bootstrap_grant": result.BootstrapGrant,
+		"nonce":           result.Nonce,
+		"expires_at":      result.ExpiresAt,
+		"key_fingerprint": result.KeyFingerprint,
+		"proof": map[string]interface{}{
+			"algorithm": "ed25519",
+			"domain":    "EF-AUTH-V2",
+			"body":      "sign the canonical provision payload described by the API contract",
+		},
+	}
+}
+
 func (s *Service) issueBootstrapGrant(_ context.Context, c *app.RequestContext) {
 	if s.bootstrapSecret == "" || subtleHeaderMismatch(string(c.GetHeader("X-Bootstrap-Broker-Secret")), s.bootstrapSecret) {
 		fail(c, http.StatusNotFound, "NOT_FOUND", "resource not found", nil)
@@ -52,6 +73,19 @@ func (s *Service) issueBootstrapGrant(_ context.Context, c *app.RequestContext) 
 		req.Policy = "limited"
 	}
 
+	result, err := s.issueBootstrapGrantRecord(req, publicKey)
+	if errors.Is(err, errConflict) {
+		fail(c, http.StatusConflict, "ENTITLEMENT_CONFLICT", "this installation entitlement is bound to a different request", nil)
+		return
+	}
+	if err != nil {
+		fail(c, http.StatusInternalServerError, "BOOTSTRAP_GRANT_FAILED", "could not issue bootstrap grant", nil)
+		return
+	}
+	reply(c, http.StatusCreated, result.response())
+}
+
+func (s *Service) issueBootstrapGrantRecord(req issueGrantRequest, publicKey ed25519.PublicKey) (bootstrapGrantResult, error) {
 	keyFingerprint := fingerprint(publicKey)
 	entitlementHash := keyedHash(s.bootstrapSecret, req.EntitlementID)
 	requestID := req.IdempotencyKey
@@ -59,7 +93,7 @@ func (s *Service) issueBootstrapGrant(_ context.Context, c *app.RequestContext) 
 	grant := "efbg_" + keyedHash(s.bootstrapSecret, "grant\x00"+receiptSeed)
 	nonce := "efn_" + keyedHash(s.bootstrapSecret, "nonce\x00"+receiptSeed)
 	var expiresAt int64
-	err = s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Exec(`SELECT pg_advisory_xact_lock(hashtextextended(?, 0))`, entitlementHash).Error; err != nil {
 			return err
 		}
@@ -114,25 +148,15 @@ func (s *Service) issueBootstrapGrant(_ context.Context, c *app.RequestContext) 
 			(nonce_hash, key_fingerprint, domain, expires_at, created_at)
 			VALUES (?, ?, 'provision', ?, ?)`, hashString(nonce), keyFingerprint, expiresAt, now).Error
 	})
-	if errors.Is(err, errConflict) {
-		fail(c, http.StatusConflict, "ENTITLEMENT_CONFLICT", "this installation entitlement is bound to a different request", nil)
-		return
-	}
 	if err != nil {
-		fail(c, http.StatusInternalServerError, "BOOTSTRAP_GRANT_FAILED", "could not issue bootstrap grant", nil)
-		return
+		return bootstrapGrantResult{}, err
 	}
-	reply(c, http.StatusCreated, map[string]interface{}{
-		"bootstrap_grant": grant,
-		"nonce":           nonce,
-		"expires_at":      expiresAt,
-		"key_fingerprint": keyFingerprint,
-		"proof": map[string]interface{}{
-			"algorithm": "ed25519",
-			"domain":    "EF-AUTH-V2",
-			"body":      "sign the canonical provision payload described by the API contract",
-		},
-	})
+	return bootstrapGrantResult{
+		BootstrapGrant: grant,
+		Nonce:          nonce,
+		ExpiresAt:      expiresAt,
+		KeyFingerprint: keyFingerprint,
+	}, nil
 }
 
 func subtleHeaderMismatch(got, want string) bool {

--- a/api/consolev2/registration_handlers.go
+++ b/api/consolev2/registration_handlers.go
@@ -1,0 +1,162 @@
+package consolev2
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	redis "github.com/redis/go-redis/v9"
+)
+
+type registrationRateLimits struct {
+	Window    time.Duration
+	IP        int64
+	Subnet    int64
+	PublicKey int64
+	Global    int64
+}
+
+func (limits registrationRateLimits) valid() bool {
+	return limits.Window > 0 && limits.IP > 0 && limits.Subnet > 0 && limits.PublicKey > 0 && limits.Global > 0
+}
+
+type publicRegistrationChallengeRequest struct {
+	PublicKey      string `json:"public_key"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+type registrationRateDecision struct {
+	Allowed      bool
+	RetryAfterMS int64
+}
+
+// All quota keys share one Redis cluster hash tag, so every request must pass
+// every quota before any counter is incremented. Retries count as requests too;
+// database idempotency prevents them from creating a second Agent.
+var publicRegistrationRateScript = redis.NewScript(`
+for i = 1, #KEYS do
+  local count = tonumber(redis.call('GET', KEYS[i]) or '0')
+  local limit = tonumber(ARGV[i + 1])
+  if count >= limit then
+    local ttl = redis.call('PTTL', KEYS[i])
+    if ttl < 0 then ttl = tonumber(ARGV[1]) end
+    return {0, i, ttl}
+  end
+end
+
+for i = 1, #KEYS do
+  local count = redis.call('INCR', KEYS[i])
+  if count == 1 then redis.call('PEXPIRE', KEYS[i], ARGV[1]) end
+end
+return {1, 0, tonumber(ARGV[1])}
+`)
+
+func registrationSubnet(ipText string) string {
+	ip := net.ParseIP(strings.TrimSpace(ipText))
+	if ip == nil {
+		return "unknown"
+	}
+	if ipv4 := ip.To4(); ipv4 != nil {
+		return net.IP(ipv4).Mask(net.CIDRMask(24, 32)).String() + "/24"
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).String() + "/64"
+}
+
+func (s *Service) allowPublicRegistration(ctx context.Context, clientIP, keyFingerprint string) (registrationRateDecision, error) {
+	if s.redisClient == nil || !s.registrationLimits.valid() {
+		return registrationRateDecision{}, fmt.Errorf("public registration limiter is unavailable")
+	}
+	prefix := "console:v2:registration:{v1}:"
+	hashKey := func(value string) string { return keyedHash(s.otpPepper, value) }
+	keys := []string{
+		prefix + "ip:" + hashKey(clientIP),
+		prefix + "subnet:" + hashKey(registrationSubnet(clientIP)),
+		prefix + "key:" + hashKey(keyFingerprint),
+		prefix + "global",
+	}
+	arguments := []interface{}{
+		int64(s.registrationLimits.Window / time.Millisecond),
+		s.registrationLimits.IP,
+		s.registrationLimits.Subnet,
+		s.registrationLimits.PublicKey,
+		s.registrationLimits.Global,
+	}
+	result, err := publicRegistrationRateScript.Run(ctx, s.redisClient, keys, arguments...).Slice()
+	if err != nil {
+		return registrationRateDecision{}, err
+	}
+	if len(result) != 3 {
+		return registrationRateDecision{}, fmt.Errorf("unexpected public registration limiter response")
+	}
+	toInt64 := func(value interface{}) (int64, bool) {
+		switch typed := value.(type) {
+		case int64:
+			return typed, true
+		case int:
+			return int64(typed), true
+		default:
+			return 0, false
+		}
+	}
+	allowed, ok := toInt64(result[0])
+	if !ok {
+		return registrationRateDecision{}, fmt.Errorf("invalid public registration limiter decision")
+	}
+	retryAfter, ok := toInt64(result[2])
+	if !ok {
+		return registrationRateDecision{}, fmt.Errorf("invalid public registration limiter retry time")
+	}
+	return registrationRateDecision{Allowed: allowed == 1, RetryAfterMS: retryAfter}, nil
+}
+
+func (s *Service) issuePublicRegistrationChallenge(ctx context.Context, c *app.RequestContext) {
+	var req publicRegistrationChallengeRequest
+	if err := decodeBody(c, &req); err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error(), nil)
+		return
+	}
+	publicKey, err := decodePublicKey(req.PublicKey)
+	if err != nil || len(req.IdempotencyKey) < 16 || len(req.IdempotencyKey) > 128 {
+		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "idempotency_key and a valid public_key are required", nil)
+		return
+	}
+	keyFingerprint := fingerprint(publicKey)
+	clientIP := resolveV2ClientIP(c.RemoteAddr().String(),
+		string(c.Request.Header.Peek("X-Forwarded-For")),
+		string(c.Request.Header.Peek("X-Real-IP")), s.trustedProxyNets)
+	rateContext, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	decision, rateErr := s.allowPublicRegistration(rateContext, clientIP, keyFingerprint)
+	cancel()
+	if rateErr != nil {
+		fail(c, http.StatusServiceUnavailable, "REGISTRATION_UNAVAILABLE", "automatic Agent registration is temporarily unavailable", nil)
+		return
+	}
+	if !decision.Allowed {
+		fail(c, http.StatusTooManyRequests, "REGISTRATION_RATE_LIMITED", "automatic Agent registration is temporarily rate limited", map[string]interface{}{
+			"retry_after_ms": decision.RetryAfterMS,
+		})
+		return
+	}
+
+	grantRequest := issueGrantRequest{
+		EntitlementID:  "public-registration:" + keyFingerprint + ":" + req.IdempotencyKey,
+		IdempotencyKey: req.IdempotencyKey,
+		Channel:        "public_auto",
+		Policy:         "limited",
+		PublicKey:      req.PublicKey,
+	}
+	result, grantErr := s.issueBootstrapGrantRecord(grantRequest, publicKey)
+	if grantErr != nil {
+		if grantErr == errConflict {
+			fail(c, http.StatusConflict, "REGISTRATION_IDEMPOTENCY_CONFLICT", "registration request key was reused with different input", nil)
+			return
+		}
+		fail(c, http.StatusInternalServerError, "REGISTRATION_FAILED", "could not prepare Agent registration", nil)
+		return
+	}
+	reply(c, http.StatusCreated, result.response())
+}

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -71,6 +71,8 @@ type Service struct {
 	enableFeed               bool
 	enableControl            bool
 	enableCommunication      bool
+	enablePublicRegistration bool
+	registrationLimits       registrationRateLimits
 	activityMu               sync.Mutex
 	activityConnections      map[int64]int
 	activityTotal            int
@@ -135,6 +137,19 @@ func NewService(gdb *gorm.DB, idgen IDGenerator, cfg *config.Config) (*Service, 
 		}
 		trustedProxyNets = append(trustedProxyNets, network)
 	}
+	registrationLimits := registrationRateLimits{
+		Window:    time.Duration(cfg.ConsoleV2Registration.WindowSec) * time.Second,
+		IP:        int64(cfg.ConsoleV2Registration.IPLimit),
+		Subnet:    int64(cfg.ConsoleV2Registration.SubnetLimit),
+		PublicKey: int64(cfg.ConsoleV2Registration.KeyLimit),
+		Global:    int64(cfg.ConsoleV2Registration.GlobalLimit),
+	}
+	if cfg.EnablePublicRegistration && !registrationLimits.valid() {
+		return nil, errors.New("public Agent registration limits must all be positive")
+	}
+	if cfg.EnablePublicRegistration && strings.TrimSpace(cfg.ConsoleV2BootstrapSecret) == "" {
+		return nil, errors.New("CONSOLE_V2_BOOTSTRAP_SECRET is required for public Agent registration")
+	}
 	service := &Service{
 		db:                       gdb,
 		idgen:                    idgen,
@@ -145,6 +160,8 @@ func NewService(gdb *gorm.DB, idgen IDGenerator, cfg *config.Config) (*Service, 
 		enableFeed:               cfg.EnableFeedV2,
 		enableControl:            cfg.EnableControlChannelV2,
 		enableCommunication:      cfg.EnableCommunicationV2,
+		enablePublicRegistration: cfg.EnablePublicRegistration,
+		registrationLimits:       registrationLimits,
 		activityConnections:      make(map[int64]int),
 		activityWakeSubs:         make(map[int64]map[chan struct{}]struct{}),
 		communicationSubs:        make(map[int64]map[chan communicationWakeEvent]struct{}),
@@ -268,6 +285,9 @@ func (s *Service) requireSameOrigin() app.HandlerFunc {
 // Console V2 feature flag, so disabled deployments retain the exact V1 surface.
 func (s *Service) Register(h *server.Hertz) {
 	h.POST("/api/v2/bootstrap-grants", s.issueBootstrapGrant)
+	if s.enablePublicRegistration {
+		h.POST("/api/v2/agent-identities/registration-challenges", s.issuePublicRegistrationChallenge)
+	}
 	h.POST("/api/v2/agent-identities/provision", s.provision)
 	h.POST("/api/v2/agent-sessions/refresh-challenges", s.createRefreshChallenge)
 	h.POST("/api/v2/agent-sessions/refresh", s.refreshAgentSession)

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -8,9 +8,12 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/app/server"
+	redis "github.com/redis/go-redis/v9"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -206,6 +209,88 @@ func TestV2ClientIPOnlyTrustsConfiguredProxy(t *testing.T) {
 	}
 	if got := resolveV2ClientIP("10.1.2.3:4321", "198.51.100.8, 10.2.3.4", "", []*net.IPNet{trusted}); got != "198.51.100.8" {
 		t.Fatalf("trusted proxy client IP = %s", got)
+	}
+}
+
+func TestRegistrationSubnetUsesIPv4Slash24AndIPv6Slash64(t *testing.T) {
+	for input, expected := range map[string]string{
+		"203.0.113.81":         "203.0.113.0/24",
+		"2001:db8:abcd:12::99": "2001:db8:abcd:12::/64",
+		"not-an-ip":            "unknown",
+	} {
+		if actual := registrationSubnet(input); actual != expected {
+			t.Fatalf("registrationSubnet(%q)=%q want %q", input, actual, expected)
+		}
+	}
+}
+
+func TestPublicRegistrationRequiresBootstrapSecretAndPositiveLimits(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := config.Config{
+		EnablePublicRegistration: true,
+		ConsoleV2OTPPepper:       "test-otp-pepper",
+		ConsoleV2PublicURL:       "https://console.example.test",
+		ConsoleV2Registration: config.RegLimit{
+			WindowSec: 86400, IPLimit: 500, SubnetLimit: 500, KeyLimit: 5, GlobalLimit: 1000,
+		},
+	}
+	if _, err := NewService(gdb, &fixedIDGenerator{}, &base); err == nil || !strings.Contains(err.Error(), "BOOTSTRAP_SECRET") {
+		t.Fatalf("public registration accepted an empty bootstrap secret: %v", err)
+	}
+	base.ConsoleV2BootstrapSecret = "test-bootstrap-secret"
+	base.ConsoleV2Registration.KeyLimit = 0
+	if _, err := NewService(gdb, &fixedIDGenerator{}, &base); err == nil || !strings.Contains(err.Error(), "limits") {
+		t.Fatalf("public registration accepted invalid limits: %v", err)
+	}
+}
+
+func TestPublicRegistrationRateLimiterAppliesEveryDimension(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		limits    registrationRateLimits
+		firstIP   string
+		firstKey  string
+		secondIP  string
+		secondKey string
+	}{
+		{
+			name: "ip", limits: registrationRateLimits{Window: time.Hour, IP: 1, Subnet: 10, PublicKey: 10, Global: 10},
+			firstIP: "203.0.113.10", firstKey: "key-a", secondIP: "203.0.113.10", secondKey: "key-b",
+		},
+		{
+			name: "subnet", limits: registrationRateLimits{Window: time.Hour, IP: 10, Subnet: 1, PublicKey: 10, Global: 10},
+			firstIP: "203.0.113.10", firstKey: "key-a", secondIP: "203.0.113.11", secondKey: "key-b",
+		},
+		{
+			name: "public key", limits: registrationRateLimits{Window: time.Hour, IP: 10, Subnet: 10, PublicKey: 1, Global: 10},
+			firstIP: "203.0.113.10", firstKey: "key-a", secondIP: "198.51.100.10", secondKey: "key-a",
+		},
+		{
+			name: "global", limits: registrationRateLimits{Window: time.Hour, IP: 10, Subnet: 10, PublicKey: 10, Global: 1},
+			firstIP: "203.0.113.10", firstKey: "key-a", secondIP: "198.51.100.10", secondKey: "key-b",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+			t.Cleanup(func() { _ = client.Close() })
+			service := &Service{redisClient: client, otpPepper: "test-registration-pepper", registrationLimits: test.limits}
+
+			first, err := service.allowPublicRegistration(context.Background(), test.firstIP, test.firstKey)
+			if err != nil || !first.Allowed {
+				t.Fatalf("first request decision=%#v err=%v", first, err)
+			}
+			second, err := service.allowPublicRegistration(context.Background(), test.secondIP, test.secondKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if second.Allowed || second.RetryAfterMS <= 0 {
+				t.Fatalf("second request was not rate limited: %#v", second)
+			}
+		})
 	}
 }
 

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -42,10 +42,16 @@ Default config in `pkg/config/config.go`, override via environment variables:
 | `ENABLE_FEED_V2` | `false` | Enables the stateless latest-view Feed V2 route; V1 feed behavior is unchanged |
 | `ENABLE_CONTROL_CHANNEL_V2` | `false` | Enables Agent attention and command delivery routes |
 | `ENABLE_COMMUNICATION_V2` | `false` | Enables V2 PM/friend envelopes enriched with public Agent Card data |
+| `ENABLE_PUBLIC_AGENT_REGISTRATION` | `false` | Lets a CLI obtain a short-lived key-bound registration challenge without a broker; Redis limits must be available |
 | `CONSOLE_V2_BOOTSTRAP_SECRET` | -- | Secret accepted only by the controlled bootstrap-grant issuer; required when that route is enabled |
 | `CONSOLE_V2_PUBLIC_URL` | `http://localhost:5173` | Browser origin used for one-time Console V2 handoff URLs |
 | `RESEND_API_KEY` | -- | Resend API key (required only when OTP enabled) |
 | `CONSOLE_V2_OTP_PEPPER` | -- | Console V2 OTP HMAC pepper; required when Console V2 is enabled |
+| `CONSOLE_V2_REGISTRATION_WINDOW_SEC` | `86400` | Automatic registration fixed-window duration in seconds |
+| `CONSOLE_V2_REGISTRATION_IP_LIMIT` | `500` | Automatic registration challenges per client IP and window (temporary internal-test default; restore to 20 before public rollout) |
+| `CONSOLE_V2_REGISTRATION_SUBNET_LIMIT` | `500` | Automatic registration challenges per IPv4 /24 or IPv6 /64 and window (temporary internal-test default; restore to 100 before public rollout) |
+| `CONSOLE_V2_REGISTRATION_KEY_LIMIT` | `5` | Automatic registration challenges per public key and window; Agent creation remains permanently unique per key |
+| `CONSOLE_V2_REGISTRATION_GLOBAL_LIMIT` | `1000` | Global automatic registration challenges per window |
 | `RESEND_FROM_EMAIL` | -- | Sender address (required only when OTP enabled) |
 | `MOCK_UNIVERSAL_OTP` | `123456` | Fixed verification code when whitelist matched |
 | `MOCK_OTP_EMAIL_SUFFIXES` | -- | Comma-separated email suffix whitelist |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,24 @@ const (
 	defaultProjectTitle = "MyHub"
 )
 
+type RegLimit struct {
+	WindowSec   int
+	IPLimit     int
+	SubnetLimit int
+	KeyLimit    int
+	GlobalLimit int
+}
+
+func loadConsoleV2RegistrationLimits() RegLimit {
+	return RegLimit{
+		WindowSec:   getEnvInt("CONSOLE_V2_REGISTRATION_WINDOW_SEC", 86400),
+		IPLimit:     getEnvInt("CONSOLE_V2_REGISTRATION_IP_LIMIT", 500),
+		SubnetLimit: getEnvInt("CONSOLE_V2_REGISTRATION_SUBNET_LIMIT", 500),
+		KeyLimit:    getEnvInt("CONSOLE_V2_REGISTRATION_KEY_LIMIT", 5),
+		GlobalLimit: getEnvInt("CONSOLE_V2_REGISTRATION_GLOBAL_LIMIT", 1000),
+	}
+}
+
 type Config struct {
 	EtcdAddr                    string
 	PgDSN                       string
@@ -66,10 +84,12 @@ type Config struct {
 	EnableFeedV2                bool     // Enable the stateless latest-view Feed V2 route
 	EnableControlChannelV2      bool     // Enable Agent command and attention routes
 	EnableCommunicationV2       bool     // Enable V2 PM/friend responses enriched with public Agent Card data
+	EnablePublicRegistration    bool     // Allow Agents to obtain a rate-limited key-bound bootstrap challenge without a broker
 	ConsoleV2BootstrapSecret    string   // Shared secret used only by the controlled bootstrap broker
 	ConsoleV2OTPPepper          string   // Server-side HMAC pepper for Console V2 email challenges
 	ConsoleV2PublicURL          string   // Browser origin used when constructing one-time handoff URLs
 	ConsoleV2TrustedProxyCIDRs  []string // Proxies allowed to supply client IP forwarding headers for V2 OTP limits
+	ConsoleV2Registration       RegLimit // Public automatic registration rate limits
 	MockUniversalOTP            string   // fixed OTP for whitelist-matched requests
 	ESReplicas                  int      // Elasticsearch number_of_replicas
 	ESShards                    int      // Elasticsearch number_of_shards
@@ -239,10 +259,12 @@ func Load() *Config {
 		EnableFeedV2:                 getEnvBool("ENABLE_FEED_V2", false),
 		EnableControlChannelV2:       getEnvBool("ENABLE_CONTROL_CHANNEL_V2", false),
 		EnableCommunicationV2:        getEnvBool("ENABLE_COMMUNICATION_V2", false),
+		EnablePublicRegistration:     getEnvBool("ENABLE_PUBLIC_AGENT_REGISTRATION", false),
 		ConsoleV2BootstrapSecret:     getEnv("CONSOLE_V2_BOOTSTRAP_SECRET", ""),
 		ConsoleV2OTPPepper:           getEnv("CONSOLE_V2_OTP_PEPPER", ""),
 		ConsoleV2PublicURL:           getEnv("CONSOLE_V2_PUBLIC_URL", "http://localhost:5173"),
 		ConsoleV2TrustedProxyCIDRs:   getEnvStringList("CONSOLE_V2_TRUSTED_PROXY_CIDRS", nil),
+		ConsoleV2Registration:        loadConsoleV2RegistrationLimits(),
 		MockUniversalOTP:             getEnv("MOCK_UNIVERSAL_OTP", "123456"),
 		ESReplicas:                   getEnvInt("ES_REPLICAS", 0),
 		ESShards:                     getEnvInt("ES_SHARDS", 1),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -134,13 +134,19 @@ func TestConsoleV2FeatureFlagsDefaultOff(t *testing.T) {
 	t.Setenv("ENABLE_FEED_V2", "")
 	t.Setenv("ENABLE_CONTROL_CHANNEL_V2", "")
 	t.Setenv("ENABLE_COMMUNICATION_V2", "")
+	t.Setenv("ENABLE_PUBLIC_AGENT_REGISTRATION", "")
 	t.Setenv("POSTGRES_PORT", "")
 	t.Setenv("REDIS_PORT", "")
 	t.Setenv("ETCD_PORT", "")
 
 	cfg := Load()
-	if cfg.EnableConsoleV2 || cfg.EnableFeedV2 || cfg.EnableControlChannelV2 || cfg.EnableCommunicationV2 {
+	if cfg.EnableConsoleV2 || cfg.EnableFeedV2 || cfg.EnableControlChannelV2 || cfg.EnableCommunicationV2 || cfg.EnablePublicRegistration {
 		t.Fatal("Console V2 feature flags must default to disabled")
+	}
+	if cfg.ConsoleV2Registration.WindowSec != 86400 || cfg.ConsoleV2Registration.IPLimit != 500 ||
+		cfg.ConsoleV2Registration.SubnetLimit != 500 || cfg.ConsoleV2Registration.KeyLimit != 5 ||
+		cfg.ConsoleV2Registration.GlobalLimit != 1000 {
+		t.Fatalf("unexpected public registration defaults: %#v", cfg.ConsoleV2Registration)
 	}
 }
 
@@ -149,12 +155,13 @@ func TestConsoleV2FeatureFlagsCanBeEnabledIndependently(t *testing.T) {
 	t.Setenv("ENABLE_FEED_V2", "false")
 	t.Setenv("ENABLE_CONTROL_CHANNEL_V2", "true")
 	t.Setenv("ENABLE_COMMUNICATION_V2", "false")
+	t.Setenv("ENABLE_PUBLIC_AGENT_REGISTRATION", "true")
 	t.Setenv("POSTGRES_PORT", "")
 	t.Setenv("REDIS_PORT", "")
 	t.Setenv("ETCD_PORT", "")
 
 	cfg := Load()
-	if !cfg.EnableConsoleV2 || cfg.EnableFeedV2 || !cfg.EnableControlChannelV2 || cfg.EnableCommunicationV2 {
+	if !cfg.EnableConsoleV2 || cfg.EnableFeedV2 || !cfg.EnableControlChannelV2 || cfg.EnableCommunicationV2 || !cfg.EnablePublicRegistration {
 		t.Fatal("Console V2 feature flags were not loaded independently")
 	}
 }


### PR DESCRIPTION
## What changed
- add `POST /api/v2/agent-identities/registration-challenges`
- issue short-lived, single-use, Ed25519-key-bound bootstrap grants through the existing provision trust model
- enforce atomic Redis quotas by client IP, subnet, public key, and global window
- keep the capability behind `ENABLE_PUBLIC_AGENT_REGISTRATION` (default off)
- document the temporary internal-test limits and add configuration/unit coverage

## Why
The Console V2 onboarding flow must work from a simple Agent instruction without manually supplying a broker grant and nonce. The missing public challenge step blocked local WorkBuddy and colleague testing.

## Safety and compatibility
- no V1 route or response changes
- public registration fails closed when Redis is unavailable
- production startup rejects public registration without a bootstrap secret or positive limits
- one Ed25519 public key remains permanently mapped to one Agent by the existing database uniqueness constraint
- this PR does not publish CLI 0.0.34, Skills, plugins, or installer changes

## Validation
- `go test ./api/consolev2 ./pkg/config`
- `go test ./api/...`
- `bash scripts/common/build.sh`
- `git diff --check`