### PR TITLE
fix(console-v2): return encounter country codes

### DIFF
--- a/api/consolev2/today_handlers.go
+++ b/api/consolev2/today_handlers.go
@@ -22,10 +22,29 @@ const (
 )
 
 type todayEncounter struct {
-	PeerAgentID      int64 `gorm:"column:peer_agent_id" json:"peer_agent_id,string"`
-	LastInteraction  int64 `gorm:"column:last_interaction_at" json:"last_interaction_at"`
-	InteractionCount int64 `gorm:"column:interaction_count" json:"interaction_count"`
-	TotalCount       int64 `gorm:"column:total_count" json:"-"`
+	PeerAgentID      int64  `gorm:"column:peer_agent_id" json:"peer_agent_id,string"`
+	LastInteraction  int64  `gorm:"column:last_interaction_at" json:"last_interaction_at"`
+	InteractionCount int64  `gorm:"column:interaction_count" json:"interaction_count"`
+	CountryCode      string `gorm:"column:country_code" json:"country_code,omitempty"`
+	TotalCount       int64  `gorm:"column:total_count" json:"-"`
+}
+
+func todayCountryCode(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	if code, ok := onboardingCountryAliases[strings.ToUpper(value)]; ok {
+		if code == "ZZ" {
+			return ""
+		}
+		return code
+	}
+	upper := strings.ToUpper(value)
+	if countryCodePattern.MatchString(upper) && upper != "ZZ" {
+		return upper
+	}
+	return ""
 }
 
 var consoleV2CardCompletionFields = []string{
@@ -259,9 +278,13 @@ func (s *Service) getToday(_ context.Context, c *app.RequestContext) {
 				COUNT(*)::bigint AS interaction_count
 			FROM recent WHERE peer_agent_id <> ? GROUP BY peer_agent_id
 		)
-		SELECT peer_agent_id, last_interaction_at, interaction_count,
+		SELECT grouped.peer_agent_id, grouped.last_interaction_at, grouped.interaction_count,
+			COALESCE(NULLIF(BTRIM(profile.profile_data->>'geo'), ''),
+				NULLIF(BTRIM(profile.country), '')) AS country_code,
 			COUNT(*) OVER() AS total_count
-		FROM grouped ORDER BY last_interaction_at DESC, peer_agent_id DESC LIMIT ?`,
+		FROM grouped
+		LEFT JOIN agent_profiles profile ON profile.agent_id = grouped.peer_agent_id
+		ORDER BY grouped.last_interaction_at DESC, grouped.peer_agent_id DESC LIMIT ?`,
 		agentIDValue, todayStart, agentIDValue, todayStart,
 		agentIDValue, todayStart,
 		agentIDValue, todayEncounterLimit).Scan(&encounters).Error; err != nil {
@@ -275,6 +298,9 @@ func (s *Service) getToday(_ context.Context, c *app.RequestContext) {
 	}
 	for _, encounter := range encounters {
 		peerIDs = append(peerIDs, encounter.PeerAgentID)
+	}
+	for index := range encounters {
+		encounters[index].CountryCode = todayCountryCode(encounters[index].CountryCode)
 	}
 	relations, err := s.loadViewerRelations(agentIDValue, peerIDs)
 	if err != nil {

--- a/api/consolev2/today_handlers_test.go
+++ b/api/consolev2/today_handlers_test.go
@@ -1,9 +1,34 @@
 package consolev2
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestTodayCountryCodeNormalizesKnownAndISOValues(t *testing.T) {
+	tests := map[string]string{
+		"CN": "CN", "China": "CN", "中国大陆": "CN",
+		"SG": "SG", "Singapore": "SG", "DE": "DE",
+		"": "", "ZZ": "", "not-a-country": "",
+	}
+	for input, want := range tests {
+		if got := todayCountryCode(input); got != want {
+			t.Fatalf("todayCountryCode(%q)=%q want=%q", input, got, want)
+		}
+	}
+}
+
+func TestTodayEncounterReturnsCountryCode(t *testing.T) {
+	payload, err := json.Marshal(todayEncounter{PeerAgentID: 123, CountryCode: "SG"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), `"peer_agent_id":"123"`) || !strings.Contains(string(payload), `"country_code":"SG"`) {
+		t.Fatalf("unexpected Today encounter payload: %s", payload)
+	}
+}
 
 func TestCalculateCardCompletionUsesEditableRegistry(t *testing.T) {
 	publicCard := `{


### PR DESCRIPTION
## Summary
- return normalized country_code for Today encounters
- keep missing or unknown locations on the globe fallback
- batch-enrich at the bounded encounter query without N+1

## Tests
- GOCACHE=/private/tmp/eigenflux-go-cache go test ./api/consolev2 -count=1