### PR TITLE
fix(migrations): preserve membership trigger function body

### DIFF
--- a/migrations/000072_agent_network_memberships.sql
+++ b/migrations/000072_agent_network_memberships.sql
@@ -18,6 +18,7 @@ FROM agents
 ORDER BY created_at, agent_id
 ON CONFLICT (agent_id) DO NOTHING;
 
+-- +goose StatementBegin
 CREATE OR REPLACE FUNCTION ensure_agent_network_membership()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -27,6 +28,7 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+-- +goose StatementEnd
 
 -- Close the small gap between the unlocked backfill and trigger creation.
 -- The lock is held only while the normally tiny delta is inserted.


### PR DESCRIPTION
## Summary
- wrap the PL/pgSQL trigger function in Goose StatementBegin/StatementEnd markers
- prevent Goose from splitting the dollar-quoted body at its first internal semicolon
- keep migration 072 safely rerunnable after the prior NO TRANSACTION failures

## Verification
- Goose v3.24.3 `validate` passes for the full migrations directory
- go test ./api/consolev2 ./pkg/config ./rpc/auth

This fixes the second production deployment failure: unterminated dollar-quoted string (SQLSTATE 42601).