### PR TITLE
feat(agent-card): add anonymous public sharing

### DIFF
--- a/api/agentcard/handlers.go
+++ b/api/agentcard/handlers.go
@@ -163,7 +163,7 @@ func GetMyCard(ctx context.Context, c *app.RequestContext) {
 		respond(c, http.StatusInternalServerError, 500, "failed to load card", nil)
 		return
 	}
-	publicCard := overlayCurrentLastActive(ctx, card.PublicCard, agentID)
+	publicCard := overlayPublicMetadata(ctx, card.PublicCard, agentID)
 	respond(c, http.StatusOK, 0, "success", map[string]interface{}{
 		"public":       publicCard,
 		"private":      json.RawMessage(card.PrivateCard),
@@ -235,11 +235,58 @@ func GetPublicCard(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	publicCard := overlayCurrentLastActive(ctx, card.PublicCard, targetID)
+	publicCard := overlayPublicMetadata(ctx, card.PublicCard, targetID)
 	respond(c, http.StatusOK, 0, "success", map[string]interface{}{
 		"card":               publicCard,
 		"relation_to_viewer": relationToViewer(viewerID, targetID),
 	})
+}
+
+// GetSharedPublicCard serves the anonymous Agent Card share page. It reads the
+// already-built public projection only: private fields and viewer-relative
+// relationship data never enter this response.
+func GetSharedPublicCard(ctx context.Context, c *app.RequestContext) {
+	targetID, err := strconv.ParseInt(c.Param("agent_id"), 10, 64)
+	if err != nil || targetID <= 0 {
+		respond(c, http.StatusBadRequest, 400, "invalid agent_id", nil)
+		return
+	}
+	card, err := profiledal.GetAgentCard(db.DB, targetID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			respond(c, http.StatusNotFound, 404, "agent not found", nil)
+			return
+		}
+		logger.Ctx(ctx).Error("GetSharedPublicCard failed", "targetID", targetID, "err", err)
+		respond(c, http.StatusInternalServerError, 500, "failed to load card", nil)
+		return
+	}
+	c.Header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
+	c.Header("ETag", fmt.Sprintf("\"agent-card-%d-%d\"", targetID, card.PublicCardVersion))
+	respond(c, http.StatusOK, 0, "success", map[string]interface{}{
+		"card":                overlayPublicMetadata(ctx, card.PublicCard, targetID),
+		"public_card_version": card.PublicCardVersion,
+		"generated_at":        card.PublicCardGeneratedAt,
+	})
+}
+
+func overlayPublicMetadata(ctx context.Context, raw string, agentID int64) json.RawMessage {
+	card := overlayCurrentLastActive(ctx, raw, agentID)
+	var payload map[string]interface{}
+	if err := json.Unmarshal(card, &payload); err != nil {
+		return card
+	}
+	var memberNo int64
+	if err := db.DB.Raw(`SELECT member_no FROM agent_network_memberships WHERE agent_id = ?`, agentID).Scan(&memberNo).Error; err != nil {
+		logger.Ctx(ctx).Warn("network member number unavailable", "agentID", agentID, "err", err)
+	} else if memberNo > 0 {
+		payload["network_member_no"] = memberNo
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return card
+	}
+	return json.RawMessage(encoded)
 }
 
 // overlayCurrentLastActive keeps the hot activity signal current without

--- a/api/main.go
+++ b/api/main.go
@@ -266,6 +266,7 @@ func main() {
 	if consoleV2Service != nil {
 		consoleV2Service.Register(h)
 		registerConsoleV2BusinessBFF(h, consoleV2Service)
+		h.GET("/api/v2/public/agents/:agent_id/card", agentcardapi.GetSharedPublicCard)
 		log.Print("Console V2 routes registered")
 	}
 

--- a/migrations/000072_agent_network_memberships.sql
+++ b/migrations/000072_agent_network_memberships.sql
@@ -1,0 +1,51 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CREATE SEQUENCE IF NOT EXISTS agent_network_member_no_seq;
+
+CREATE TABLE IF NOT EXISTS agent_network_memberships (
+    agent_id BIGINT PRIMARY KEY REFERENCES agents(agent_id) ON DELETE CASCADE,
+    member_no BIGINT NOT NULL UNIQUE DEFAULT nextval('agent_network_member_no_seq'),
+    joined_at BIGINT NOT NULL
+);
+
+-- Existing agents keep a deterministic, stable order. This first pass is
+-- intentionally unlocked so a large historical backfill does not pause
+-- normal registration traffic.
+INSERT INTO agent_network_memberships (agent_id, joined_at)
+SELECT agent_id, created_at
+FROM agents
+ON CONFLICT (agent_id) DO NOTHING
+ORDER BY created_at, agent_id;
+
+CREATE OR REPLACE FUNCTION ensure_agent_network_membership()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO agent_network_memberships (agent_id, joined_at)
+    VALUES (NEW.agent_id, NEW.created_at)
+    ON CONFLICT (agent_id) DO NOTHING;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Close the small gap between the unlocked backfill and trigger creation.
+-- The lock is held only while the normally tiny delta is inserted.
+BEGIN;
+LOCK TABLE agents IN SHARE ROW EXCLUSIVE MODE;
+DROP TRIGGER IF EXISTS trg_agents_network_membership ON agents;
+CREATE TRIGGER trg_agents_network_membership
+AFTER INSERT ON agents
+FOR EACH ROW EXECUTE FUNCTION ensure_agent_network_membership();
+INSERT INTO agent_network_memberships (agent_id, joined_at)
+SELECT agent_id, created_at
+FROM agents
+ON CONFLICT (agent_id) DO NOTHING
+ORDER BY created_at, agent_id;
+COMMIT;
+
+-- +goose Down
+
+DROP TRIGGER IF EXISTS trg_agents_network_membership ON agents;
+DROP FUNCTION IF EXISTS ensure_agent_network_membership();
+DROP TABLE IF EXISTS agent_network_memberships;
+DROP SEQUENCE IF EXISTS agent_network_member_no_seq;


### PR DESCRIPTION
## Summary
- add a stable network membership number with deterministic historical backfill
- expose an anonymous V2 public Agent Card read endpoint
- include the real membership number in authenticated Agent Card responses

## Compatibility
- additive migration, table, trigger, and endpoint only
- no V1 route or response contract changes
- anonymous endpoint reads only the existing public projection

## Verification
- go test ./api/agentcard ./api/consolev2
- git diff --check origin/main...HEAD