### PR TITLE
fix(console-v2): persist claim computer name

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/lib/pq"
@@ -227,6 +229,17 @@ func provisionReceiptHash(req provisionRequest) (string, error) {
 	return hashString(string(canonical)), nil
 }
 
+func normalizeDeviceName(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", true
+	}
+	if utf8.RuneCountInString(value) > 128 || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return "", false
+	}
+	return value, true
+}
+
 func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	var req provisionRequest
 	if err := decodeBody(c, &req); err != nil {
@@ -259,6 +272,11 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	}
 	if strings.TrimSpace(req.AgentName) == "" {
 		req.AgentName = "EigenFlux Agent"
+	}
+	deviceName, validDeviceName := normalizeDeviceName(string(c.GetHeader("X-Client-Device-Name")))
+	if !validDeviceName {
+		fail(c, http.StatusBadRequest, "INVALID_DEVICE_NAME", "device name is invalid", nil)
+		return
 	}
 	if len(req.Draft) == 0 {
 		req.Draft = json.RawMessage(`{}`)
@@ -299,7 +317,7 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	}
 	initialScopes := []string{"onboarding:write", "context:read", "feed:read", "notifications:ack", "commands:claim", "console:handoff:create"}
 	keyFingerprint := fingerprint(publicKey)
-	observedRuntime, hasObservedRuntime := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
+	observedRuntime, _ := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
 	var agentID, principalID, expiresAt int64
 	created := false
 	err = s.db.Transaction(func(tx *gorm.DB) error {
@@ -458,11 +476,9 @@ func (s *Service) provision(_ context.Context, c *app.RequestContext) {
 	// Provision is the first authenticated request in Console V2 onboarding.
 	// Persist its validated, self-reported product identity synchronously so the
 	// claim page can name the actual runtime before the first settings heartbeat.
-	if hasObservedRuntime {
-		if err := consoledal.UpdateRuntimeIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version); err != nil {
-			fail(c, http.StatusInternalServerError, "PROVISION_RUNTIME_REPORT_FAILED", "could not record Agent runtime", nil)
-			return
-		}
+	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName); err != nil {
+		fail(c, http.StatusInternalServerError, "PROVISION_CLIENT_REPORT_FAILED", "could not record Agent client identity", nil)
+		return
 	}
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":         fmt.Sprintf("%d", agentID),
@@ -751,6 +767,16 @@ func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
 	}
 	if len(req.BrowserNonce) < 32 || len(req.BrowserNonce) > 256 {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "browser_nonce is required", nil)
+		return
+	}
+	observedRuntime, _ := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
+	deviceName, validDeviceName := normalizeDeviceName(string(c.GetHeader("X-Client-Device-Name")))
+	if !validDeviceName {
+		fail(c, http.StatusBadRequest, "INVALID_DEVICE_NAME", "device name is invalid", nil)
+		return
+	}
+	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName); err != nil {
+		fail(c, http.StatusInternalServerError, "HANDOFF_CLIENT_REPORT_FAILED", "could not record Console client identity", nil)
 		return
 	}
 	ticket, err := randomToken("efht_", 32)

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -220,7 +220,8 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		}
 		req.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, transcript))
 		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agent-identities/provision", req,
-			ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.3.14"})
+			ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.3.14"},
+			ut.Header{Key: "X-Client-Device-Name", Value: "Provision-MacBook"})
 		if status != 200 {
 			t.Fatalf("provision status=%d payload=%#v", status, payload)
 		}
@@ -353,7 +354,9 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 
 	browserNonce := strings.Repeat("n", 32)
 	status, handoffPayload, _ := performJSON(t, h, "POST", "/api/v2/console/handoffs", map[string]interface{}{"browser_nonce": browserNonce},
-		ut.Header{Key: "Authorization", Value: "Bearer " + accessToken})
+		ut.Header{Key: "Authorization", Value: "Bearer " + accessToken},
+		ut.Header{Key: "X-Client-Host", Value: "codex"},
+		ut.Header{Key: "X-Client-Device-Name", Value: "Lynn-MacBook-Pro"})
 	if status != 201 {
 		t.Fatalf("handoff status=%d payload=%#v", status, handoffPayload)
 	}
@@ -422,9 +425,11 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		t.Fatalf("onboarding completion is not bound to an active context: %#v", onboarding)
 	}
 	session := responseData(t, sessionPayload)
-	if session["runtime"] != "workbuddy/5.3.14" || session["runtime_name"] != "workbuddy" ||
-		session["runtime_version"] != "5.3.14" {
-		t.Fatalf("console session did not expose the provision runtime: %#v", session)
+	if session["runtime"] != "codex" || session["runtime_name"] != "codex" || session["runtime_version"] != "" {
+		t.Fatalf("console session did not expose the latest handoff runtime: %#v", session)
+	}
+	if session["device_name"] != "Lynn-MacBook-Pro" {
+		t.Fatalf("console session did not expose the handoff computer name: %#v", session)
 	}
 	var profileCompletedAt *int64
 	if err := gdb.Raw(`SELECT profile_completed_at FROM agents WHERE agent_id = ?`, agentIDInt).

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -108,6 +108,7 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		RuntimeVersion string `gorm:"column:runtime_version"`
 		RuntimeMode    string `gorm:"column:runtime_mode"`
 		ClientHost     string `gorm:"column:client_host"`
+		DeviceName     string `gorm:"column:device_name"`
 	}
 	if err := s.db.Raw(`SELECT a.agent_name, a.bio, a.created_at, a.is_official,
 		COALESCE(b.normalized_email, '') AS bound_email,
@@ -115,7 +116,8 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		COALESCE(settings.runtime_name, '') AS runtime_name,
 		COALESCE(settings.runtime_version, '') AS runtime_version,
 		COALESCE(settings.mode, '') AS runtime_mode,
-		COALESCE(settings.client_host, '') AS client_host
+		COALESCE(settings.client_host, '') AS client_host,
+		COALESCE(settings.device_name, '') AS device_name
 		FROM agents a
 		LEFT JOIN agent_email_bindings b ON b.agent_id = a.agent_id
 			AND b.status = 'active' AND b.verification_state = 'verified'
@@ -146,6 +148,7 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		"runtime_name":       runtimeName,
 		"runtime_version":    runtimeVersion,
 		"runtime_mode":       identity.RuntimeMode,
+		"device_name":        identity.DeviceName,
 		"onboarding":         state,
 	})
 }

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -67,6 +67,28 @@ func TestProvisionTranscriptVerifiesAndCoversMutableFields(t *testing.T) {
 	}
 }
 
+func TestNormalizeDeviceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+		ok    bool
+	}{
+		{name: "trimmed", value: "  Lynn-MacBook-Pro  ", want: "Lynn-MacBook-Pro", ok: true},
+		{name: "empty", value: "  ", want: "", ok: true},
+		{name: "control character", value: "Lynn\nMac", want: "", ok: false},
+		{name: "too long", value: strings.Repeat("电", 129), want: "", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := normalizeDeviceName(test.value)
+			if got != test.want || ok != test.ok {
+				t.Fatalf("normalizeDeviceName(%q) = (%q, %v), want (%q, %v)", test.value, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}
+
 func TestRefreshTranscriptVerifiesAndCoversTokenAndNonce(t *testing.T) {
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -52,6 +52,7 @@ type AgentSettings struct {
 	FeedDeliveryPreference string `gorm:"column:feed_delivery_preference"`
 	Mode                   string `gorm:"column:mode"`
 	ClientHost             string `gorm:"column:client_host"`
+	DeviceName             string `gorm:"column:device_name"`
 	RuntimeName            string `gorm:"column:runtime_name"`
 	RuntimeVersion         string `gorm:"column:runtime_version"`
 	RuntimeReportedAt      int64  `gorm:"column:runtime_reported_at"`
@@ -202,6 +203,26 @@ func UpdateRuntimeIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersi
 			"runtime_reported_at": now,
 			"updated_at":          now,
 		}).Error
+}
+
+// UpdateHandoffClientIdentity records the computer that generated a Console
+// handoff and, when present, the current Agent product identity in one write.
+func UpdateHandoffClientIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion, deviceName string) error {
+	vals := map[string]interface{}{}
+	now := time.Now().UnixMilli()
+	if runtimeName != "" {
+		vals["runtime_name"] = runtimeName
+		vals["runtime_version"] = runtimeVersion
+		vals["runtime_reported_at"] = now
+	}
+	// The provision/handoff represents the current computer. Clear a stale value
+	// when an older CLI cannot report it instead of displaying another machine.
+	vals["device_name"] = deviceName
+	if _, err := GetSettings(db, agentID); err != nil {
+		return err
+	}
+	vals["updated_at"] = now
+	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).Updates(vals).Error
 }
 
 // UpdateAgentModel persists the agent's reported runtime model (X-Client-Model).

--- a/migrations/000073_console_v2_device_name.sql
+++ b/migrations/000073_console_v2_device_name.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Computer name reported by the authenticated CLI that provisions an Agent or
+-- creates a Console V2 handoff. It is presentation metadata only.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE agent_settings
+    ADD COLUMN IF NOT EXISTS device_name VARCHAR(128) NOT NULL DEFAULT '';
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE agent_settings
+    DROP COLUMN IF EXISTS device_name;


### PR DESCRIPTION
## 变更\n- 接收 CLI 在 provision / handoff 上报的电脑名称\n- 在 agent_settings 中持久化 device_name\n- Console V2 session 返回 device_name\n- 增加字段校验与流程测试\n\n## 范围\n仅后端与数据库迁移；不包含 CLI、Skills、Web。\n\n## 验证\n- go test ./api/consolev2 ./api/dal\n- go build -o /private/tmp/eigenflux-device-name-api ./api\n- git diff --check