### PR TITLE
feat(console-v2): normalize onboarding location and provenance

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -16,6 +16,9 @@ import (
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
+
+	consoledal "eigenflux_server/api/dal"
+	"eigenflux_server/pkg/runtimeidentity"
 )
 
 type issueGrantRequest struct {
@@ -283,6 +286,7 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	}
 	initialScopes := []string{"onboarding:write", "context:read", "feed:read", "notifications:ack", "commands:claim", "console:handoff:create"}
 	keyFingerprint := fingerprint(publicKey)
+	observedRuntime, hasObservedRuntime := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
 	var agentID, principalID, expiresAt int64
 	created := false
 	err = s.db.Transaction(func(tx *gorm.DB) error {
@@ -437,6 +441,15 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "PROVISION_FAILED", "could not provision Agent identity", nil)
 		return
+	}
+	// Provision is the first authenticated request in Console V2 onboarding.
+	// Persist its validated, self-reported product identity synchronously so the
+	// claim page can name the actual runtime before the first settings heartbeat.
+	if hasObservedRuntime {
+		if err := consoledal.UpdateRuntimeIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version); err != nil {
+			fail(c, http.StatusInternalServerError, "PROVISION_RUNTIME_REPORT_FAILED", "could not record Agent runtime", nil)
+			return
+		}
 	}
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":         fmt.Sprintf("%d", agentID),

--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -174,35 +174,38 @@ func subtleHeaderMismatch(got, want string) bool {
 }
 
 type provisionRequest struct {
-	BootstrapGrant string          `json:"bootstrap_grant"`
-	IdempotencyKey string          `json:"idempotency_key"`
-	Nonce          string          `json:"nonce"`
-	PublicKey      string          `json:"public_key"`
-	IssuedAt       int64           `json:"issued_at"`
-	AgentName      string          `json:"agent_name"`
-	Signature      string          `json:"signature"`
-	Draft          json.RawMessage `json:"onboarding_draft,omitempty"`
+	BootstrapGrant  string            `json:"bootstrap_grant"`
+	IdempotencyKey  string            `json:"idempotency_key"`
+	Nonce           string            `json:"nonce"`
+	PublicKey       string            `json:"public_key"`
+	IssuedAt        int64             `json:"issued_at"`
+	AgentName       string            `json:"agent_name"`
+	Signature       string            `json:"signature"`
+	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
+	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
 }
 
 type provisionProofPayload struct {
-	BootstrapGrant string          `json:"bootstrap_grant"`
-	IdempotencyKey string          `json:"idempotency_key"`
-	Nonce          string          `json:"nonce"`
-	PublicKey      string          `json:"public_key"`
-	IssuedAt       int64           `json:"issued_at"`
-	AgentName      string          `json:"agent_name"`
-	Draft          json.RawMessage `json:"onboarding_draft,omitempty"`
+	BootstrapGrant  string            `json:"bootstrap_grant"`
+	IdempotencyKey  string            `json:"idempotency_key"`
+	Nonce           string            `json:"nonce"`
+	PublicKey       string            `json:"public_key"`
+	IssuedAt        int64             `json:"issued_at"`
+	AgentName       string            `json:"agent_name"`
+	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
+	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
 }
 
 func provisionTranscript(req provisionRequest) ([]byte, error) {
 	payload := provisionProofPayload{
-		BootstrapGrant: req.BootstrapGrant,
-		IdempotencyKey: req.IdempotencyKey,
-		Nonce:          req.Nonce,
-		PublicKey:      req.PublicKey,
-		IssuedAt:       req.IssuedAt,
-		AgentName:      req.AgentName,
-		Draft:          req.Draft,
+		BootstrapGrant:  req.BootstrapGrant,
+		IdempotencyKey:  req.IdempotencyKey,
+		Nonce:           req.Nonce,
+		PublicKey:       req.PublicKey,
+		IssuedAt:        req.IssuedAt,
+		AgentName:       req.AgentName,
+		Draft:           req.Draft,
+		FieldProvenance: req.FieldProvenance,
 	}
 	canonical, err := json.Marshal(payload)
 	if err != nil {
@@ -215,6 +218,7 @@ func provisionReceiptHash(req provisionRequest) (string, error) {
 	payload := provisionProofPayload{
 		BootstrapGrant: req.BootstrapGrant, IdempotencyKey: req.IdempotencyKey,
 		Nonce: req.Nonce, PublicKey: req.PublicKey, AgentName: req.AgentName, Draft: req.Draft,
+		FieldProvenance: req.FieldProvenance,
 	}
 	canonical, err := json.Marshal(payload)
 	if err != nil {
@@ -259,12 +263,21 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	if len(req.Draft) == 0 {
 		req.Draft = json.RawMessage(`{}`)
 	}
-	var draftObject map[string]interface{}
-	if len(req.Draft) > 64<<10 || json.Unmarshal(req.Draft, &draftObject) != nil {
+	if len(req.Draft) > 64<<10 {
 		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "onboarding_draft must be a JSON object no larger than 64KB", nil)
 		return
 	}
-	initialProvenance, err := json.Marshal(deriveInitialProvenance(draftObject, provenanceAgent))
+	normalizedDraft, draftObject, err := normalizeOnboardingDraftJSON(req.Draft)
+	if err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_DRAFT", err.Error(), nil)
+		return
+	}
+	if err := validateRequestedAgentProvenance(req.FieldProvenance); err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_FIELD_PROVENANCE", err.Error(), nil)
+		return
+	}
+	req.Draft = normalizedDraft
+	initialProvenance, err := json.Marshal(deriveInitialProvenance(draftObject, provenanceAgent, req.FieldProvenance, wallNow))
 	if err != nil {
 		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "could not derive onboarding field sources", nil)
 		return

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -209,7 +209,8 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 			t.Fatal(err)
 		}
 		req.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, transcript))
-		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agent-identities/provision", req)
+		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agent-identities/provision", req,
+			ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.3.14"})
 		if status != 200 {
 			t.Fatalf("provision status=%d payload=%#v", status, payload)
 		}
@@ -380,6 +381,11 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	onboarding := responseData(t, sessionPayload)["onboarding"].(map[string]interface{})
 	if onboarding["state"] != "completed" || onboarding["active_context_revision"] == nil {
 		t.Fatalf("onboarding completion is not bound to an active context: %#v", onboarding)
+	}
+	session := responseData(t, sessionPayload)
+	if session["runtime"] != "workbuddy/5.3.14" || session["runtime_name"] != "workbuddy" ||
+		session["runtime_version"] != "5.3.14" {
+		t.Fatalf("console session did not expose the provision runtime: %#v", session)
 	}
 	var profileCompletedAt *int64
 	if err := gdb.Raw(`SELECT profile_completed_at FROM agents WHERE agent_id = ?`, agentIDInt).

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -18,6 +18,7 @@ import (
 	"eigenflux_server/pkg/agentcard"
 	"eigenflux_server/pkg/logger"
 	"eigenflux_server/pkg/mq"
+	"eigenflux_server/pkg/runtimeidentity"
 	profiledal "eigenflux_server/rpc/profile/dal"
 )
 
@@ -75,19 +76,28 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	var identity struct {
-		AgentName     string `gorm:"column:agent_name"`
-		Bio           string `gorm:"column:bio"`
-		CreatedAt     int64  `gorm:"column:created_at"`
-		IsOfficial    bool   `gorm:"column:is_official"`
-		BoundEmail    string `gorm:"column:bound_email"`
-		EmailVerified bool   `gorm:"column:email_verified"`
+		AgentName      string `gorm:"column:agent_name"`
+		Bio            string `gorm:"column:bio"`
+		CreatedAt      int64  `gorm:"column:created_at"`
+		IsOfficial     bool   `gorm:"column:is_official"`
+		BoundEmail     string `gorm:"column:bound_email"`
+		EmailVerified  bool   `gorm:"column:email_verified"`
+		RuntimeName    string `gorm:"column:runtime_name"`
+		RuntimeVersion string `gorm:"column:runtime_version"`
+		RuntimeMode    string `gorm:"column:runtime_mode"`
+		ClientHost     string `gorm:"column:client_host"`
 	}
 	if err := s.db.Raw(`SELECT a.agent_name, a.bio, a.created_at, a.is_official,
 		COALESCE(b.normalized_email, '') AS bound_email,
-		(b.binding_id IS NOT NULL) AS email_verified
+		(b.binding_id IS NOT NULL) AS email_verified,
+		COALESCE(settings.runtime_name, '') AS runtime_name,
+		COALESCE(settings.runtime_version, '') AS runtime_version,
+		COALESCE(settings.mode, '') AS runtime_mode,
+		COALESCE(settings.client_host, '') AS client_host
 		FROM agents a
 		LEFT JOIN agent_email_bindings b ON b.agent_id = a.agent_id
 			AND b.status = 'active' AND b.verification_state = 'verified'
+		LEFT JOIN agent_settings settings ON settings.agent_id = a.agent_id
 		WHERE a.agent_id = ?`, id).Scan(&identity).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "SESSION_READ_FAILED", "could not read Agent identity", nil)
 		return
@@ -99,6 +109,9 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 	if identity.IsOfficial {
 		verificationLevel = "official"
 	}
+	runtime, runtimeName, runtimeVersion := consoleSessionRuntime(
+		identity.RuntimeName, identity.RuntimeVersion, identity.ClientHost,
+	)
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":           fmt.Sprintf("%d", id),
 		"agent_name":         identity.AgentName,
@@ -107,8 +120,30 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		"email":              identity.BoundEmail,
 		"email_bound":        identity.EmailVerified,
 		"verification_level": verificationLevel,
+		"runtime":            runtime,
+		"runtime_name":       runtimeName,
+		"runtime_version":    runtimeVersion,
+		"runtime_mode":       identity.RuntimeMode,
 		"onboarding":         state,
 	})
+}
+
+func consoleSessionRuntime(name, version, clientHost string) (runtime, runtimeName, runtimeVersion string) {
+	runtimeName = strings.TrimSpace(name)
+	runtimeVersion = strings.TrimSpace(version)
+	if runtimeName == "" {
+		if identity, ok := runtimeidentity.Parse(clientHost); ok {
+			runtimeName, runtimeVersion = identity.Name, identity.Version
+		}
+	}
+	if runtimeName == "" {
+		return "", "", ""
+	}
+	runtime = runtimeName
+	if runtimeVersion != "" {
+		runtime += "/" + runtimeVersion
+	}
+	return runtime, runtimeName, runtimeVersion
 }
 
 func (s *Service) deleteConsoleSession(_ context.Context, c *app.RequestContext) {

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -61,7 +61,29 @@ func (s *Service) loadOnboarding(agentID int64) (onboardingState, onboardingDraf
 		Revision: stored.Revision, DraftData: json.RawMessage(stored.DraftData),
 		FieldProvenance: json.RawMessage(stored.FieldProvenance), ActorType: stored.ActorType, CreatedAt: stored.CreatedAt,
 	}
-	return state, draft, err
+	if err != nil {
+		return state, draft, err
+	}
+	normalized, normalizeErr := normalizeLoadedOnboardingDraft(draft)
+	return state, normalized, normalizeErr
+}
+
+func normalizeLoadedOnboardingDraft(draft onboardingDraft) (onboardingDraft, error) {
+	normalizedData, draftObject, err := normalizeOnboardingDraftJSON(draft.DraftData)
+	if err != nil {
+		return draft, err
+	}
+	provenance := decodeProvenance(draft.FieldProvenance)
+	if len(provenance) == 0 && validProvenance(draft.ActorType) {
+		provenance = deriveInitialProvenance(draftObject, draft.ActorType, nil, draft.CreatedAt)
+	}
+	normalizedProvenance, err := json.Marshal(provenance)
+	if err != nil {
+		return draft, err
+	}
+	draft.DraftData = normalizedData
+	draft.FieldProvenance = normalizedProvenance
+	return draft, nil
 }
 
 func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
@@ -165,18 +187,16 @@ func (s *Service) deleteConsoleSession(_ context.Context, c *app.RequestContext)
 }
 
 type putDraftRequest struct {
-	ExpectedRevision int64           `json:"expected_revision"`
-	IdempotencyKey   string          `json:"idempotency_key"`
-	Draft            json.RawMessage `json:"draft"`
-	// Kept for rolling client compatibility. Field ownership is derived from
-	// the authenticated actor and this request value is intentionally ignored.
-	FieldProvenance json.RawMessage `json:"field_provenance,omitempty"`
+	ExpectedRevision int64             `json:"expected_revision"`
+	IdempotencyKey   string            `json:"idempotency_key"`
+	Draft            json.RawMessage   `json:"draft"`
+	FieldProvenance  map[string]string `json:"field_provenance,omitempty"`
 }
 
 type putDraftResponse struct {
-	Revision        int64             `json:"revision"`
-	FieldProvenance map[string]string `json:"field_provenance"`
-	BlockedPaths    []string          `json:"blocked_paths"`
+	Revision        int64                      `json:"revision"`
+	FieldProvenance map[string]fieldProvenance `json:"field_provenance"`
+	BlockedPaths    []string                   `json:"blocked_paths"`
 }
 
 func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
@@ -198,17 +218,27 @@ func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "draft must be a JSON object no larger than 64KB", nil)
 		return
 	}
-	var draftObject map[string]interface{}
-	if json.Unmarshal(req.Draft, &draftObject) != nil {
-		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "draft must be a JSON object", nil)
+	normalizedDraft, draftObject, normalizeErr := normalizeOnboardingDraftJSON(req.Draft)
+	if normalizeErr != nil {
+		fail(c, http.StatusBadRequest, "INVALID_DRAFT", normalizeErr.Error(), nil)
 		return
 	}
+	req.Draft = normalizedDraft
 	actorType := "agent_prefill"
 	if _, console := c.Get("console_session_id"); console {
 		actorType = "human_edit"
 	}
-	requestHash := hashString(fmt.Sprintf("%d:%s:%s", req.ExpectedRevision, req.Draft, actorType))
-	response := putDraftResponse{FieldProvenance: map[string]string{}, BlockedPaths: []string{}}
+	if actorType == provenanceAgent {
+		if err := validateRequestedAgentProvenance(req.FieldProvenance); err != nil {
+			fail(c, http.StatusBadRequest, "INVALID_FIELD_PROVENANCE", err.Error(), nil)
+			return
+		}
+	} else {
+		req.FieldProvenance = nil
+	}
+	provenanceRequestJSON, _ := json.Marshal(req.FieldProvenance)
+	requestHash := hashString(fmt.Sprintf("%d:%s:%s:%s", req.ExpectedRevision, req.Draft, provenanceRequestJSON, actorType))
+	response := putDraftResponse{FieldProvenance: map[string]fieldProvenance{}, BlockedPaths: []string{}}
 	now := time.Now().UnixMilli()
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var prior struct {
@@ -248,15 +278,12 @@ func (s *Service) putOnboardingDraft(_ context.Context, c *app.RequestContext) {
 		if err != nil {
 			return err
 		}
-		incoming, err := decodeJSONObject(req.Draft)
-		if err != nil {
-			return err
-		}
+		incoming := draftObject
 		provenance := decodeProvenance(json.RawMessage(stored.FieldProvenance))
 		if len(provenance) == 0 && validProvenance(stored.ActorType) {
-			provenance = deriveInitialProvenance(previous, stored.ActorType)
+			provenance = deriveInitialProvenance(previous, stored.ActorType, nil, now)
 		}
-		merged, provenance, blockedPaths := mergeOnboardingDraft(previous, incoming, provenance, actorType)
+		merged, provenance, blockedPaths := mergeOnboardingDraft(previous, incoming, provenance, actorType, req.FieldProvenance, now)
 		mergedJSON, err := json.Marshal(merged)
 		if err != nil {
 			return err
@@ -528,21 +555,22 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 			WHERE agent_id = ? ORDER BY revision DESC LIMIT 1`, id).Scan(&storedDraft).Error; err != nil {
 			return err
 		}
+		normalizedDraftJSON, rawDraft, err := normalizeOnboardingDraftJSON(json.RawMessage(storedDraft.DraftData))
+		if err != nil {
+			return fmt.Errorf("%w: %v", errInvalidOnboardingDraft, err)
+		}
 		var payload draftPayload
-		if err := json.Unmarshal([]byte(storedDraft.DraftData), &payload); err != nil {
+		if err := json.Unmarshal(normalizedDraftJSON, &payload); err != nil {
 			return err
 		}
 		provenance := decodeProvenance(json.RawMessage(storedDraft.FieldProvenance))
 		if len(provenance) == 0 && validProvenance(storedDraft.ActorType) {
-			rawObject, decodeErr := decodeJSONObject(json.RawMessage(storedDraft.DraftData))
-			if decodeErr != nil {
-				return decodeErr
-			}
-			provenance = deriveInitialProvenance(rawObject, storedDraft.ActorType)
+			provenance = deriveInitialProvenance(rawDraft, storedDraft.ActorType, nil, now)
 		}
 		if err := validateDraftStep(payload, req.Step); err != nil {
 			return err
 		}
+		provenance = confirmStepProvenance(rawDraft, provenance, req.Step, now)
 		if err := applyConfirmedStep(tx, id, req.Step, payload, provenance, now); err != nil {
 			return err
 		}
@@ -586,6 +614,16 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 				WHERE agent_id = ? AND revision = ?`, nextStep, newRevision, now, id, state.Revision); res.Error != nil || res.RowsAffected != 1 {
 				return errConflict
 			}
+		}
+		provenanceJSON, err := json.Marshal(provenance)
+		if err != nil {
+			return err
+		}
+		if err := tx.Exec(`INSERT INTO agent_onboarding_drafts
+			(agent_id, revision, draft_data, field_provenance, actor_type, request_id, created_at)
+			VALUES (?, ?, ?::jsonb, ?::jsonb, 'human_edit', ?, ?)`, id, newRevision,
+			string(normalizedDraftJSON), string(provenanceJSON), "confirm:"+hashString(req.IdempotencyKey), now).Error; err != nil {
+			return err
 		}
 		response = map[string]interface{}{
 			"state": newState, "current_step": nextStep, "revision": newRevision,
@@ -641,7 +679,7 @@ func publishProfileCompletion(ctx context.Context, agentID int64) {
 	}
 }
 
-func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPayload, provenance map[string]string, now int64) error {
+func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPayload, provenance map[string]fieldProvenance, now int64) error {
 	switch step {
 	case 2:
 		if strings.TrimSpace(payload.IdentityCard.AgentName) == "" {

--- a/api/consolev2/onboarding_location.go
+++ b/api/consolev2/onboarding_location.go
@@ -1,0 +1,117 @@
+package consolev2
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var countryCodePattern = regexp.MustCompile(`^[A-Z]{2}$`)
+
+var onboardingCountryAliases = map[string]string{
+	"CN": "CN", "CHINA": "CN", "中国": "CN", "中国大陆": "CN",
+	"HK": "HK", "HONG KONG": "HK", "香港": "HK", "中国香港": "HK",
+	"SG": "SG", "SINGAPORE": "SG", "新加坡": "SG",
+	"JP": "JP", "JAPAN": "JP", "日本": "JP",
+	"US": "US", "USA": "US", "UNITED STATES": "US", "美国": "US",
+	"GB": "GB", "UK": "GB", "UNITED KINGDOM": "GB", "英国": "GB",
+	"ZZ": "ZZ", "OTHER": "ZZ", "其他": "ZZ",
+}
+
+var onboardingTimezoneAliases = map[string]string{
+	"ASIA/SHANGHAI":       "Asia/Shanghai",
+	"ASIA/SINGAPORE":      "Asia/Singapore",
+	"ASIA/TOKYO":          "Asia/Tokyo",
+	"AMERICA/LOS_ANGELES": "America/Los_Angeles",
+	"AMERICA/NEW_YORK":    "America/New_York",
+	"EUROPE/LONDON":       "Europe/London",
+}
+
+func normalizeOnboardingCountry(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", nil
+	}
+	if code, ok := onboardingCountryAliases[strings.ToUpper(value)]; ok {
+		return code, nil
+	}
+	upper := strings.ToUpper(value)
+	if countryCodePattern.MatchString(upper) {
+		return "", fmt.Errorf("country code %s is not supported by Console V2", upper)
+	}
+	return "", fmt.Errorf("geo must use a supported ISO 3166-1 alpha-2 code")
+}
+
+func normalizeOnboardingTimezone(raw, countryCode string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", nil
+	}
+	withoutOffset := regexp.MustCompile(`(?i)\s*\(UTC[+-][^)]+\)\s*$`).ReplaceAllString(value, "")
+	if zone, ok := onboardingTimezoneAliases[strings.ToUpper(withoutOffset)]; ok {
+		return zone, nil
+	}
+	compactOffset := strings.ToUpper(strings.ReplaceAll(value, " ", ""))
+	if compactOffset == "UTC+8" || compactOffset == "GMT+8" {
+		switch countryCode {
+		case "CN", "HK":
+			return "Asia/Shanghai", nil
+		case "SG":
+			return "Asia/Singapore", nil
+		default:
+			// An offset alone cannot identify a location. Keep the field empty so
+			// the human selects the correct IANA zone in Step 2.
+			return "", nil
+		}
+	}
+	if _, err := time.LoadLocation(withoutOffset); err != nil {
+		return "", fmt.Errorf("timezone must use a valid IANA identifier")
+	}
+	return "", fmt.Errorf("timezone %s is not supported by Console V2", withoutOffset)
+}
+
+func normalizeOnboardingDraftLocations(draft map[string]interface{}) error {
+	identity, ok := draft["identity_card"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	country := ""
+	if raw, exists := identity["geo"]; exists {
+		text, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("geo must be a string")
+		}
+		normalized, err := normalizeOnboardingCountry(text)
+		if err != nil {
+			return err
+		}
+		country = normalized
+		identity["geo"] = normalized
+	}
+	if raw, exists := identity["timezone"]; exists {
+		text, ok := raw.(string)
+		if !ok {
+			return fmt.Errorf("timezone must be a string")
+		}
+		normalized, err := normalizeOnboardingTimezone(text, country)
+		if err != nil {
+			return err
+		}
+		identity["timezone"] = normalized
+	}
+	return nil
+}
+
+func normalizeOnboardingDraftJSON(raw json.RawMessage) (json.RawMessage, map[string]interface{}, error) {
+	draft, err := decodeJSONObject(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := normalizeOnboardingDraftLocations(draft); err != nil {
+		return nil, nil, err
+	}
+	encoded, err := json.Marshal(draft)
+	return encoded, draft, err
+}

--- a/api/consolev2/onboarding_location_test.go
+++ b/api/consolev2/onboarding_location_test.go
@@ -1,0 +1,73 @@
+package consolev2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeOnboardingDraftLocationsUsesStableValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		geo          string
+		timezone     string
+		wantGeo      string
+		wantTimezone string
+	}{
+		{name: "canonical", geo: "CN", timezone: "Asia/Shanghai", wantGeo: "CN", wantTimezone: "Asia/Shanghai"},
+		{name: "display aliases", geo: "China", timezone: "Asia/Shanghai (UTC+8)", wantGeo: "CN", wantTimezone: "Asia/Shanghai"},
+		{name: "Singapore offset", geo: "Singapore", timezone: "UTC+8", wantGeo: "SG", wantTimezone: "Asia/Singapore"},
+		{name: "ambiguous offset stays empty", geo: "", timezone: "UTC+8", wantGeo: "", wantTimezone: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			draft := map[string]interface{}{"identity_card": map[string]interface{}{"geo": test.geo, "timezone": test.timezone}}
+			if err := normalizeOnboardingDraftLocations(draft); err != nil {
+				t.Fatal(err)
+			}
+			identity := draft["identity_card"].(map[string]interface{})
+			if identity["geo"] != test.wantGeo || identity["timezone"] != test.wantTimezone {
+				t.Fatalf("normalized location = %v/%v, want %s/%s", identity["geo"], identity["timezone"], test.wantGeo, test.wantTimezone)
+			}
+		})
+	}
+}
+
+func TestNormalizeOnboardingDraftLocationsRejectsUnsupportedValues(t *testing.T) {
+	for _, draft := range []map[string]interface{}{
+		{"identity_card": map[string]interface{}{"geo": "Moon"}},
+		{"identity_card": map[string]interface{}{"geo": "CN", "timezone": "UTC+25"}},
+		{"identity_card": map[string]interface{}{"geo": 86}},
+	} {
+		if err := normalizeOnboardingDraftLocations(draft); err == nil {
+			t.Fatalf("expected invalid location to fail: %#v", draft)
+		}
+	}
+}
+
+func TestNormalizeLoadedOnboardingDraftFillsPreReleaseEmptyProvenance(t *testing.T) {
+	draft, err := normalizeLoadedOnboardingDraft(onboardingDraft{
+		Revision: 2,
+		DraftData: json.RawMessage(`{
+			"identity_card":{"agent_name":"Atlas","geo":"China","timezone":"Asia/Shanghai (UTC+8)"}
+		}`),
+		FieldProvenance: json.RawMessage(`{}`),
+		ActorType:       provenanceAgent,
+		CreatedAt:       123,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(draft.DraftData, &data); err != nil {
+		t.Fatal(err)
+	}
+	identity := data["identity_card"].(map[string]interface{})
+	if identity["geo"] != "CN" || identity["timezone"] != "Asia/Shanghai" {
+		t.Fatalf("loaded locations were not normalized: %#v", identity)
+	}
+	provenance := decodeProvenance(draft.FieldProvenance)
+	entry := provenance["identity_card.geo"]
+	if entry.OriginSource != fieldSourceAgentInferred || entry.ValueSource != fieldSourceAgentInferred || entry.UpdatedAt != 123 {
+		t.Fatalf("empty pre-release provenance was not derived: %#v", entry)
+	}
+}

--- a/api/consolev2/onboarding_provenance.go
+++ b/api/consolev2/onboarding_provenance.go
@@ -2,6 +2,7 @@ package consolev2
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -11,7 +12,24 @@ const (
 	provenanceAgent  = "agent_prefill"
 	provenanceHuman  = "human_edit"
 	provenanceSystem = "system_derived"
+
+	fieldSourceAgentInferred    = "agent_inferred"
+	fieldSourceAgentUserContext = "agent_user_context"
+	fieldSourceHumanInput       = "human_input"
+	fieldSourceSystemGenerated  = "system_generated"
+
+	fieldActorAgent  = "agent"
+	fieldActorHuman  = "human"
+	fieldActorSystem = "system"
 )
+
+type fieldProvenance struct {
+	OriginSource   string `json:"origin_source"`
+	ValueSource    string `json:"value_source"`
+	LastActorType  string `json:"last_actor_type"`
+	HumanConfirmed bool   `json:"human_confirmed"`
+	UpdatedAt      int64  `json:"updated_at"`
+}
 
 var onboardingDraftFieldPaths = []string{
 	"identity_card.agent_name",
@@ -42,15 +60,29 @@ func decodeJSONObject(raw json.RawMessage) (map[string]interface{}, error) {
 	return value, nil
 }
 
-func decodeProvenance(raw json.RawMessage) map[string]string {
-	values := map[string]string{}
+func decodeProvenance(raw json.RawMessage) map[string]fieldProvenance {
+	values := map[string]fieldProvenance{}
 	if len(raw) == 0 {
 		return values
 	}
-	_ = json.Unmarshal(raw, &values)
-	for path, source := range values {
-		if !validProvenance(source) {
-			delete(values, path)
+	var encoded map[string]json.RawMessage
+	if json.Unmarshal(raw, &encoded) != nil {
+		return values
+	}
+	for path, entryRaw := range encoded {
+		var entry fieldProvenance
+		if json.Unmarshal(entryRaw, &entry) == nil && validFieldSource(entry.OriginSource) &&
+			validFieldSource(entry.ValueSource) && validFieldActor(entry.LastActorType) {
+			values[path] = entry
+			continue
+		}
+		// Accept the pre-release string representation while test environments
+		// roll forward. New responses always use the structured representation.
+		var legacyActor string
+		if json.Unmarshal(entryRaw, &legacyActor) == nil {
+			if converted, ok := provenanceForActor(legacyActor, 0); ok {
+				values[path] = converted
+			}
 		}
 	}
 	return values
@@ -63,6 +95,54 @@ func validProvenance(source string) bool {
 	default:
 		return false
 	}
+}
+
+func validFieldSource(source string) bool {
+	switch source {
+	case fieldSourceAgentInferred, fieldSourceAgentUserContext, fieldSourceHumanInput, fieldSourceSystemGenerated:
+		return true
+	default:
+		return false
+	}
+}
+
+func validAgentFieldSource(source string) bool {
+	return source == fieldSourceAgentInferred || source == fieldSourceAgentUserContext || source == fieldSourceSystemGenerated
+}
+
+func validFieldActor(actor string) bool {
+	return actor == fieldActorAgent || actor == fieldActorHuman || actor == fieldActorSystem
+}
+
+func provenanceForActor(actor string, now int64) (fieldProvenance, bool) {
+	switch actor {
+	case provenanceAgent:
+		return fieldProvenance{OriginSource: fieldSourceAgentInferred, ValueSource: fieldSourceAgentInferred, LastActorType: fieldActorAgent, UpdatedAt: now}, true
+	case provenanceHuman:
+		return fieldProvenance{OriginSource: fieldSourceHumanInput, ValueSource: fieldSourceHumanInput, LastActorType: fieldActorHuman, HumanConfirmed: true, UpdatedAt: now}, true
+	case provenanceSystem:
+		return fieldProvenance{OriginSource: fieldSourceSystemGenerated, ValueSource: fieldSourceSystemGenerated, LastActorType: fieldActorSystem, UpdatedAt: now}, true
+	default:
+		return fieldProvenance{}, false
+	}
+}
+
+func knownDraftFieldPath(path string) bool {
+	for _, candidate := range onboardingDraftFieldPaths {
+		if path == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func validateRequestedAgentProvenance(values map[string]string) error {
+	for path, source := range values {
+		if !knownDraftFieldPath(path) || !validAgentFieldSource(source) {
+			return fmt.Errorf("invalid Agent field provenance for %s", path)
+		}
+	}
+	return nil
 }
 
 func draftPathValue(root map[string]interface{}, path string) (interface{}, bool) {
@@ -121,15 +201,26 @@ func meaningfulDraftValue(value interface{}, exists bool) bool {
 // deriveInitialProvenance records only fields that the Agent actually
 // supplied. Empty placeholders stay unlabelled so the Web cannot claim they
 // were prefilled when no value exists.
-func deriveInitialProvenance(draft map[string]interface{}, source string) map[string]string {
-	result := map[string]string{}
-	if !validProvenance(source) {
+func deriveInitialProvenance(draft map[string]interface{}, actor string, requested map[string]string, now int64) map[string]fieldProvenance {
+	result := map[string]fieldProvenance{}
+	base, ok := provenanceForActor(actor, now)
+	if !ok {
 		return result
 	}
 	for _, path := range onboardingDraftFieldPaths {
 		value, exists := draftPathValue(draft, path)
 		if meaningfulDraftValue(value, exists) {
-			result[path] = source
+			entry := base
+			if actor == provenanceAgent {
+				if source := requested[path]; validAgentFieldSource(source) {
+					entry.OriginSource = source
+					entry.ValueSource = source
+					if source == fieldSourceSystemGenerated {
+						entry.LastActorType = fieldActorSystem
+					}
+				}
+			}
+			result[path] = entry
 		}
 	}
 	return result
@@ -138,12 +229,12 @@ func deriveInitialProvenance(draft map[string]interface{}, source string) map[st
 // mergeOnboardingDraft enforces field ownership at the server boundary. A
 // human edit wins permanently for that draft field; later Agent prefills are
 // skipped and reported instead of silently overwriting the user's choice.
-func mergeOnboardingDraft(previous, incoming map[string]interface{}, previousProvenance map[string]string, actor string) (map[string]interface{}, map[string]string, []string) {
+func mergeOnboardingDraft(previous, incoming map[string]interface{}, previousProvenance map[string]fieldProvenance, actor string, requested map[string]string, now int64) (map[string]interface{}, map[string]fieldProvenance, []string) {
 	merged := incoming
-	provenance := make(map[string]string, len(previousProvenance))
-	for path, source := range previousProvenance {
-		if validProvenance(source) {
-			provenance[path] = source
+	provenance := make(map[string]fieldProvenance, len(previousProvenance))
+	for path, entry := range previousProvenance {
+		if validFieldSource(entry.OriginSource) && validFieldSource(entry.ValueSource) && validFieldActor(entry.LastActorType) {
+			provenance[path] = entry
 		}
 	}
 	blocked := make([]string, 0)
@@ -152,7 +243,8 @@ func mergeOnboardingDraft(previous, incoming map[string]interface{}, previousPro
 		newValue, newExists := draftPathValue(incoming, path)
 		changed := oldExists != newExists || !reflect.DeepEqual(oldValue, newValue)
 
-		if actor == provenanceAgent && provenance[path] == provenanceHuman {
+		entry, hasEntry := provenance[path]
+		if actor == provenanceAgent && hasEntry && entry.HumanConfirmed {
 			setDraftPathValue(merged, path, oldValue, oldExists)
 			if newExists {
 				blocked = append(blocked, path)
@@ -160,16 +252,50 @@ func mergeOnboardingDraft(previous, incoming map[string]interface{}, previousPro
 			continue
 		}
 		if !changed {
+			if actor == provenanceAgent && meaningfulDraftValue(newValue, newExists) {
+				if source := requested[path]; validAgentFieldSource(source) && !entry.HumanConfirmed {
+					if !hasEntry {
+						entry.OriginSource = source
+					}
+					entry.ValueSource = source
+					entry.LastActorType = fieldActorAgent
+					if source == fieldSourceSystemGenerated {
+						entry.LastActorType = fieldActorSystem
+					}
+					entry.UpdatedAt = now
+					provenance[path] = entry
+				}
+			}
 			continue
 		}
 		if actor == provenanceHuman {
-			// Keep human ownership even when the value was cleared; otherwise a
-			// later Agent prefill could resurrect data the user deliberately removed.
-			provenance[path] = provenanceHuman
+			if !hasEntry {
+				entry.OriginSource = fieldSourceHumanInput
+			}
+			entry.ValueSource = fieldSourceHumanInput
+			entry.LastActorType = fieldActorHuman
+			entry.HumanConfirmed = true
+			entry.UpdatedAt = now
+			provenance[path] = entry
 			continue
 		}
 		if meaningfulDraftValue(newValue, newExists) {
-			provenance[path] = provenanceAgent
+			base, _ := provenanceForActor(actor, now)
+			if actor == provenanceAgent {
+				source := requested[path]
+				if !validAgentFieldSource(source) {
+					source = fieldSourceAgentInferred
+				}
+				base.OriginSource = source
+				base.ValueSource = source
+				if source == fieldSourceSystemGenerated {
+					base.LastActorType = fieldActorSystem
+				}
+			}
+			if hasEntry {
+				base.OriginSource = entry.OriginSource
+			}
+			provenance[path] = base
 		} else {
 			delete(provenance, path)
 		}
@@ -178,9 +304,45 @@ func mergeOnboardingDraft(previous, incoming map[string]interface{}, previousPro
 	return merged, provenance, blocked
 }
 
-func canonicalSource(provenance map[string]string, path string) string {
-	if source := provenance[path]; validProvenance(source) {
-		return source
+func confirmStepProvenance(draft map[string]interface{}, provenance map[string]fieldProvenance, step int16, now int64) map[string]fieldProvenance {
+	paths := onboardingDraftFieldPaths
+	switch step {
+	case 2:
+		paths = onboardingDraftFieldPaths[:12]
+	case 3:
+		paths = onboardingDraftFieldPaths[12:16]
+	case 4:
+		paths = onboardingDraftFieldPaths[16:17]
+	case 5:
+		paths = onboardingDraftFieldPaths[17:18]
+	}
+	for _, path := range paths {
+		value, exists := draftPathValue(draft, path)
+		entry, ok := provenance[path]
+		if !ok && !meaningfulDraftValue(value, exists) {
+			continue
+		}
+		if !ok {
+			entry = fieldProvenance{OriginSource: fieldSourceHumanInput, ValueSource: fieldSourceHumanInput}
+		}
+		entry.LastActorType = fieldActorHuman
+		entry.HumanConfirmed = true
+		entry.UpdatedAt = now
+		provenance[path] = entry
+	}
+	return provenance
+}
+
+func canonicalSource(provenance map[string]fieldProvenance, path string) string {
+	if entry, ok := provenance[path]; ok {
+		switch entry.ValueSource {
+		case fieldSourceAgentInferred, fieldSourceAgentUserContext:
+			return provenanceAgent
+		case fieldSourceSystemGenerated:
+			return provenanceSystem
+		case fieldSourceHumanInput:
+			return provenanceHuman
+		}
 	}
 	return provenanceHuman
 }

--- a/api/consolev2/onboarding_provenance_test.go
+++ b/api/consolev2/onboarding_provenance_test.go
@@ -21,71 +21,97 @@ func TestDeriveInitialProvenanceOnlyLabelsActualValues(t *testing.T) {
 			"agent_name": "Atlas",
 			"agent_description": "",
 			"working_languages": [],
-			"geo": "China",
+			"geo": "CN",
 			"timezone": "Asia/Shanghai"
 		},
 		"security_boundary": {"recurring_publish": false},
 		"network_goal": "",
 		"intent_actions": []
 	}`)
-	got := deriveInitialProvenance(draft, provenanceAgent)
-	want := map[string]string{
-		"identity_card.agent_name":            provenanceAgent,
-		"identity_card.geo":                   provenanceAgent,
-		"identity_card.timezone":              provenanceAgent,
-		"security_boundary.recurring_publish": provenanceAgent,
+	got := deriveInitialProvenance(draft, provenanceAgent, map[string]string{
+		"identity_card.geo": fieldSourceAgentUserContext,
+	}, 123)
+	if len(got) != 4 {
+		t.Fatalf("provenance count = %d, want 4: %#v", len(got), got)
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("provenance mismatch\n got: %#v\nwant: %#v", got, want)
+	if got["identity_card.geo"].ValueSource != fieldSourceAgentUserContext ||
+		got["identity_card.agent_name"].ValueSource != fieldSourceAgentInferred {
+		t.Fatalf("Agent source classification was not preserved: %#v", got)
+	}
+	if got["identity_card.agent_description"].ValueSource != "" {
+		t.Fatalf("empty field must not have provenance: %#v", got)
 	}
 }
 
 func TestMergeOnboardingDraftHumanOwnershipBlocksLaterAgent(t *testing.T) {
 	original := mustDraftObject(t, `{
-		"identity_card":{"agent_name":"Atlas","geo":"China"},
+		"identity_card":{"agent_name":"Atlas","geo":"CN"},
 		"network_goal":"Find AI infrastructure signals",
 		"intent_actions":[]
 	}`)
 	humanEdit := mustDraftObject(t, `{
-		"identity_card":{"agent_name":"Atlas Research","geo":"China"},
+		"identity_card":{"agent_name":"Atlas Research","geo":"CN"},
 		"network_goal":"Find AI infrastructure signals",
 		"intent_actions":[]
 	}`)
-	initial := deriveInitialProvenance(original, provenanceAgent)
-	merged, afterHuman, blocked := mergeOnboardingDraft(original, humanEdit, initial, provenanceHuman)
+	initial := deriveInitialProvenance(original, provenanceAgent, nil, 1)
+	merged, afterHuman, blocked := mergeOnboardingDraft(original, humanEdit, initial, provenanceHuman, nil, 2)
 	if len(blocked) != 0 {
 		t.Fatalf("human edit unexpectedly blocked: %v", blocked)
 	}
-	if afterHuman["identity_card.agent_name"] != provenanceHuman {
+	nameSource := afterHuman["identity_card.agent_name"]
+	if nameSource.OriginSource != fieldSourceAgentInferred || nameSource.ValueSource != fieldSourceHumanInput || !nameSource.HumanConfirmed {
 		t.Fatalf("human ownership not recorded: %#v", afterHuman)
 	}
 
 	agentRetry := mustDraftObject(t, `{
-		"identity_card":{"agent_name":"Agent overwrite","geo":"Singapore"},
+		"identity_card":{"agent_name":"Agent overwrite","geo":"SG"},
 		"network_goal":"Find AI infrastructure signals",
 		"intent_actions":[]
 	}`)
-	merged, afterAgent, blocked := mergeOnboardingDraft(merged, agentRetry, afterHuman, provenanceAgent)
+	merged, afterAgent, blocked := mergeOnboardingDraft(merged, agentRetry, afterHuman, provenanceAgent, map[string]string{
+		"identity_card.geo": fieldSourceAgentUserContext,
+	}, 3)
 	name, _ := draftPathValue(merged, "identity_card.agent_name")
 	if name != "Atlas Research" {
 		t.Fatalf("agent overwrote human value: %v", name)
 	}
 	geo, _ := draftPathValue(merged, "identity_card.geo")
-	if geo != "Singapore" {
+	if geo != "SG" {
 		t.Fatalf("agent-owned field did not refresh: %v", geo)
 	}
 	if !reflect.DeepEqual(blocked, []string{"identity_card.agent_name"}) {
 		t.Fatalf("blocked paths mismatch: %v", blocked)
 	}
-	if afterAgent["identity_card.agent_name"] != provenanceHuman || afterAgent["identity_card.geo"] != provenanceAgent {
+	if afterAgent["identity_card.agent_name"].ValueSource != fieldSourceHumanInput ||
+		afterAgent["identity_card.geo"].ValueSource != fieldSourceAgentUserContext {
 		t.Fatalf("sources mismatch after Agent retry: %#v", afterAgent)
 	}
 }
 
+func TestConfirmStepProvenancePreservesOriginAndLocksAgentRetries(t *testing.T) {
+	draft := mustDraftObject(t, `{"identity_card":{"agent_name":"Atlas","geo":"CN"}}`)
+	provenance := deriveInitialProvenance(draft, provenanceAgent, map[string]string{
+		"identity_card.geo": fieldSourceAgentUserContext,
+	}, 1)
+	confirmed := confirmStepProvenance(draft, provenance, 2, 2)
+	entry := confirmed["identity_card.geo"]
+	if entry.OriginSource != fieldSourceAgentUserContext || entry.ValueSource != fieldSourceAgentUserContext || !entry.HumanConfirmed {
+		t.Fatalf("confirmation did not preserve origin: %#v", entry)
+	}
+
+	retry := mustDraftObject(t, `{"identity_card":{"agent_name":"Atlas","geo":"SG"}}`)
+	merged, _, blocked := mergeOnboardingDraft(draft, retry, confirmed, provenanceAgent, nil, 3)
+	geo, _ := draftPathValue(merged, "identity_card.geo")
+	if geo != "CN" || !reflect.DeepEqual(blocked, []string{"identity_card.agent_name", "identity_card.geo"}) {
+		t.Fatalf("confirmed fields were not protected: geo=%v blocked=%v", geo, blocked)
+	}
+}
+
 func TestCanonicalSourceUsesStoredOwnership(t *testing.T) {
-	provenance := map[string]string{
-		"network_goal":   provenanceAgent,
-		"intent_actions": provenanceSystem,
+	provenance := map[string]fieldProvenance{
+		"network_goal":   {OriginSource: fieldSourceAgentInferred, ValueSource: fieldSourceAgentInferred, LastActorType: fieldActorAgent},
+		"intent_actions": {OriginSource: fieldSourceSystemGenerated, ValueSource: fieldSourceSystemGenerated, LastActorType: fieldActorSystem},
 	}
 	if got := canonicalSource(provenance, "network_goal"); got != provenanceAgent {
 		t.Fatalf("network goal source = %q", got)

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -39,7 +39,7 @@ const (
 	csrfCookieName    = "ef_console_v2_csrf"
 	accessTTL         = 15 * time.Minute
 	refreshTTL        = 30 * 24 * time.Hour
-	handoffTTL        = 5 * time.Minute
+	handoffTTL        = 15 * time.Minute
 	grantTTL          = 5 * time.Minute
 	proofClockSkew    = 5 * time.Minute
 	maxRequestBytes   = 256 << 10

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -27,6 +27,12 @@ func (g *fixedIDGenerator) NextID() (int64, error) {
 	return g.id, nil
 }
 
+func TestConsoleHandoffTTL(t *testing.T) {
+	if handoffTTL != 15*time.Minute {
+		t.Fatalf("handoffTTL = %s, want 15m", handoffTTL)
+	}
+}
+
 func TestProvisionTranscriptVerifiesAndCoversMutableFields(t *testing.T) {
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -308,6 +308,22 @@ func TestNotificationIssuerIdentityFailsClosed(t *testing.T) {
 	}
 }
 
+func TestConsoleSessionRuntime(t *testing.T) {
+	for _, test := range []struct {
+		name, version, host, wantRuntime, wantName, wantVersion string
+	}{
+		{name: "workbuddy", version: "5.3.14", host: "openclaw/1.2.3", wantRuntime: "workbuddy/5.3.14", wantName: "workbuddy", wantVersion: "5.3.14"},
+		{host: "openclaw/1.2.3", wantRuntime: "openclaw/1.2.3", wantName: "openclaw", wantVersion: "1.2.3"},
+		{host: "terminal"},
+	} {
+		runtime, name, version := consoleSessionRuntime(test.name, test.version, test.host)
+		if runtime != test.wantRuntime || name != test.wantName || version != test.wantVersion {
+			t.Fatalf("consoleSessionRuntime(%q, %q, %q) = (%q, %q, %q)",
+				test.name, test.version, test.host, runtime, name, version)
+		}
+	}
+}
+
 func TestCommunicationResponseBudgetAndTextFallback(t *testing.T) {
 	data := map[string]interface{}{"messages": []communicationMessage{{Content: strings.Repeat("🙂", 100000)}}}
 	if communicationReplyFits(data) {


### PR DESCRIPTION
## Summary
- normalize Console V2 geo values to stable country codes and timezone values to IANA identifiers
- persist structured per-field provenance and preserve human confirmation ownership
- include Agent-provided provenance in the signed provision contract
- retain the pending runtime identity and 15-minute handoff fixes already on this backend branch

## Compatibility
- V1 routes and DTOs are unchanged
- no migration, index, or additional database query is introduced
- pre-release empty provenance is derived on read without a backfill

## Verification
- `go test ./api/consolev2`
- Web and CLI contract tests were run in their separate test branches