### PR TITLE
feat(console-v2): expose email state and improve Today defaults

### DIFF
--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -406,6 +406,16 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	if status != 200 || responseData(t, bindPayload)["verification_level"] != "email_verified" {
 		t.Fatalf("email binding verify status=%d payload=%#v", status, bindPayload)
 	}
+	status, boundSessionPayload, _ := performJSON(t, h, "GET", "/api/v2/console/session", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != 200 {
+		t.Fatalf("bound session status=%d payload=%#v", status, boundSessionPayload)
+	}
+	boundSession := responseData(t, boundSessionPayload)
+	if boundSession["email"] != boundEmail || boundSession["email_bound"] != true ||
+		boundSession["verification_level"] != "email_verified" {
+		t.Fatalf("bound session did not expose verified binding: %#v", boundSession)
+	}
 	var emailKind string
 	if err := gdb.Raw(`SELECT email_kind FROM agents WHERE agent_id = ?`, agentID).Scan(&emailKind).Error; err != nil || emailKind != "v2_bound" {
 		t.Fatalf("bound Agent email_kind=%q err=%v", emailKind, err)

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -73,20 +73,39 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	var identity struct {
-		AgentName string `gorm:"column:agent_name"`
-		Bio       string `gorm:"column:bio"`
-		CreatedAt int64  `gorm:"column:created_at"`
+		AgentName     string `gorm:"column:agent_name"`
+		Bio           string `gorm:"column:bio"`
+		CreatedAt     int64  `gorm:"column:created_at"`
+		IsOfficial    bool   `gorm:"column:is_official"`
+		BoundEmail    string `gorm:"column:bound_email"`
+		EmailVerified bool   `gorm:"column:email_verified"`
 	}
-	if err := s.db.Raw(`SELECT agent_name, bio, created_at FROM agents WHERE agent_id = ?`, id).Scan(&identity).Error; err != nil {
+	if err := s.db.Raw(`SELECT a.agent_name, a.bio, a.created_at, a.is_official,
+		COALESCE(b.normalized_email, '') AS bound_email,
+		(b.binding_id IS NOT NULL) AS email_verified
+		FROM agents a
+		LEFT JOIN agent_email_bindings b ON b.agent_id = a.agent_id
+			AND b.status = 'active' AND b.verification_state = 'verified'
+		WHERE a.agent_id = ?`, id).Scan(&identity).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "SESSION_READ_FAILED", "could not read Agent identity", nil)
 		return
 	}
+	verificationLevel := "unverified"
+	if identity.EmailVerified {
+		verificationLevel = "email_verified"
+	}
+	if identity.IsOfficial {
+		verificationLevel = "official"
+	}
 	reply(c, http.StatusOK, map[string]interface{}{
-		"agent_id":   fmt.Sprintf("%d", id),
-		"agent_name": identity.AgentName,
-		"bio":        identity.Bio,
-		"created_at": identity.CreatedAt,
-		"onboarding": state,
+		"agent_id":           fmt.Sprintf("%d", id),
+		"agent_name":         identity.AgentName,
+		"bio":                identity.Bio,
+		"created_at":         identity.CreatedAt,
+		"email":              identity.BoundEmail,
+		"email_bound":        identity.EmailVerified,
+		"verification_level": verificationLevel,
+		"onboarding":         state,
 	})
 }
 

--- a/api/consolev2/today_handlers.go
+++ b/api/consolev2/today_handlers.go
@@ -60,6 +60,21 @@ func cardFieldPresent(value interface{}) bool {
 	}
 }
 
+func calculateCardCompletionValues(values map[string]interface{}) (int, int, int) {
+	completed := 0
+	for _, field := range consoleV2CardCompletionFields {
+		if cardFieldPresent(values[field]) {
+			completed++
+		}
+	}
+	total := len(consoleV2CardCompletionFields)
+	percent := 0
+	if total > 0 {
+		percent = (completed*100 + total/2) / total
+	}
+	return completed, total, percent
+}
+
 func calculateCardCompletion(publicJSON, privateJSON string) (int, int, int, error) {
 	publicCard := map[string]interface{}{}
 	privateCard := map[string]interface{}{}
@@ -73,7 +88,7 @@ func calculateCardCompletion(publicJSON, privateJSON string) (int, int, int, err
 			return 0, 0, 0, err
 		}
 	}
-	completed := 0
+	values := map[string]interface{}{}
 	for _, field := range consoleV2CardCompletionFields {
 		source := privateCard
 		for _, spec := range agentcard.EditableFields {
@@ -82,15 +97,22 @@ func calculateCardCompletion(publicJSON, privateJSON string) (int, int, int, err
 				break
 			}
 		}
-		if cardFieldPresent(source[field]) {
-			completed++
+		values[field] = source[field]
+	}
+	completed, total, percent := calculateCardCompletionValues(values)
+	return completed, total, percent, nil
+}
+
+func calculateCurrentCardCompletion(agentName, agentDescription, profileJSON string) (int, int, int, error) {
+	values := map[string]interface{}{}
+	if strings.TrimSpace(profileJSON) != "" {
+		if err := json.Unmarshal([]byte(profileJSON), &values); err != nil {
+			return 0, 0, 0, err
 		}
 	}
-	total := len(consoleV2CardCompletionFields)
-	percent := 0
-	if total > 0 {
-		percent = completed * 100 / total
-	}
+	values["agent_name"] = agentName
+	values["agent_description"] = agentDescription
+	completed, total, percent := calculateCardCompletionValues(values)
 	return completed, total, percent, nil
 }
 
@@ -193,15 +215,24 @@ func (s *Service) getToday(_ context.Context, c *app.RequestContext) {
 	}
 
 	var card struct {
-		PublicCard  string `gorm:"column:public_card"`
-		PrivateCard string `gorm:"column:private_card"`
+		PublicCard       string `gorm:"column:public_card"`
+		PrivateCard      string `gorm:"column:private_card"`
+		AgentName        string `gorm:"column:agent_name"`
+		AgentDescription string `gorm:"column:agent_description"`
+		ProfileData      string `gorm:"column:profile_data"`
 	}
-	if err := s.db.Raw(`SELECT public_card::text AS public_card, private_card::text AS private_card
-		FROM agent_cards WHERE agent_id = ?`, agentIDValue).Scan(&card).Error; err != nil {
+	if err := s.db.Raw(`SELECT COALESCE(card.public_card, '{}'::jsonb)::text AS public_card,
+			COALESCE(card.private_card, '{}'::jsonb)::text AS private_card,
+			agent.agent_name, agent.bio AS agent_description,
+			COALESCE(profile.profile_data, '{}'::jsonb)::text AS profile_data
+		FROM agents agent
+		LEFT JOIN agent_cards card ON card.agent_id = agent.agent_id
+		LEFT JOIN agent_profiles profile ON profile.agent_id = agent.agent_id
+		WHERE agent.agent_id = ?`, agentIDValue).Scan(&card).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "TODAY_READ_FAILED", "could not load Agent Card", nil)
 		return
 	}
-	completedFields, totalFields, completionPercent, err := calculateCardCompletion(card.PublicCard, card.PrivateCard)
+	completedFields, totalFields, completionPercent, err := calculateCurrentCardCompletion(card.AgentName, card.AgentDescription, card.ProfileData)
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "TODAY_READ_FAILED", "could not calculate Agent Card completion", nil)
 		return

--- a/api/consolev2/today_handlers_test.go
+++ b/api/consolev2/today_handlers_test.go
@@ -27,7 +27,7 @@ func TestCalculateCardCompletionUsesEditableRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if completed != 7 || total != 11 || percent != 63 {
+	if completed != 7 || total != 11 || percent != 64 {
 		t.Fatalf("unexpected completion completed=%d total=%d percent=%d", completed, total, percent)
 	}
 }
@@ -43,6 +43,33 @@ func TestTodayStartAcceptsDisplayTimezone(t *testing.T) {
 func TestCalculateCardCompletionRejectsInvalidProjection(t *testing.T) {
 	if _, _, _, err := calculateCardCompletion(`{"agent_name":`, `{}`); err == nil {
 		t.Fatal("invalid Card projection should fail closed")
+	}
+}
+
+func TestCalculateCurrentCardCompletionUsesFactData(t *testing.T) {
+	profileData := `{
+		"human_description":"Works on agent infrastructure",
+		"working_languages":["zh-CN","en"],
+		"seeking":[],
+		"offering":["research"],
+		"geo":"Singapore",
+		"timezone":"Asia/Singapore",
+		"agent_status":[],
+		"human_status":[],
+		"interests_negative":[]
+	}`
+	completed, total, percent, err := calculateCurrentCardCompletion("Atlas", "Research assistant", profileData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if completed != 7 || total != 11 || percent != 64 {
+		t.Fatalf("unexpected current completion completed=%d total=%d percent=%d", completed, total, percent)
+	}
+}
+
+func TestCalculateCurrentCardCompletionRejectsInvalidFactData(t *testing.T) {
+	if _, _, _, err := calculateCurrentCardCompletion("Atlas", "Research assistant", `{"timezone":`); err == nil {
+		t.Fatal("invalid fact data should fail closed")
 	}
 }
 

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -2600,6 +2600,37 @@ func ConsoleGetActivityCalendar(ctx context.Context, c *app.RequestContext) {
 	})
 }
 
+func consoleGlobalDailyPicks(uiLang string, now int64) []map[string]interface{} {
+	zhPicks := [][2]string{
+		{"完善 Agent 身份卡", "补全正在寻找、能够提供和近期状态，能让网络更准确地理解并匹配你的 Agent。"},
+		{"写清网络活动目标", "一个清晰的目标能帮助 Agent 判断该关注谁、何时行动，以及哪些机会值得带回。"},
+		{"设置意图与行动", "用具体的关注条件和行动方式，告诉网络什么信息对你真正重要。"},
+		{"从今天查看网络进展", "今天页会持续汇总值得关注的信息、遇见的 Agent 和实时网络活动。"},
+		{"绑定恢复邮箱", "邮箱只用于账号绑定与恢复，不会改变 Agent 的稳定身份。"},
+	}
+	enPicks := [][2]string{
+		{"Complete the Agent Card", "Add what the Agent is looking for, what it can offer, and its recent status so the network can match it accurately."},
+		{"Define a clear network goal", "A clear goal helps the Agent decide whom to follow, when to act, and which opportunities deserve your attention."},
+		{"Configure intents and actions", "Use concrete conditions and actions to tell the network which information genuinely matters to you."},
+		{"Review network progress in Today", "The Today page brings together important signals, encountered Agents, and real-time network activity."},
+		{"Connect a recovery email", "Email is used only for account binding and recovery; it never changes the Agent's stable identity."},
+	}
+	picks := zhPicks
+	if uiLang == "en" {
+		picks = enPicks
+	}
+	start := int(now/86400000) % len(picks)
+	highlights := make([]map[string]interface{}, 0, 3)
+	for offset := 0; offset < 3; offset++ {
+		pick := picks[(start+offset)%len(picks)]
+		highlights = append(highlights, map[string]interface{}{
+			"content": pick[0], "summary": pick[1], "source": "EigenFlux",
+			"created_at": now, "global_pick": true, "feedbacked": false,
+		})
+	}
+	return highlights
+}
+
 // ConsoleGetHighlights returns today's top feed items.
 // @router /api/v1/console/highlights [GET]
 func ConsoleGetHighlights(ctx context.Context, c *app.RequestContext) {
@@ -2813,6 +2844,9 @@ func ConsoleGetHighlights(ctx context.Context, c *app.RequestContext) {
 			hl["url"] = it.RawURL
 		}
 		highlights = append(highlights, hl)
+	}
+	if len(highlights) == 0 {
+		highlights = consoleGlobalDailyPicks(uiLang, now)
 	}
 
 	writeJSON(c, http.StatusOK, 0, "success", map[string]interface{}{

--- a/api/handler_gen/eigenflux/api/console_highlights_test.go
+++ b/api/handler_gen/eigenflux/api/console_highlights_test.go
@@ -1,0 +1,25 @@
+package api
+
+import "testing"
+
+func TestConsoleGlobalDailyPicksAreBoundedAndLocalized(t *testing.T) {
+	now := int64(1787136000000)
+	zh := consoleGlobalDailyPicks("zh", now)
+	en := consoleGlobalDailyPicks("en", now)
+	if len(zh) != 3 || len(en) != 3 {
+		t.Fatalf("daily picks must contain exactly three items: zh=%d en=%d", len(zh), len(en))
+	}
+	for _, picks := range [][]map[string]interface{}{zh, en} {
+		for _, pick := range picks {
+			if pick["source"] != "EigenFlux" || pick["global_pick"] != true || pick["created_at"] != now {
+				t.Fatalf("unexpected global pick envelope: %#v", pick)
+			}
+			if pick["content"] == "" || pick["summary"] == "" {
+				t.Fatalf("global pick content must not be empty: %#v", pick)
+			}
+		}
+	}
+	if zh[0]["content"] == en[0]["content"] {
+		t.Fatalf("daily picks should be localized: zh=%q en=%q", zh[0]["content"], en[0]["content"])
+	}
+}


### PR DESCRIPTION
## What

- expose verified email binding state in Console V2 session/onboarding responses
- align Today Agent Card completion with the 11 editable V2 fields
- return rotating global daily picks when personalized highlights are empty

## Why

Console V2 claim step 1 now supports optional email binding, while Today needs the same completion score as the Agent Card page and a useful new-user fallback that does not expose other users' data.

## Compatibility and impact

- additive Console V2 response fields and V2 behavior only
- no V1 endpoint or DTO removal
- no database migration
- global picks are curated first-party content and require no extra database query

## Checks

- `go test ./api/consolev2 ./api/handler_gen/eigenflux/api`

