### PR TITLE
feat(console-v2): add safe Attention rollout foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,7 @@ ENABLE_EMAIL_VERIFICATION=false
 ENABLE_CONSOLE_V2=false
 ENABLE_FEED_V2=false
 ENABLE_CONTROL_CHANNEL_V2=false
+ENABLE_AGENT_ATTENTION_V1=false
 ENABLE_COMMUNICATION_V2=false
 ENABLE_PUBLIC_AGENT_REGISTRATION=false
 # Required by the controlled installation broker when Console V2 is enabled.

--- a/migrations/000075_console_v2_agent_attention_expand.sql
+++ b/migrations/000075_console_v2_agent_attention_expand.sql
@@ -1,0 +1,46 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Phase 1 is expand-only. Existing Attention readers and writers continue to
+-- use the legacy columns while the agent_attention.v1 implementation remains
+-- disabled. No data is deleted and no legacy write is rejected here.
+SET lock_timeout = '2s';
+SET statement_timeout = '5min';
+
+ALTER TABLE agent_attention_items
+    ADD COLUMN IF NOT EXISTS producer VARCHAR(16) NOT NULL DEFAULT 'legacy',
+    ADD COLUMN IF NOT EXISTS surface VARCHAR(24) NOT NULL DEFAULT 'focus',
+    ADD COLUMN IF NOT EXISTS category VARCHAR(32) NOT NULL DEFAULT 'other_attention',
+    ADD COLUMN IF NOT EXISTS client_item_id VARCHAR(128) NULL,
+    ADD COLUMN IF NOT EXISTS payload_hash VARCHAR(128) NULL,
+    ADD COLUMN IF NOT EXISTS language VARCHAR(16) NOT NULL DEFAULT 'en',
+    ADD COLUMN IF NOT EXISTS body TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS recommendation TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS source_ref JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS context_ref JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS actions_snapshot JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS item_revision BIGINT NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS selected_action_key VARCHAR(128) NULL,
+    ADD COLUMN IF NOT EXISTS response_status VARCHAR(16) NOT NULL DEFAULT 'none',
+    ADD COLUMN IF NOT EXISTS generated_at BIGINT NULL,
+    ADD COLUMN IF NOT EXISTS updated_at BIGINT NULL,
+    ADD COLUMN IF NOT EXISTS responded_at BIGINT NULL,
+    ADD COLUMN IF NOT EXISTS redacted_at BIGINT NULL;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_agent_attention_client_item
+    ON agent_attention_items(agent_id, client_item_id)
+    WHERE producer = 'agent';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_attention_agent_surface_recent
+    ON agent_attention_items(agent_id, surface, created_at DESC, attention_id DESC)
+    WHERE producer = 'agent';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_attention_redaction
+    ON agent_attention_items(generated_at, attention_id)
+    WHERE producer = 'agent' AND redacted_at IS NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_attention_protocol_expiry
+    ON agent_attention_items(expires_at, attention_id)
+    WHERE producer = 'agent' AND status IN ('open', 'selected', 'pending');
+
+-- +goose Down
+
+-- Expand-only migrations are rolled back by keeping the protocol flag off.
+SELECT 1;

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	EnableConsoleV2             bool     // Enable the isolated Console V2 BFF and onboarding routes
 	EnableFeedV2                bool     // Enable the stateless latest-view Feed V2 route
 	EnableControlChannelV2      bool     // Enable Agent command and attention routes
+	EnableAgentAttentionV1      bool     // Reserve the default-off agent_attention.v1 rollout gate
 	EnableCommunicationV2       bool     // Enable V2 PM/friend responses enriched with public Agent Card data
 	EnablePublicRegistration    bool     // Allow Agents to obtain a rate-limited key-bound bootstrap challenge without a broker
 	ConsoleV2BootstrapSecret    string   // Shared secret used only by the controlled bootstrap broker
@@ -258,6 +259,7 @@ func Load() *Config {
 		EnableConsoleV2:              getEnvBool("ENABLE_CONSOLE_V2", false),
 		EnableFeedV2:                 getEnvBool("ENABLE_FEED_V2", false),
 		EnableControlChannelV2:       getEnvBool("ENABLE_CONTROL_CHANNEL_V2", false),
+		EnableAgentAttentionV1:       getEnvBool("ENABLE_AGENT_ATTENTION_V1", false),
 		EnableCommunicationV2:        getEnvBool("ENABLE_COMMUNICATION_V2", false),
 		EnablePublicRegistration:     getEnvBool("ENABLE_PUBLIC_AGENT_REGISTRATION", false),
 		ConsoleV2BootstrapSecret:     getEnv("CONSOLE_V2_BOOTSTRAP_SECRET", ""),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -133,6 +133,7 @@ func TestConsoleV2FeatureFlagsDefaultOff(t *testing.T) {
 	t.Setenv("ENABLE_CONSOLE_V2", "")
 	t.Setenv("ENABLE_FEED_V2", "")
 	t.Setenv("ENABLE_CONTROL_CHANNEL_V2", "")
+	t.Setenv("ENABLE_AGENT_ATTENTION_V1", "")
 	t.Setenv("ENABLE_COMMUNICATION_V2", "")
 	t.Setenv("ENABLE_PUBLIC_AGENT_REGISTRATION", "")
 	t.Setenv("POSTGRES_PORT", "")
@@ -140,7 +141,7 @@ func TestConsoleV2FeatureFlagsDefaultOff(t *testing.T) {
 	t.Setenv("ETCD_PORT", "")
 
 	cfg := Load()
-	if cfg.EnableConsoleV2 || cfg.EnableFeedV2 || cfg.EnableControlChannelV2 || cfg.EnableCommunicationV2 || cfg.EnablePublicRegistration {
+	if cfg.EnableConsoleV2 || cfg.EnableFeedV2 || cfg.EnableControlChannelV2 || cfg.EnableAgentAttentionV1 || cfg.EnableCommunicationV2 || cfg.EnablePublicRegistration {
 		t.Fatal("Console V2 feature flags must default to disabled")
 	}
 	if cfg.ConsoleV2Registration.WindowSec != 86400 || cfg.ConsoleV2Registration.IPLimit != 500 ||
@@ -154,6 +155,7 @@ func TestConsoleV2FeatureFlagsCanBeEnabledIndependently(t *testing.T) {
 	t.Setenv("ENABLE_CONSOLE_V2", "true")
 	t.Setenv("ENABLE_FEED_V2", "false")
 	t.Setenv("ENABLE_CONTROL_CHANNEL_V2", "true")
+	t.Setenv("ENABLE_AGENT_ATTENTION_V1", "true")
 	t.Setenv("ENABLE_COMMUNICATION_V2", "false")
 	t.Setenv("ENABLE_PUBLIC_AGENT_REGISTRATION", "true")
 	t.Setenv("POSTGRES_PORT", "")
@@ -161,7 +163,7 @@ func TestConsoleV2FeatureFlagsCanBeEnabledIndependently(t *testing.T) {
 	t.Setenv("ETCD_PORT", "")
 
 	cfg := Load()
-	if !cfg.EnableConsoleV2 || cfg.EnableFeedV2 || !cfg.EnableControlChannelV2 || cfg.EnableCommunicationV2 || !cfg.EnablePublicRegistration {
+	if !cfg.EnableConsoleV2 || cfg.EnableFeedV2 || !cfg.EnableControlChannelV2 || !cfg.EnableAgentAttentionV1 || cfg.EnableCommunicationV2 || !cfg.EnablePublicRegistration {
 		t.Fatal("Console V2 feature flags were not loaded independently")
 	}
 }


### PR DESCRIPTION
## Scope\n- add an expand-only Agent Attention schema foundation\n- add a default-off ENABLE_AGENT_ATTENTION_V1 configuration gate\n- keep all existing Attention, Feed, Today, and command behavior unchanged\n\n## Production safety\n- no route registration changes\n- no legacy write rejection\n- no data purge or backfill\n- concurrent indexes only\n- ALTER TABLE uses a 2-second lock timeout and fails rather than queueing online traffic\n- feature flag remains false in production\n\n## Verification\n- go test ./pkg/config ./api/consolev2 ./pkg/consolev2retention\n- git diff --check\n\nThe full agent_attention.v1 protocol and flag activation remain a separate follow-up release after this compatibility foundation is live.