### PR TITLE
fix(console-v2): report runtime and extend handoff lifetime

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -16,6 +16,9 @@ import (
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
+
+	consoledal "eigenflux_server/api/dal"
+	"eigenflux_server/pkg/runtimeidentity"
 )
 
 type issueGrantRequest struct {
@@ -283,6 +286,7 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	}
 	initialScopes := []string{"onboarding:write", "context:read", "feed:read", "notifications:ack", "commands:claim", "console:handoff:create"}
 	keyFingerprint := fingerprint(publicKey)
+	observedRuntime, hasObservedRuntime := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
 	var agentID, principalID, expiresAt int64
 	created := false
 	err = s.db.Transaction(func(tx *gorm.DB) error {
@@ -437,6 +441,15 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "PROVISION_FAILED", "could not provision Agent identity", nil)
 		return
+	}
+	// Provision is the first authenticated request in Console V2 onboarding.
+	// Persist its validated, self-reported product identity synchronously so the
+	// claim page can name the actual runtime before the first settings heartbeat.
+	if hasObservedRuntime {
+		if err := consoledal.UpdateRuntimeIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version); err != nil {
+			fail(c, http.StatusInternalServerError, "PROVISION_RUNTIME_REPORT_FAILED", "could not record Agent runtime", nil)
+			return
+		}
 	}
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":         fmt.Sprintf("%d", agentID),

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -209,7 +209,8 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 			t.Fatal(err)
 		}
 		req.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, transcript))
-		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agent-identities/provision", req)
+		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agent-identities/provision", req,
+			ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.3.14"})
 		if status != 200 {
 			t.Fatalf("provision status=%d payload=%#v", status, payload)
 		}
@@ -380,6 +381,11 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	onboarding := responseData(t, sessionPayload)["onboarding"].(map[string]interface{})
 	if onboarding["state"] != "completed" || onboarding["active_context_revision"] == nil {
 		t.Fatalf("onboarding completion is not bound to an active context: %#v", onboarding)
+	}
+	session := responseData(t, sessionPayload)
+	if session["runtime"] != "workbuddy/5.3.14" || session["runtime_name"] != "workbuddy" ||
+		session["runtime_version"] != "5.3.14" {
+		t.Fatalf("console session did not expose the provision runtime: %#v", session)
 	}
 	var profileCompletedAt *int64
 	if err := gdb.Raw(`SELECT profile_completed_at FROM agents WHERE agent_id = ?`, agentIDInt).

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -18,6 +18,7 @@ import (
 	"eigenflux_server/pkg/agentcard"
 	"eigenflux_server/pkg/logger"
 	"eigenflux_server/pkg/mq"
+	"eigenflux_server/pkg/runtimeidentity"
 	profiledal "eigenflux_server/rpc/profile/dal"
 )
 
@@ -75,19 +76,28 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	var identity struct {
-		AgentName     string `gorm:"column:agent_name"`
-		Bio           string `gorm:"column:bio"`
-		CreatedAt     int64  `gorm:"column:created_at"`
-		IsOfficial    bool   `gorm:"column:is_official"`
-		BoundEmail    string `gorm:"column:bound_email"`
-		EmailVerified bool   `gorm:"column:email_verified"`
+		AgentName      string `gorm:"column:agent_name"`
+		Bio            string `gorm:"column:bio"`
+		CreatedAt      int64  `gorm:"column:created_at"`
+		IsOfficial     bool   `gorm:"column:is_official"`
+		BoundEmail     string `gorm:"column:bound_email"`
+		EmailVerified  bool   `gorm:"column:email_verified"`
+		RuntimeName    string `gorm:"column:runtime_name"`
+		RuntimeVersion string `gorm:"column:runtime_version"`
+		RuntimeMode    string `gorm:"column:runtime_mode"`
+		ClientHost     string `gorm:"column:client_host"`
 	}
 	if err := s.db.Raw(`SELECT a.agent_name, a.bio, a.created_at, a.is_official,
 		COALESCE(b.normalized_email, '') AS bound_email,
-		(b.binding_id IS NOT NULL) AS email_verified
+		(b.binding_id IS NOT NULL) AS email_verified,
+		COALESCE(settings.runtime_name, '') AS runtime_name,
+		COALESCE(settings.runtime_version, '') AS runtime_version,
+		COALESCE(settings.mode, '') AS runtime_mode,
+		COALESCE(settings.client_host, '') AS client_host
 		FROM agents a
 		LEFT JOIN agent_email_bindings b ON b.agent_id = a.agent_id
 			AND b.status = 'active' AND b.verification_state = 'verified'
+		LEFT JOIN agent_settings settings ON settings.agent_id = a.agent_id
 		WHERE a.agent_id = ?`, id).Scan(&identity).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "SESSION_READ_FAILED", "could not read Agent identity", nil)
 		return
@@ -99,6 +109,9 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 	if identity.IsOfficial {
 		verificationLevel = "official"
 	}
+	runtime, runtimeName, runtimeVersion := consoleSessionRuntime(
+		identity.RuntimeName, identity.RuntimeVersion, identity.ClientHost,
+	)
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":           fmt.Sprintf("%d", id),
 		"agent_name":         identity.AgentName,
@@ -107,8 +120,30 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		"email":              identity.BoundEmail,
 		"email_bound":        identity.EmailVerified,
 		"verification_level": verificationLevel,
+		"runtime":            runtime,
+		"runtime_name":       runtimeName,
+		"runtime_version":    runtimeVersion,
+		"runtime_mode":       identity.RuntimeMode,
 		"onboarding":         state,
 	})
+}
+
+func consoleSessionRuntime(name, version, clientHost string) (runtime, runtimeName, runtimeVersion string) {
+	runtimeName = strings.TrimSpace(name)
+	runtimeVersion = strings.TrimSpace(version)
+	if runtimeName == "" {
+		if identity, ok := runtimeidentity.Parse(clientHost); ok {
+			runtimeName, runtimeVersion = identity.Name, identity.Version
+		}
+	}
+	if runtimeName == "" {
+		return "", "", ""
+	}
+	runtime = runtimeName
+	if runtimeVersion != "" {
+		runtime += "/" + runtimeVersion
+	}
+	return runtime, runtimeName, runtimeVersion
 }
 
 func (s *Service) deleteConsoleSession(_ context.Context, c *app.RequestContext) {

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -39,7 +39,7 @@ const (
 	csrfCookieName    = "ef_console_v2_csrf"
 	accessTTL         = 15 * time.Minute
 	refreshTTL        = 30 * 24 * time.Hour
-	handoffTTL        = 5 * time.Minute
+	handoffTTL        = 15 * time.Minute
 	grantTTL          = 5 * time.Minute
 	proofClockSkew    = 5 * time.Minute
 	maxRequestBytes   = 256 << 10

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -27,6 +27,12 @@ func (g *fixedIDGenerator) NextID() (int64, error) {
 	return g.id, nil
 }
 
+func TestConsoleHandoffTTL(t *testing.T) {
+	if handoffTTL != 15*time.Minute {
+		t.Fatalf("handoffTTL = %s, want 15m", handoffTTL)
+	}
+}
+
 func TestProvisionTranscriptVerifiesAndCoversMutableFields(t *testing.T) {
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -308,6 +308,22 @@ func TestNotificationIssuerIdentityFailsClosed(t *testing.T) {
 	}
 }
 
+func TestConsoleSessionRuntime(t *testing.T) {
+	for _, test := range []struct {
+		name, version, host, wantRuntime, wantName, wantVersion string
+	}{
+		{name: "workbuddy", version: "5.3.14", host: "openclaw/1.2.3", wantRuntime: "workbuddy/5.3.14", wantName: "workbuddy", wantVersion: "5.3.14"},
+		{host: "openclaw/1.2.3", wantRuntime: "openclaw/1.2.3", wantName: "openclaw", wantVersion: "1.2.3"},
+		{host: "terminal"},
+	} {
+		runtime, name, version := consoleSessionRuntime(test.name, test.version, test.host)
+		if runtime != test.wantRuntime || name != test.wantName || version != test.wantVersion {
+			t.Fatalf("consoleSessionRuntime(%q, %q, %q) = (%q, %q, %q)",
+				test.name, test.version, test.host, runtime, name, version)
+		}
+	}
+}
+
 func TestCommunicationResponseBudgetAndTextFallback(t *testing.T) {
 	data := map[string]interface{}{"messages": []communicationMessage{{Content: strings.Repeat("🙂", 100000)}}}
 	if communicationReplyFits(data) {


### PR DESCRIPTION
## Summary
- persist the Agent-reported runtime identity during V2 provision
- expose runtime name/version/mode in the Console V2 session
- extend the single-use Console V2 handoff link from 5 minutes to 15 minutes
- keep legacy sessions compatible when runtime metadata is absent

## Validation
- GOCACHE=/tmp/eigenflux-go-cache-runtime-handoff go test ./api/consolev2

## Scope
Backend only. No CLI binary, public Skills, Web deployment, or database migration changes.