### PR TITLE
fix(migrations): unblock agent membership backfill

### DIFF
--- a/migrations/000072_agent_network_memberships.sql
+++ b/migrations/000072_agent_network_memberships.sql
@@ -15,8 +15,8 @@ CREATE TABLE IF NOT EXISTS agent_network_memberships (
 INSERT INTO agent_network_memberships (agent_id, joined_at)
 SELECT agent_id, created_at
 FROM agents
-ON CONFLICT (agent_id) DO NOTHING
-ORDER BY created_at, agent_id;
+ORDER BY created_at, agent_id
+ON CONFLICT (agent_id) DO NOTHING;
 
 CREATE OR REPLACE FUNCTION ensure_agent_network_membership()
 RETURNS TRIGGER AS $$
@@ -39,8 +39,8 @@ FOR EACH ROW EXECUTE FUNCTION ensure_agent_network_membership();
 INSERT INTO agent_network_memberships (agent_id, joined_at)
 SELECT agent_id, created_at
 FROM agents
-ON CONFLICT (agent_id) DO NOTHING
-ORDER BY created_at, agent_id;
+ORDER BY created_at, agent_id
+ON CONFLICT (agent_id) DO NOTHING;
 COMMIT;
 
 -- +goose Down


### PR DESCRIPTION
## Summary
- place ORDER BY before ON CONFLICT in both migration 072 backfill statements
- keep the migration safely rerunnable after the failed NO TRANSACTION attempt left the guarded sequence/table in place

## Verification
- go test ./api/consolev2 ./pkg/config ./rpc/auth
- production read-only EXPLAIN successfully parsed and planned the corrected INSERT

This unblocks the root-managed production deployment that currently fails with SQLSTATE 42601.