### PR TITLE
fix(console-v2): unblock Agent Card release and require email

### DIFF
--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -122,6 +122,16 @@ func responseData(t *testing.T, payload map[string]interface{}) map[string]inter
 	return data
 }
 
+func responseErrorCode(t *testing.T, payload map[string]interface{}) string {
+	t.Helper()
+	apiError, ok := payload["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response has no error object: %#v", payload)
+	}
+	code, _ := apiError["code"].(string)
+	return code
+}
+
 func cookiePair(setCookies [][]byte, name string) string {
 	prefix := name + "="
 	for _, raw := range setCookies {
@@ -362,6 +372,35 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	}
 	cookieHeader := consoleCookie + "; " + csrfCookie
 
+	status, unboundConfirmPayload, _ := performJSON(t, h, "POST", "/api/v2/agents/me/onboarding-draft/confirm", confirmStepRequest{
+		Step: 2, ExpectedOnboardingRevision: 1, IdempotencyKey: "confirm-unbound-" + agentID,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusConflict || responseErrorCode(t, unboundConfirmPayload) != "EMAIL_BINDING_REQUIRED" {
+		t.Fatalf("unbound onboarding confirmation status=%d payload=%#v", status, unboundConfirmPayload)
+	}
+
+	boundEmail := fmt.Sprintf("console-v2-%s@example.com", agentID)
+	status, bindChallengePayload, _ := performJSON(t, h, "POST", "/api/v2/account-email-bindings/challenges", createEmailChallengeRequest{
+		Email: boundEmail,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != 202 {
+		t.Fatalf("email binding challenge status=%d payload=%#v", status, bindChallengePayload)
+	}
+	var bindMail capturedEmail
+	select {
+	case bindMail = <-mailbox:
+	case <-time.After(2 * time.Second):
+		t.Fatal("email binding OTP was not queued")
+	}
+	status, bindPayload, _ := performJSON(t, h, "POST", "/api/v2/account-email-bindings/verify", verifyEmailRequest{
+		ChallengeID: responseData(t, bindChallengePayload)["challenge_id"].(string),
+		Email:       boundEmail,
+		OTP:         bindMail.otp,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != 200 || responseData(t, bindPayload)["verification_level"] != "email_verified" {
+		t.Fatalf("email binding verify status=%d payload=%#v", status, bindPayload)
+	}
+
 	revision := int64(1)
 	for step := int16(2); step <= 5; step++ {
 		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agents/me/onboarding-draft/confirm", confirmStepRequest{
@@ -396,27 +435,6 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	testTelemetryAggregation(t, gdb, h, agentIDInt, cookieHeader, csrf)
 	testActivityCursorReset(t, gdb, h, idgen, agentIDInt, cookieHeader)
 
-	boundEmail := fmt.Sprintf("console-v2-%s@example.com", agentID)
-	status, bindChallengePayload, _ := performJSON(t, h, "POST", "/api/v2/account-email-bindings/challenges", createEmailChallengeRequest{
-		Email: boundEmail,
-	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
-	if status != 202 {
-		t.Fatalf("email binding challenge status=%d payload=%#v", status, bindChallengePayload)
-	}
-	var bindMail capturedEmail
-	select {
-	case bindMail = <-mailbox:
-	case <-time.After(2 * time.Second):
-		t.Fatal("email binding OTP was not queued")
-	}
-	status, bindPayload, _ := performJSON(t, h, "POST", "/api/v2/account-email-bindings/verify", verifyEmailRequest{
-		ChallengeID: responseData(t, bindChallengePayload)["challenge_id"].(string),
-		Email:       boundEmail,
-		OTP:         bindMail.otp,
-	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
-	if status != 200 || responseData(t, bindPayload)["verification_level"] != "email_verified" {
-		t.Fatalf("email binding verify status=%d payload=%#v", status, bindPayload)
-	}
 	status, boundSessionPayload, _ := performJSON(t, h, "GET", "/api/v2/console/session", map[string]interface{}{},
 		ut.Header{Key: "Cookie", Value: cookieHeader})
 	if status != 200 {

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -387,7 +387,10 @@ type draftPayload struct {
 	} `json:"intent_actions"`
 }
 
-var errInvalidOnboardingDraft = errors.New("invalid onboarding draft")
+var (
+	errInvalidOnboardingDraft = errors.New("invalid onboarding draft")
+	errEmailBindingRequired   = errors.New("verified email binding required")
+)
 
 func validateDraftPayload(payload draftPayload) error {
 	if utf8.RuneCountInString(payload.IdentityCard.AgentName) > 100 || utf8.RuneCountInString(payload.IdentityCard.Bio) > 2000 {
@@ -544,6 +547,16 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 		if !canConfirmOnboardingStep(state.State, state.CurrentStep, req.Step) || state.Revision != req.ExpectedOnboardingRevision {
 			return errConflict
 		}
+		var emailBound bool
+		if err := tx.Raw(`SELECT EXISTS (
+			SELECT 1 FROM agent_email_bindings
+			WHERE agent_id = ? AND status = 'active' AND verification_state = 'verified'
+		)`, id).Scan(&emailBound).Error; err != nil {
+			return err
+		}
+		if !emailBound {
+			return errEmailBindingRequired
+		}
 		var storedDraft struct {
 			DraftData       string `gorm:"column:draft_data"`
 			FieldProvenance string `gorm:"column:field_provenance"`
@@ -648,6 +661,10 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 	}
 	if errors.Is(err, errConflict) {
 		fail(c, http.StatusConflict, "REVISION_CONFLICT", "onboarding step or revision changed", nil)
+		return
+	}
+	if errors.Is(err, errEmailBindingRequired) {
+		fail(c, http.StatusConflict, "EMAIL_BINDING_REQUIRED", "bind and verify an email before confirming onboarding", nil)
 		return
 	}
 	if errors.Is(err, errInvalidOnboardingDraft) {

--- a/migrations/000072_agent_network_memberships.sql
+++ b/migrations/000072_agent_network_memberships.sql
@@ -15,8 +15,8 @@ CREATE TABLE IF NOT EXISTS agent_network_memberships (
 INSERT INTO agent_network_memberships (agent_id, joined_at)
 SELECT agent_id, created_at
 FROM agents
-ON CONFLICT (agent_id) DO NOTHING
-ORDER BY created_at, agent_id;
+ORDER BY created_at, agent_id
+ON CONFLICT (agent_id) DO NOTHING;
 
 CREATE OR REPLACE FUNCTION ensure_agent_network_membership()
 RETURNS TRIGGER AS $$
@@ -39,8 +39,8 @@ FOR EACH ROW EXECUTE FUNCTION ensure_agent_network_membership();
 INSERT INTO agent_network_memberships (agent_id, joined_at)
 SELECT agent_id, created_at
 FROM agents
-ON CONFLICT (agent_id) DO NOTHING
-ORDER BY created_at, agent_id;
+ORDER BY created_at, agent_id
+ON CONFLICT (agent_id) DO NOTHING;
 COMMIT;
 
 -- +goose Down


### PR DESCRIPTION
## Summary
- fix the PostgreSQL syntax in migration 72 so the Agent Card membership backfill can run after the partial failed attempt
- require an active verified email binding before any Console V2 onboarding step can be confirmed
- cover the unbound rejection and the bound onboarding flow in the PostgreSQL integration test

## Release composition
- based on main after PR #157 and PR #158
- preserves PR #157 location/provenance/runtime/handoff changes
- preserves PR #158 public Agent Card API and membership schema
- V1 routes and DTOs remain unchanged

## Verification
- go test ./api/consolev2 ./api/agentcard
- git diff --check