### PR TITLE
fix(console-v2): preserve onboarding provenance and completion

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -261,6 +261,11 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "onboarding_draft must be a JSON object no larger than 64KB", nil)
 		return
 	}
+	initialProvenance, err := json.Marshal(deriveInitialProvenance(draftObject, provenanceAgent))
+	if err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "could not derive onboarding field sources", nil)
+		return
+	}
 
 	requestHash, receiptHashErr := provisionReceiptHash(req)
 	if receiptHashErr != nil {
@@ -391,8 +396,9 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 			}
 			if err := tx.Exec(`INSERT INTO agent_onboarding_drafts
 				(agent_id, revision, draft_data, field_provenance, actor_type, request_id, created_at)
-				VALUES (?, 1, ?::jsonb, '{}'::jsonb, 'agent_prefill', ?, ?)`,
-				agentID, string(req.Draft), "provision:"+hashString(req.BootstrapGrant), now).Error; err != nil {
+				VALUES (?, 1, ?::jsonb, ?::jsonb, 'agent_prefill', ?, ?)`,
+				agentID, string(req.Draft), string(initialProvenance),
+				"provision:"+hashString(req.BootstrapGrant), now).Error; err != nil {
 				return err
 			}
 			created = true

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -381,6 +381,11 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	if onboarding["state"] != "completed" || onboarding["active_context_revision"] == nil {
 		t.Fatalf("onboarding completion is not bound to an active context: %#v", onboarding)
 	}
+	var profileCompletedAt *int64
+	if err := gdb.Raw(`SELECT profile_completed_at FROM agents WHERE agent_id = ?`, agentIDInt).
+		Scan(&profileCompletedAt).Error; err != nil || profileCompletedAt == nil {
+		t.Fatalf("V2 onboarding did not mark the profile complete: completed_at=%v err=%v", profileCompletedAt, err)
+	}
 	testCommunicationProjection(t, gdb, h, idgen, agentIDInt, cookieHeader)
 	testTelemetryAggregation(t, gdb, h, agentIDInt, cookieHeader, csrf)
 	testActivityCursorReset(t, gdb, h, idgen, agentIDInt, cookieHeader)

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -16,6 +16,8 @@ import (
 	"gorm.io/gorm"
 
 	"eigenflux_server/pkg/agentcard"
+	"eigenflux_server/pkg/logger"
+	"eigenflux_server/pkg/mq"
 	profiledal "eigenflux_server/rpc/profile/dal"
 )
 
@@ -131,7 +133,15 @@ type putDraftRequest struct {
 	ExpectedRevision int64           `json:"expected_revision"`
 	IdempotencyKey   string          `json:"idempotency_key"`
 	Draft            json.RawMessage `json:"draft"`
-	FieldProvenance  json.RawMessage `json:"field_provenance,omitempty"`
+	// Kept for rolling client compatibility. Field ownership is derived from
+	// the authenticated actor and this request value is intentionally ignored.
+	FieldProvenance json.RawMessage `json:"field_provenance,omitempty"`
+}
+
+type putDraftResponse struct {
+	Revision        int64             `json:"revision"`
+	FieldProvenance map[string]string `json:"field_provenance"`
+	BlockedPaths    []string          `json:"blocked_paths"`
 }
 
 func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
@@ -158,20 +168,12 @@ func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "draft must be a JSON object", nil)
 		return
 	}
-	if len(req.FieldProvenance) == 0 {
-		req.FieldProvenance = json.RawMessage(`{}`)
-	}
-	var provenance map[string]interface{}
-	if json.Unmarshal(req.FieldProvenance, &provenance) != nil {
-		fail(c, http.StatusBadRequest, "INVALID_PROVENANCE", "field_provenance must be a JSON object", nil)
-		return
-	}
-	requestHash := hashString(fmt.Sprintf("%d:%s:%s", req.ExpectedRevision, req.Draft, req.FieldProvenance))
 	actorType := "agent_prefill"
 	if _, console := c.Get("console_session_id"); console {
 		actorType = "human_edit"
 	}
-	var newRevision int64
+	requestHash := hashString(fmt.Sprintf("%d:%s:%s", req.ExpectedRevision, req.Draft, actorType))
+	response := putDraftResponse{FieldProvenance: map[string]string{}, BlockedPaths: []string{}}
 	now := time.Now().UnixMilli()
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var prior struct {
@@ -186,12 +188,7 @@ func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
 			if prior.RequestHash != requestHash {
 				return errConflict
 			}
-			var snap struct {
-				Revision int64 `json:"revision"`
-			}
-			_ = json.Unmarshal([]byte(prior.Response), &snap)
-			newRevision = snap.Revision
-			return nil
+			return json.Unmarshal([]byte(prior.Response), &response)
 		}
 		var row onboardingState
 		if err := tx.Raw(`SELECT state, current_step, revision FROM agent_onboarding_v2
@@ -201,35 +198,67 @@ func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
 		if row.State == "completed" || row.Revision != req.ExpectedRevision {
 			return errConflict
 		}
-		newRevision = row.Revision + 1
+		var stored struct {
+			DraftData       string `gorm:"column:draft_data"`
+			FieldProvenance string `gorm:"column:field_provenance"`
+			ActorType       string `gorm:"column:actor_type"`
+		}
+		if err := tx.Raw(`SELECT draft_data::text AS draft_data,
+				field_provenance::text AS field_provenance, actor_type
+			FROM agent_onboarding_drafts WHERE agent_id = ?
+			ORDER BY revision DESC LIMIT 1`, id).Scan(&stored).Error; err != nil {
+			return err
+		}
+		previous, err := decodeJSONObject(json.RawMessage(stored.DraftData))
+		if err != nil {
+			return err
+		}
+		incoming, err := decodeJSONObject(req.Draft)
+		if err != nil {
+			return err
+		}
+		provenance := decodeProvenance(json.RawMessage(stored.FieldProvenance))
+		if len(provenance) == 0 && validProvenance(stored.ActorType) {
+			provenance = deriveInitialProvenance(previous, stored.ActorType)
+		}
+		merged, provenance, blockedPaths := mergeOnboardingDraft(previous, incoming, provenance, actorType)
+		mergedJSON, err := json.Marshal(merged)
+		if err != nil {
+			return err
+		}
+		provenanceJSON, err := json.Marshal(provenance)
+		if err != nil {
+			return err
+		}
+		newRevision := row.Revision + 1
+		response = putDraftResponse{
+			Revision: newRevision, FieldProvenance: provenance, BlockedPaths: blockedPaths,
+		}
 		if err := tx.Exec(`INSERT INTO agent_onboarding_drafts
 			(agent_id, revision, draft_data, field_provenance, actor_type, request_id, created_at)
 			VALUES (?, ?, ?::jsonb, ?::jsonb, ?, ?, ?)`, id, newRevision,
-			string(req.Draft), string(req.FieldProvenance), actorType, req.IdempotencyKey, now).Error; err != nil {
+			string(mergedJSON), string(provenanceJSON), actorType, req.IdempotencyKey, now).Error; err != nil {
 			return err
 		}
 		if res := tx.Exec(`UPDATE agent_onboarding_v2 SET revision = ?, updated_at = ?
 			WHERE agent_id = ? AND revision = ?`, newRevision, now, id, row.Revision); res.Error != nil || res.RowsAffected != 1 {
 			return errConflict
 		}
-		snapshot, _ := json.Marshal(map[string]interface{}{"revision": newRevision})
+		snapshot, _ := json.Marshal(response)
 		return tx.Exec(`INSERT INTO agent_idempotency_requests
 			(agent_id, operation, idempotency_key, request_hash, response_snapshot, expires_at, created_at)
 			VALUES (?, 'onboarding_draft_put', ?, ?, ?::jsonb, ?, ?)`, id, req.IdempotencyKey,
 			requestHash, string(snapshot), now+int64(24*time.Hour/time.Millisecond), now).Error
 	})
 	if err != nil && (errors.Is(err, errConflict) || isUniqueViolation(err)) {
-		var snapshot struct {
-			Revision int64 `json:"revision"`
-		}
-		found, hashConflict, replayErr := s.loadIdempotentResponse(id, "onboarding_draft_put", req.IdempotencyKey, requestHash, &snapshot)
+		found, hashConflict, replayErr := s.loadIdempotentResponse(id, "onboarding_draft_put", req.IdempotencyKey, requestHash, &response)
 		switch {
 		case replayErr != nil:
 			err = replayErr
 		case found && hashConflict:
 			err = errConflict
 		case found:
-			newRevision, err = snapshot.Revision, nil
+			err = nil
 		}
 	}
 	if errors.Is(err, errConflict) {
@@ -240,7 +269,7 @@ func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusInternalServerError, "DRAFT_SAVE_FAILED", "could not save onboarding draft", nil)
 		return
 	}
-	reply(c, http.StatusOK, map[string]interface{}{"revision": newRevision})
+	reply(c, http.StatusOK, response)
 }
 
 func (s *Service) getOnboardingDraft(_ context.Context, c *app.RequestContext) {
@@ -453,19 +482,33 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 		if !canConfirmOnboardingStep(state.State, state.CurrentStep, req.Step) || state.Revision != req.ExpectedOnboardingRevision {
 			return errConflict
 		}
-		var rawDraft string
-		if err := tx.Raw(`SELECT draft_data::text FROM agent_onboarding_drafts
-			WHERE agent_id = ? ORDER BY revision DESC LIMIT 1`, id).Scan(&rawDraft).Error; err != nil {
+		var storedDraft struct {
+			DraftData       string `gorm:"column:draft_data"`
+			FieldProvenance string `gorm:"column:field_provenance"`
+			ActorType       string `gorm:"column:actor_type"`
+		}
+		if err := tx.Raw(`SELECT draft_data::text AS draft_data,
+				field_provenance::text AS field_provenance, actor_type
+			FROM agent_onboarding_drafts
+			WHERE agent_id = ? ORDER BY revision DESC LIMIT 1`, id).Scan(&storedDraft).Error; err != nil {
 			return err
 		}
 		var payload draftPayload
-		if err := json.Unmarshal([]byte(rawDraft), &payload); err != nil {
+		if err := json.Unmarshal([]byte(storedDraft.DraftData), &payload); err != nil {
 			return err
+		}
+		provenance := decodeProvenance(json.RawMessage(storedDraft.FieldProvenance))
+		if len(provenance) == 0 && validProvenance(storedDraft.ActorType) {
+			rawObject, decodeErr := decodeJSONObject(json.RawMessage(storedDraft.DraftData))
+			if decodeErr != nil {
+				return decodeErr
+			}
+			provenance = deriveInitialProvenance(rawObject, storedDraft.ActorType)
 		}
 		if err := validateDraftStep(payload, req.Step); err != nil {
 			return err
 		}
-		if err := applyConfirmedStep(tx, id, req.Step, payload, now); err != nil {
+		if err := applyConfirmedStep(tx, id, req.Step, payload, provenance, now); err != nil {
 			return err
 		}
 		newRevision := state.Revision + 1
@@ -489,6 +532,10 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 				"communication:read", "communication:write", "broadcast:write", "trade:write",
 				"console:handoff:create",
 			}), id, now).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE agents SET profile_completed_at = COALESCE(profile_completed_at, ?),
+				updated_at = ? WHERE agent_id = ?`, now, now, id).Error; err != nil {
 				return err
 			}
 			contextRevision = revision
@@ -541,10 +588,25 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 	if req.Step == 2 {
 		agentcard.PublishRebuild(ctx, id, "console_v2_onboarding_identity")
 	}
+	if req.Step == 5 && response["state"] == "completed" {
+		publishProfileCompletion(ctx, id)
+	}
 	reply(c, http.StatusOK, response)
 }
 
-func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPayload, now int64) error {
+func publishProfileCompletion(ctx context.Context, agentID int64) {
+	if mq.RDB == nil {
+		logger.Default().Warn("profile completion publish skipped: redis unavailable", "agentID", agentID)
+		return
+	}
+	if _, err := mq.Publish(ctx, "stream:profile:update", map[string]interface{}{
+		"agent_id": strconv.FormatInt(agentID, 10),
+	}); err != nil {
+		logger.Default().Warn("profile completion publish failed", "agentID", agentID, "err", err)
+	}
+}
+
+func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPayload, provenance map[string]string, now int64) error {
 	switch step {
 	case 2:
 		if strings.TrimSpace(payload.IdentityCard.AgentName) == "" {
@@ -619,7 +681,8 @@ func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPay
 		}
 		return tx.Exec(`INSERT INTO agent_network_goals
 			(agent_id, goal_text, source, status, version, created_at, updated_at)
-			VALUES (?, ?, 'human_edit', 'active', 1, ?, ?)`, agentID, payload.NetworkGoal, now, now).Error
+			VALUES (?, ?, ?, 'active', 1, ?, ?)`, agentID, payload.NetworkGoal,
+			canonicalSource(provenance, "network_goal"), now, now).Error
 	case 5:
 		if err := tx.Exec(`UPDATE agent_intent_actions SET status = 'deleted', updated_at = ?
 			WHERE agent_id = ? AND status <> 'deleted'`, now, agentID).Error; err != nil {
@@ -629,9 +692,9 @@ func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPay
 			if err := tx.Exec(`INSERT INTO agent_intent_actions
 				(agent_id, watch_for, trigger_when, action_instruction, action_policy, priority,
 				 source, status, version, created_at, updated_at)
-				VALUES (?, ?, ?, ?, ?, ?, 'human_edit', 'active', 1, ?, ?)`, agentID,
+				VALUES (?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?)`, agentID,
 				intent.WatchFor, intent.TriggerWhen, intent.ActionInstruction, intent.ActionPolicy,
-				intent.Priority, now, now).Error; err != nil {
+				intent.Priority, canonicalSource(provenance, "intent_actions"), now, now).Error; err != nil {
 				return err
 			}
 		}

--- a/api/consolev2/onboarding_provenance.go
+++ b/api/consolev2/onboarding_provenance.go
@@ -1,0 +1,186 @@
+package consolev2
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+const (
+	provenanceAgent  = "agent_prefill"
+	provenanceHuman  = "human_edit"
+	provenanceSystem = "system_derived"
+)
+
+var onboardingDraftFieldPaths = []string{
+	"identity_card.agent_name",
+	"identity_card.bio",
+	"identity_card.agent_description",
+	"identity_card.human_description",
+	"identity_card.working_languages",
+	"identity_card.seeking",
+	"identity_card.offering",
+	"identity_card.geo",
+	"identity_card.timezone",
+	"identity_card.agent_status",
+	"identity_card.human_status",
+	"identity_card.interests_negative",
+	"security_boundary.recurring_publish",
+	"security_boundary.auto_reply_pm",
+	"security_boundary.auto_comment",
+	"security_boundary.show_add_friend",
+	"network_goal",
+	"intent_actions",
+}
+
+func decodeJSONObject(raw json.RawMessage) (map[string]interface{}, error) {
+	value := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func decodeProvenance(raw json.RawMessage) map[string]string {
+	values := map[string]string{}
+	if len(raw) == 0 {
+		return values
+	}
+	_ = json.Unmarshal(raw, &values)
+	for path, source := range values {
+		if !validProvenance(source) {
+			delete(values, path)
+		}
+	}
+	return values
+}
+
+func validProvenance(source string) bool {
+	switch source {
+	case provenanceAgent, provenanceHuman, provenanceSystem:
+		return true
+	default:
+		return false
+	}
+}
+
+func draftPathValue(root map[string]interface{}, path string) (interface{}, bool) {
+	parts := strings.Split(path, ".")
+	var current interface{} = root
+	for _, part := range parts {
+		object, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func setDraftPathValue(root map[string]interface{}, path string, value interface{}, exists bool) {
+	parts := strings.Split(path, ".")
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		next, ok := current[part].(map[string]interface{})
+		if !ok {
+			next = map[string]interface{}{}
+			current[part] = next
+		}
+		current = next
+	}
+	leaf := parts[len(parts)-1]
+	if exists {
+		current[leaf] = value
+	} else {
+		delete(current, leaf)
+	}
+}
+
+func meaningfulDraftValue(value interface{}, exists bool) bool {
+	if !exists || value == nil {
+		return false
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed) != ""
+	case []interface{}:
+		return len(typed) > 0
+	case map[string]interface{}:
+		return len(typed) > 0
+	default:
+		// Booleans are explicit settings even when false; numeric zero may also
+		// be an intentional value in future additive fields.
+		return true
+	}
+}
+
+// deriveInitialProvenance records only fields that the Agent actually
+// supplied. Empty placeholders stay unlabelled so the Web cannot claim they
+// were prefilled when no value exists.
+func deriveInitialProvenance(draft map[string]interface{}, source string) map[string]string {
+	result := map[string]string{}
+	if !validProvenance(source) {
+		return result
+	}
+	for _, path := range onboardingDraftFieldPaths {
+		value, exists := draftPathValue(draft, path)
+		if meaningfulDraftValue(value, exists) {
+			result[path] = source
+		}
+	}
+	return result
+}
+
+// mergeOnboardingDraft enforces field ownership at the server boundary. A
+// human edit wins permanently for that draft field; later Agent prefills are
+// skipped and reported instead of silently overwriting the user's choice.
+func mergeOnboardingDraft(previous, incoming map[string]interface{}, previousProvenance map[string]string, actor string) (map[string]interface{}, map[string]string, []string) {
+	merged := incoming
+	provenance := make(map[string]string, len(previousProvenance))
+	for path, source := range previousProvenance {
+		if validProvenance(source) {
+			provenance[path] = source
+		}
+	}
+	blocked := make([]string, 0)
+	for _, path := range onboardingDraftFieldPaths {
+		oldValue, oldExists := draftPathValue(previous, path)
+		newValue, newExists := draftPathValue(incoming, path)
+		changed := oldExists != newExists || !reflect.DeepEqual(oldValue, newValue)
+
+		if actor == provenanceAgent && provenance[path] == provenanceHuman {
+			setDraftPathValue(merged, path, oldValue, oldExists)
+			if newExists {
+				blocked = append(blocked, path)
+			}
+			continue
+		}
+		if !changed {
+			continue
+		}
+		if actor == provenanceHuman {
+			// Keep human ownership even when the value was cleared; otherwise a
+			// later Agent prefill could resurrect data the user deliberately removed.
+			provenance[path] = provenanceHuman
+			continue
+		}
+		if meaningfulDraftValue(newValue, newExists) {
+			provenance[path] = provenanceAgent
+		} else {
+			delete(provenance, path)
+		}
+	}
+	sort.Strings(blocked)
+	return merged, provenance, blocked
+}
+
+func canonicalSource(provenance map[string]string, path string) string {
+	if source := provenance[path]; validProvenance(source) {
+		return source
+	}
+	return provenanceHuman
+}

--- a/api/consolev2/onboarding_provenance_test.go
+++ b/api/consolev2/onboarding_provenance_test.go
@@ -1,0 +1,99 @@
+package consolev2
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func mustDraftObject(t *testing.T, value string) map[string]interface{} {
+	t.Helper()
+	result, err := decodeJSONObject(json.RawMessage(value))
+	if err != nil {
+		t.Fatalf("decode draft: %v", err)
+	}
+	return result
+}
+
+func TestDeriveInitialProvenanceOnlyLabelsActualValues(t *testing.T) {
+	draft := mustDraftObject(t, `{
+		"identity_card": {
+			"agent_name": "Atlas",
+			"agent_description": "",
+			"working_languages": [],
+			"geo": "China",
+			"timezone": "Asia/Shanghai"
+		},
+		"security_boundary": {"recurring_publish": false},
+		"network_goal": "",
+		"intent_actions": []
+	}`)
+	got := deriveInitialProvenance(draft, provenanceAgent)
+	want := map[string]string{
+		"identity_card.agent_name":            provenanceAgent,
+		"identity_card.geo":                   provenanceAgent,
+		"identity_card.timezone":              provenanceAgent,
+		"security_boundary.recurring_publish": provenanceAgent,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("provenance mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestMergeOnboardingDraftHumanOwnershipBlocksLaterAgent(t *testing.T) {
+	original := mustDraftObject(t, `{
+		"identity_card":{"agent_name":"Atlas","geo":"China"},
+		"network_goal":"Find AI infrastructure signals",
+		"intent_actions":[]
+	}`)
+	humanEdit := mustDraftObject(t, `{
+		"identity_card":{"agent_name":"Atlas Research","geo":"China"},
+		"network_goal":"Find AI infrastructure signals",
+		"intent_actions":[]
+	}`)
+	initial := deriveInitialProvenance(original, provenanceAgent)
+	merged, afterHuman, blocked := mergeOnboardingDraft(original, humanEdit, initial, provenanceHuman)
+	if len(blocked) != 0 {
+		t.Fatalf("human edit unexpectedly blocked: %v", blocked)
+	}
+	if afterHuman["identity_card.agent_name"] != provenanceHuman {
+		t.Fatalf("human ownership not recorded: %#v", afterHuman)
+	}
+
+	agentRetry := mustDraftObject(t, `{
+		"identity_card":{"agent_name":"Agent overwrite","geo":"Singapore"},
+		"network_goal":"Find AI infrastructure signals",
+		"intent_actions":[]
+	}`)
+	merged, afterAgent, blocked := mergeOnboardingDraft(merged, agentRetry, afterHuman, provenanceAgent)
+	name, _ := draftPathValue(merged, "identity_card.agent_name")
+	if name != "Atlas Research" {
+		t.Fatalf("agent overwrote human value: %v", name)
+	}
+	geo, _ := draftPathValue(merged, "identity_card.geo")
+	if geo != "Singapore" {
+		t.Fatalf("agent-owned field did not refresh: %v", geo)
+	}
+	if !reflect.DeepEqual(blocked, []string{"identity_card.agent_name"}) {
+		t.Fatalf("blocked paths mismatch: %v", blocked)
+	}
+	if afterAgent["identity_card.agent_name"] != provenanceHuman || afterAgent["identity_card.geo"] != provenanceAgent {
+		t.Fatalf("sources mismatch after Agent retry: %#v", afterAgent)
+	}
+}
+
+func TestCanonicalSourceUsesStoredOwnership(t *testing.T) {
+	provenance := map[string]string{
+		"network_goal":   provenanceAgent,
+		"intent_actions": provenanceSystem,
+	}
+	if got := canonicalSource(provenance, "network_goal"); got != provenanceAgent {
+		t.Fatalf("network goal source = %q", got)
+	}
+	if got := canonicalSource(provenance, "intent_actions"); got != provenanceSystem {
+		t.Fatalf("intent source = %q", got)
+	}
+	if got := canonicalSource(provenance, "missing"); got != provenanceHuman {
+		t.Fatalf("legacy fallback source = %q", got)
+	}
+}


### PR DESCRIPTION
## What changed

- derive onboarding `field_provenance` from the authenticated Agent or Console actor instead of trusting client input
- preserve human-edited draft fields when the Agent submits another prefill and return `blocked_paths`
- carry the authoritative source into canonical network goals and intent/actions
- mark Console V2 profiles complete at onboarding step 5 and publish the existing profile-completion event so the official welcome/friend pipeline runs

## Why

Console V2 stored an empty or client-reported provenance object, while the Web labeled every editable field as Agent-prefilled. The V2 completion transaction also did not enter the existing V1 profile-completion pipeline, so new Agents did not receive the default official friend.

## Impact

- empty, Agent-prefilled, human-edited, and system-derived values can be distinguished reliably
- later Agent prefills cannot overwrite a human decision
- newly completed V2 Agents use the existing idempotent official welcome pipeline

## Validation

- `GOCACHE=/tmp/eigenflux-go-cache go test ./api/consolev2`
- added focused provenance ownership tests
- extended the PostgreSQL flow test to assert `profile_completed_at`
