### PR TITLE
fix(console-v2): align onboarding step semantics

### DIFF
--- a/api/consolev2/control_handlers.go
+++ b/api/consolev2/control_handlers.go
@@ -96,8 +96,8 @@ type IntentWriteFields struct {
 }
 
 func validateIntent(fields IntentWriteFields) error {
-	if strings.TrimSpace(fields.WatchFor) == "" || strings.TrimSpace(fields.TriggerWhen) == "" || strings.TrimSpace(fields.ActionInstruction) == "" {
-		return errors.New("intent text fields are required")
+	if strings.TrimSpace(fields.WatchFor) == "" {
+		return errors.New("watch_for is required")
 	}
 	if utf8.RuneCountInString(fields.WatchFor) > 1000 || utf8.RuneCountInString(fields.TriggerWhen) > 1000 || utf8.RuneCountInString(fields.ActionInstruction) > 2000 {
 		return errors.New("intent text exceeds its length limit")

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -471,15 +471,13 @@ func validateDraftStep(payload draftPayload, step int16) error {
 			}
 		}
 	case 3:
-		return nil
-	case 4:
 		if strings.TrimSpace(payload.NetworkGoal) == "" {
 			return fmt.Errorf("%w: network_goal is required", errInvalidOnboardingDraft)
 		}
 		if utf8.RuneCountInString(payload.NetworkGoal) > 2000 {
 			return fmt.Errorf("%w: network goal exceeds 2000 characters", errInvalidOnboardingDraft)
 		}
-	case 5:
+	case 4:
 		if len(payload.IntentActions) > 10 {
 			return fmt.Errorf("%w: at most 10 intent actions are allowed", errInvalidOnboardingDraft)
 		}
@@ -492,6 +490,8 @@ func validateDraftStep(payload draftPayload, step int16) error {
 				return fmt.Errorf("%w: %v", errInvalidOnboardingDraft, err)
 			}
 		}
+	case 5:
+		return nil
 	default:
 		return fmt.Errorf("%w: unsupported onboarding step", errInvalidOnboardingDraft)
 	}
@@ -755,15 +755,6 @@ func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPay
 		}
 		return err
 	case 3:
-		return tx.Exec(`INSERT INTO agent_settings
-			(agent_id, recurring_publish, auto_reply_pm, auto_comment, show_add_friend, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?)
-			ON CONFLICT (agent_id) DO UPDATE SET recurring_publish = EXCLUDED.recurring_publish,
-				auto_reply_pm = EXCLUDED.auto_reply_pm, auto_comment = EXCLUDED.auto_comment,
-				show_add_friend = EXCLUDED.show_add_friend, updated_at = EXCLUDED.updated_at`, agentID,
-			payload.SecurityBoundary.RecurringPublish, payload.SecurityBoundary.AutoReplyPM,
-			payload.SecurityBoundary.AutoComment, payload.SecurityBoundary.ShowAddFriend, now).Error
-	case 4:
 		if strings.TrimSpace(payload.NetworkGoal) == "" {
 			return fmt.Errorf("%w: network_goal is required", errInvalidOnboardingDraft)
 		}
@@ -775,7 +766,7 @@ func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPay
 			(agent_id, goal_text, source, status, version, created_at, updated_at)
 			VALUES (?, ?, ?, 'active', 1, ?, ?)`, agentID, payload.NetworkGoal,
 			canonicalSource(provenance, "network_goal"), now, now).Error
-	case 5:
+	case 4:
 		if err := tx.Exec(`UPDATE agent_intent_actions SET status = 'deleted', updated_at = ?
 			WHERE agent_id = ? AND status <> 'deleted'`, now, agentID).Error; err != nil {
 			return err
@@ -790,6 +781,15 @@ func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPay
 				return err
 			}
 		}
+	case 5:
+		return tx.Exec(`INSERT INTO agent_settings
+			(agent_id, recurring_publish, auto_reply_pm, auto_comment, show_add_friend, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?)
+			ON CONFLICT (agent_id) DO UPDATE SET recurring_publish = EXCLUDED.recurring_publish,
+				auto_reply_pm = EXCLUDED.auto_reply_pm, auto_comment = EXCLUDED.auto_comment,
+				show_add_friend = EXCLUDED.show_add_friend, updated_at = EXCLUDED.updated_at`, agentID,
+			payload.SecurityBoundary.RecurringPublish, payload.SecurityBoundary.AutoReplyPM,
+			payload.SecurityBoundary.AutoComment, payload.SecurityBoundary.ShowAddFriend, now).Error
 	}
 	return nil
 }

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -406,13 +406,12 @@ func validateDraftPayload(payload draftPayload) error {
 		return errors.New("at most 10 intent actions are allowed")
 	}
 	for _, intent := range payload.IntentActions {
-		if intent.WatchFor == "" || intent.TriggerWhen == "" || intent.ActionInstruction == "" {
-			return errors.New("each intent requires watch_for, trigger_when, and action_instruction")
-		}
-		switch intent.ActionPolicy {
-		case "analyze_only", "draft", "network_action", "trade_action":
-		default:
-			return errors.New("unsupported action_policy")
+		if err := validateIntent(IntentWriteFields{
+			WatchFor: intent.WatchFor, TriggerWhen: intent.TriggerWhen,
+			ActionInstruction: intent.ActionInstruction, ActionPolicy: intent.ActionPolicy,
+			Priority: intent.Priority,
+		}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/api/consolev2/onboarding_provenance.go
+++ b/api/consolev2/onboarding_provenance.go
@@ -310,11 +310,11 @@ func confirmStepProvenance(draft map[string]interface{}, provenance map[string]f
 	case 2:
 		paths = onboardingDraftFieldPaths[:12]
 	case 3:
-		paths = onboardingDraftFieldPaths[12:16]
-	case 4:
 		paths = onboardingDraftFieldPaths[16:17]
-	case 5:
+	case 4:
 		paths = onboardingDraftFieldPaths[17:18]
+	case 5:
+		paths = onboardingDraftFieldPaths[12:16]
 	}
 	for _, path := range paths {
 		value, exists := draftPathValue(draft, path)

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -467,6 +467,20 @@ func TestOnboardingIntentValidationRejectsWhitespace(t *testing.T) {
 	}
 }
 
+func TestOnboardingIntentValidationAllowsOptionalConditionAndAction(t *testing.T) {
+	var payload draftPayload
+	payload.IntentActions = append(payload.IntentActions, struct {
+		WatchFor          string `json:"watch_for"`
+		TriggerWhen       string `json:"trigger_when"`
+		ActionInstruction string `json:"action_instruction"`
+		ActionPolicy      string `json:"action_policy"`
+		Priority          int16  `json:"priority"`
+	}{WatchFor: "AI Agent infrastructure", ActionPolicy: "analyze_only"})
+	if err := validateDraftStep(payload, 5); err != nil {
+		t.Fatalf("optional intent fields blocked onboarding completion: %v", err)
+	}
+}
+
 func TestProcessStreamLimitIsSharedAcrossStreamKinds(t *testing.T) {
 	service := &Service{processStreamTotal: maxProcessStreams - 1}
 	if !service.tryAcquireProcessStream() {

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -462,7 +462,7 @@ func TestOnboardingIntentValidationRejectsWhitespace(t *testing.T) {
 		ActionPolicy      string `json:"action_policy"`
 		Priority          int16  `json:"priority"`
 	}{WatchFor: "   ", TriggerWhen: "signal", ActionInstruction: "report", ActionPolicy: "analyze_only"})
-	if err := validateDraftStep(payload, 5); err == nil {
+	if err := validateDraftStep(payload, 4); err == nil {
 		t.Fatal("whitespace-only intent passed validation")
 	}
 }
@@ -476,7 +476,7 @@ func TestOnboardingIntentValidationAllowsOptionalConditionAndAction(t *testing.T
 		ActionPolicy      string `json:"action_policy"`
 		Priority          int16  `json:"priority"`
 	}{WatchFor: "AI Agent infrastructure", ActionPolicy: "analyze_only"})
-	if err := validateDraftStep(payload, 5); err != nil {
+	if err := validateDraftStep(payload, 4); err != nil {
 		t.Fatalf("optional intent fields blocked onboarding completion: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- align Console V2 onboarding step semantics with the Web flow: identity card, network goal, intents, then safety boundary
- make intent condition and action details optional while keeping watch_for required
- align field-provenance confirmation with the corrected step order
- preserve length, action-policy, and whitespace validation

## Verification

- go test ./api/consolev2
- git diff --check

## Scope

Console V2 onboarding only. V1 APIs and behavior are unchanged.
