### PR TITLE
fix(console-v2): accept legacy list draft values

### DIFF
--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -574,7 +574,7 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 		}
 		var payload draftPayload
 		if err := json.Unmarshal(normalizedDraftJSON, &payload); err != nil {
-			return err
+			return fmt.Errorf("%w: %v", errInvalidOnboardingDraft, err)
 		}
 		provenance := decodeProvenance(json.RawMessage(storedDraft.FieldProvenance))
 		if len(provenance) == 0 && validProvenance(storedDraft.ActorType) {

--- a/api/consolev2/onboarding_location.go
+++ b/api/consolev2/onboarding_location.go
@@ -29,6 +29,15 @@ var onboardingTimezoneAliases = map[string]string{
 	"EUROPE/LONDON":       "Europe/London",
 }
 
+var onboardingListFields = []string{
+	"working_languages",
+	"seeking",
+	"offering",
+	"agent_status",
+	"human_status",
+	"interests_negative",
+}
+
 func normalizeOnboardingCountry(raw string) (string, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
@@ -104,12 +113,58 @@ func normalizeOnboardingDraftLocations(draft map[string]interface{}) error {
 	return nil
 }
 
+func normalizeOnboardingDraftLists(draft map[string]interface{}) error {
+	identity, ok := draft["identity_card"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for _, field := range onboardingListFields {
+		raw, exists := identity[field]
+		if !exists || raw == nil {
+			continue
+		}
+		switch value := raw.(type) {
+		case []interface{}:
+			items := make([]string, 0, len(value))
+			for _, item := range value {
+				text, ok := item.(string)
+				if !ok {
+					return fmt.Errorf("%s must contain strings", field)
+				}
+				if text = strings.TrimSpace(text); text != "" {
+					items = append(items, text)
+				}
+			}
+			identity[field] = items
+		case string:
+			items := strings.FieldsFunc(value, func(r rune) bool {
+				switch r {
+				case '·', ',', '，', ';', '；', '\n', '\r':
+					return true
+				default:
+					return false
+				}
+			})
+			for index := range items {
+				items[index] = strings.TrimSpace(items[index])
+			}
+			identity[field] = items
+		default:
+			return fmt.Errorf("%s must be an array of strings", field)
+		}
+	}
+	return nil
+}
+
 func normalizeOnboardingDraftJSON(raw json.RawMessage) (json.RawMessage, map[string]interface{}, error) {
 	draft, err := decodeJSONObject(raw)
 	if err != nil {
 		return nil, nil, err
 	}
 	if err := normalizeOnboardingDraftLocations(draft); err != nil {
+		return nil, nil, err
+	}
+	if err := normalizeOnboardingDraftLists(draft); err != nil {
 		return nil, nil, err
 	}
 	encoded, err := json.Marshal(draft)

--- a/api/consolev2/onboarding_location_test.go
+++ b/api/consolev2/onboarding_location_test.go
@@ -44,6 +44,56 @@ func TestNormalizeOnboardingDraftLocationsRejectsUnsupportedValues(t *testing.T)
 	}
 }
 
+func TestNormalizeOnboardingDraftListsSupportsLegacyScalars(t *testing.T) {
+	raw := json.RawMessage(`{
+		"identity_card": {
+			"working_languages": "中文 · English",
+			"seeking": "",
+			"offering": ["研究", " ", "任务整理"]
+		}
+	}`)
+	normalized, _, err := normalizeOnboardingDraftJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload draftPayload
+	if err := json.Unmarshal(normalized, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := payload.IdentityCard.WorkingLanguages, []string{"中文", "English"}; !equalStrings(got, want) {
+		t.Fatalf("working_languages = %#v, want %#v", got, want)
+	}
+	if len(payload.IdentityCard.Seeking) != 0 {
+		t.Fatalf("seeking = %#v, want empty", payload.IdentityCard.Seeking)
+	}
+	if got, want := payload.IdentityCard.Offering, []string{"研究", "任务整理"}; !equalStrings(got, want) {
+		t.Fatalf("offering = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeOnboardingDraftListsRejectsInvalidTypes(t *testing.T) {
+	for _, raw := range []json.RawMessage{
+		json.RawMessage(`{"identity_card":{"seeking":42}}`),
+		json.RawMessage(`{"identity_card":{"seeking":["valid",42]}}`),
+	} {
+		if _, _, err := normalizeOnboardingDraftJSON(raw); err == nil {
+			t.Fatalf("expected invalid list field to fail: %s", raw)
+		}
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestNormalizeLoadedOnboardingDraftFillsPreReleaseEmptyProvenance(t *testing.T) {
 	draft, err := normalizeLoadedOnboardingDraft(onboardingDraft{
 		Revision: 2,


### PR DESCRIPTION
## Summary

- Normalize legacy scalar Agent Card list fields before onboarding confirmation.
- Keep canonical array payloads trimmed and reject invalid mixed types.
- Return a stable invalid-draft response instead of a generic server failure.

## Verification

- `GOCACHE=/tmp/eigenflux-backend-go-cache go test ./api/consolev2`
- `git diff --check`

## Scope

Console V2 onboarding only; V1 APIs are unchanged.