### PR TITLE
fix(console-v2): record Feed and communication activity

### DIFF
--- a/api/consolev2/feed_handlers.go
+++ b/api/consolev2/feed_handlers.go
@@ -16,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	feedrpc "eigenflux_server/kitex_gen/eigenflux/feed"
+	"eigenflux_server/pkg/activity"
 	"eigenflux_server/pkg/feedcontract"
 	profiledal "eigenflux_server/rpc/profile/dal"
 )
@@ -181,6 +182,7 @@ func (s *Service) pullFeedV2(ctx context.Context, c *app.RequestContext) {
 		fail(c, http.StatusServiceUnavailable, "FEED_PAYLOAD_TOO_LARGE", "Feed response exceeds the V2 response budget", nil)
 		return
 	}
+	activity.PublishFeedPull(ctx, agentIDValue, len(feedResp.Items))
 	reply(c, http.StatusOK, response)
 }
 

--- a/pipeline/consumer/activity_consumer.go
+++ b/pipeline/consumer/activity_consumer.go
@@ -264,7 +264,8 @@ func (c *ActivityConsumer) processMessage(ctx context.Context, msgID string, val
 
 func isSupportedActivityType(value string) bool {
 	switch value {
-	case "feed_pull", "broadcast", "feedback", "message_sent", "reply_received", "profile_update", "friend_added":
+	case "feed_pull", "broadcast", "feedback", "message_sent", "message_received", "reply_received",
+		"profile_update", "friend_request_sent", "friend_request_received", "friend_added":
 		return true
 	default:
 		return false

--- a/pipeline/consumer/activity_types_test.go
+++ b/pipeline/consumer/activity_types_test.go
@@ -1,0 +1,14 @@
+package consumer
+
+import "testing"
+
+func TestSupportedCommunicationActivityTypes(t *testing.T) {
+	for _, eventType := range []string{
+		"feed_pull", "message_sent", "message_received", "friend_request_sent",
+		"friend_request_received", "friend_added",
+	} {
+		if !isSupportedActivityType(eventType) {
+			t.Fatalf("expected %q to be supported", eventType)
+		}
+	}
+}

--- a/pkg/activity/events.go
+++ b/pkg/activity/events.go
@@ -74,6 +74,27 @@ func PublishReplyReceived(ctx context.Context, agentID int64, senderName string)
 	go publish(ctx, agentID, "reply_received", summary, "")
 }
 
+// PublishMessageReceived emits a message_received event for the recipient of
+// an ordinary private message. It is distinct from reply_received, which is
+// retained for the legacy broadcast-reply metric.
+func PublishMessageReceived(ctx context.Context, agentID int64, senderName string) {
+	summary := "Received a private message"
+	if senderName != "" {
+		summary = fmt.Sprintf("Received message from %s", senderName)
+	}
+	go publish(ctx, agentID, "message_received", summary, "")
+}
+
+// PublishFriendRequestSent and PublishFriendRequestReceived record the two
+// viewer-relative sides of a pending relationship request.
+func PublishFriendRequestSent(ctx context.Context, agentID int64) {
+	go publish(ctx, agentID, "friend_request_sent", "Sent a friend request", "")
+}
+
+func PublishFriendRequestReceived(ctx context.Context, agentID int64) {
+	go publish(ctx, agentID, "friend_request_received", "Received a friend request", "")
+}
+
 // PublishProfileUpdate emits a profile_update event asynchronously, recorded
 // when the agent refreshes its bio. Low-frequency (vs. feed_pull), so the
 // console can pin the most recent one rather than let it scroll away.

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"eigenflux_server/kitex_gen/eigenflux/base"
 	"eigenflux_server/kitex_gen/eigenflux/pm"
+	"eigenflux_server/pkg/activity"
 	"eigenflux_server/pkg/agentcard"
 	"eigenflux_server/pkg/db"
 	"eigenflux_server/pkg/logger"
@@ -194,6 +195,7 @@ func (s *PMServiceImpl) handleNewConversation(ctx context.Context, req *pm.SendP
 	}
 
 	logger.Ctx(ctx).Info("new conversation", "convID", convID, "msgID", msgID, "senderID", req.SenderId, "receiverID", receiverID, "itemID", itemID)
+	activity.PublishMessageReceived(ctx, receiverID, senderName)
 
 	return &pm.SendPMResp{
 		MsgId:    msgID,
@@ -293,6 +295,7 @@ func (s *PMServiceImpl) handleReply(ctx context.Context, req *pm.SendPMReq, skip
 	}
 
 	logger.Ctx(ctx).Info("reply sent", "convID", convID, "msgID", msgID, "senderID", req.SenderId, "receiverID", receiverID)
+	activity.PublishMessageReceived(ctx, receiverID, senderName)
 
 	return &pm.SendPMResp{
 		MsgId:    msgID,
@@ -354,6 +357,7 @@ func (s *PMServiceImpl) handleFriendPM(ctx context.Context, req *pm.SendPMReq) (
 		logger.Ctx(ctx).Error("failed to publish pm push notification", "receiverID", req.ReceiverId, "msgID", msgID, "err", err)
 	}
 	logger.Ctx(ctx).Info("FriendPM new conv", "convID", convID, "msgID", msgID, "senderID", req.SenderId, "receiverID", req.ReceiverId)
+	activity.PublishMessageReceived(ctx, req.ReceiverId, nameMap[req.SenderId])
 	return &pm.SendPMResp{MsgId: msgID, ConvId: convID, BaseResp: &base.BaseResp{Code: 0, Msg: "success"}}, nil
 }
 
@@ -784,6 +788,8 @@ func (s *PMServiceImpl) SendFriendRequest(ctx context.Context, req *pm.SendFrien
 	}
 
 	if notifyRecipient {
+		activity.PublishFriendRequestSent(ctx, req.FromUid)
+		activity.PublishFriendRequestReceived(ctx, req.ToUid)
 		logger.Ctx(ctx).Info("SendFriendRequest created", "requestID", requestID, "fromUID", req.FromUid, "toUID", req.ToUid)
 		go func() {
 			if err := notifyutil.WriteFriendRequestNotification(context.Background(), db.RDB, requestID, req.ToUid, greeting); err != nil {
@@ -794,6 +800,8 @@ func (s *PMServiceImpl) SendFriendRequest(ctx context.Context, req *pm.SendFrien
 			logger.Ctx(ctx).Error("failed to publish friend request push notification", "agentID", req.ToUid, "err", err)
 		}
 	} else {
+		activity.PublishFriendAdded(ctx, req.FromUid, "")
+		activity.PublishFriendAdded(ctx, req.ToUid, "")
 		logger.Ctx(ctx).Info("SendFriendRequest auto-accepted mutual request", "requestID", requestID, "fromUID", req.FromUid, "toUID", req.ToUid)
 		go func() {
 			if err := notifyutil.WriteFriendResponseNotification(context.Background(), db.RDB, requestID, req.ToUid, "friend_accepted", ""); err != nil {
@@ -946,6 +954,9 @@ func (s *PMServiceImpl) HandleFriendRequest(ctx context.Context, req *pm.HandleF
 	switch responseNotifType {
 	case "friend_accepted":
 		logger.Ctx(ctx).Info("FriendRequest accepted", "requestID", req.RequestId, "fromUID", friendReq.FromUID, "toUID", friendReq.ToUID)
+		// The HTTP gateway already records the accepting Agent. Record the
+		// original requester here so both sides see the established relation.
+		activity.PublishFriendAdded(ctx, friendReq.FromUID, "")
 		agentcard.PublishRebuild(ctx, friendReq.FromUID, "friend_added")
 		agentcard.PublishRebuild(ctx, friendReq.ToUID, "friend_added")
 		go func() {


### PR DESCRIPTION
## Summary
- record successful Console V2 Feed pulls in the activity stream
- record incoming private messages and both sides of friend-request/friend-added activity
- allow the new event types through the durable activity consumer

## Validation
- go test ./api/consolev2 -count=1
- compiled pipeline/consumer and rpc/pm test binaries
- pipeline/consumer full test run requires local PostgreSQL and was not available in this worktree