### PR TITLE
feat(rerank): boost whitelisted item IDs

### DIFF
--- a/configs/sort/rerank.yaml
+++ b/configs/sort/rerank.yaml
@@ -5,7 +5,6 @@ policies:
         max_age: 12h
         action: drop
   - name: boost
-    item_boosts: []              # entries: {item_id: <positive int64>, weight: <positive multiplier>}
     boost_rules:
       - field: type
         values: [supply, demand]

--- a/configs/sort/rerank.yaml
+++ b/configs/sort/rerank.yaml
@@ -5,6 +5,7 @@ policies:
         max_age: 12h
         action: drop
   - name: boost
+    item_boosts: []              # entries: {item_id: <positive int64>, weight: <positive multiplier>}
     boost_rules:
       - field: type
         values: [supply, demand]

--- a/docs/dev/rerank.md
+++ b/docs/dev/rerank.md
@@ -11,7 +11,7 @@ Item discovery uses three layers: recall produces candidate IDs, the typed item 
 `rpc/sort/rerank` provides the policy chain and the policies currently used by `SortItems`:
 
 - `FreshnessPolicy` drops stale items according to type-specific YAML rules.
-- `BoostPolicy` applies operator weights to category and content-class signals.
+- `BoostPolicy` applies operator weights to category/content-class signals and an optional item-ID whitelist multiplier; a whitelist match overrides category boost rules for that item.
 - `InjectPolicy` reserves delivery capacity for candidates from configured recall sources.
 - `MatchLimitPolicy` caps candidates matching a configured recall-source predicate.
 
@@ -20,6 +20,8 @@ Policies are pure transforms with no I/O. Request-specific predicates and source
 ## Configuration
 
 `SortItems` reads `configs/sort/rerank.yaml` once at startup. Missing or invalid configuration logs a warning and disables configured item policies for that process. Freshness runs before typed ranking, boost runs after ranking, injection runs before Bloom deduplication, and source limits run after Bloom deduplication but before final truncation.
+
+`boost` accepts an `item_boosts` list of `{item_id, weight}` entries. IDs and weights must be positive, weights must be finite, and IDs must be unique. A matching item has its score multiplied by the configured weight and skips `boost_rules`; nonmatching items retain the existing attribute-rule behavior. The repository list is empty because operators own production IDs and weights.
 
 ## Verification
 

--- a/docs/dev/rerank.md
+++ b/docs/dev/rerank.md
@@ -21,7 +21,7 @@ Policies are pure transforms with no I/O. Request-specific predicates and source
 
 `SortItems` reads `configs/sort/rerank.yaml` once at startup. Missing or invalid configuration logs a warning and disables configured item policies for that process. Freshness runs before typed ranking, boost runs after ranking, injection runs before Bloom deduplication, and source limits run after Bloom deduplication but before final truncation.
 
-`boost` accepts an `item_boosts` list of `{item_id, weight}` entries. IDs and weights must be positive, weights must be finite, and IDs must be unique. A matching item has its score multiplied by the configured weight and skips `boost_rules`; nonmatching items retain the existing attribute-rule behavior. The repository list is empty because operators own production IDs and weights.
+`boost` accepts an optional `item_boosts` list of `{item_id, weight}` entries. IDs and weights must be positive, weights must be finite, and IDs must be unique. A matching item has its score multiplied by the configured weight and skips `boost_rules`; nonmatching items retain the existing attribute-rule behavior. The repository configuration omits `item_boosts`; operators add it only when production IDs and weights are required.
 
 ## Verification
 

--- a/docs/dev/rerank.md
+++ b/docs/dev/rerank.md
@@ -11,7 +11,7 @@ Item discovery uses three layers: recall produces candidate IDs, the typed item 
 `rpc/sort/rerank` provides the policy chain and the policies currently used by `SortItems`:
 
 - `FreshnessPolicy` drops stale items according to type-specific YAML rules.
-- `BoostPolicy` applies operator weights to category/content-class signals and an optional item-ID whitelist multiplier; a whitelist match overrides category boost rules for that item.
+- `BoostPolicy` applies operator weights through `type`, `source_type`, and `content_class` rules plus optional per-item multipliers; a matching `item_id` skips all `boost_rules` for that item.
 - `InjectPolicy` reserves delivery capacity for candidates from configured recall sources.
 - `MatchLimitPolicy` caps candidates matching a configured recall-source predicate.
 

--- a/docs/superpowers/specs/2026-08-26-item-id-whitelist-boost-design.md
+++ b/docs/superpowers/specs/2026-08-26-item-id-whitelist-boost-design.md
@@ -1,0 +1,84 @@
+# Item ID Whitelist Boost Design
+
+## Problem
+
+The Sort rerank layer can currently boost candidates only by item attributes (`type`, `source_type`, and `content_class`). Operators need to heat a specific set of item IDs through `configs/sort/rerank.yaml` without changing code.
+
+## Decision
+
+Extend the existing `boost` policy with item-specific boost entries. Keeping item and attribute boosts in one policy gives that policy sole ownership of boost precedence and requires only one score update and one stable sort.
+
+A dedicated whitelist policy was rejected because the existing attribute boost policy would need cross-policy state to detect and skip already-whitelisted candidates. Handler-level logic was rejected because it would move operator scoring behavior outside the rerank strategy layer.
+
+## Configuration Contract
+
+The `boost` policy accepts an optional `item_boosts` list:
+
+```yaml
+policies:
+  - name: boost
+    item_boosts:
+      - item_id: 123456
+        weight: 2.0
+      - item_id: 789012
+        weight: 1.5
+    boost_rules:
+      - field: type
+        values: [supply, demand]
+        weight: 1.3
+```
+
+Each entry has two required fields:
+
+- `item_id`: a positive signed 64-bit item ID.
+- `weight`: a positive finite multiplier.
+
+Duplicate `item_id` entries are invalid. Rejecting duplicates avoids implicit last-write-wins or accidental multiplicative behavior.
+
+The repository configuration will declare `item_boosts: []`. Production item IDs and weights remain operator-owned and are not invented by this change.
+
+## Runtime Behavior
+
+`BoostPolicy` remains a post-rank policy. It runs after typed ranking and before the relevance-threshold split, allowing a heated item to cross the delivery threshold.
+
+For each mutable item candidate:
+
+1. Look up the candidate ID in the configured item boost table.
+2. When found, multiply the current score by that item weight, add reason `boost:item_id=<id>`, and skip all attribute `boost_rules` for that candidate.
+3. When not found, apply existing matching attribute rules multiplicatively without behavior changes.
+4. Stable-sort all candidates by descending final score.
+
+Whitelist precedence is therefore override precedence within the boost stage: an item whitelist multiplier replaces all type, source-type, and content-class multipliers for that candidate. It does not replace the upstream ranker score.
+
+Non-item candidates, immutable `Candidate` implementations, and empty configurations continue to pass through unchanged.
+
+## Components
+
+### Configuration
+
+`rpc/sort/rerank/config.go` owns YAML decoding and validation. It will add an item boost configuration type, validate IDs and weights, reject duplicate IDs, and construct the runtime lookup table.
+
+### Policy
+
+`rpc/sort/rerank/policy_boost.go` owns whitelist precedence and score mutation. The lookup is keyed by `int64`, giving constant-time matching per candidate without scanning every configured ID.
+
+### Sort integration
+
+No new handler path is required. `applyPostRankBoost` already wraps ranked items as `rank.Candidate`, executes `BoostPolicy`, copies final scores back into `ranker.RankedItem`, and preserves the policy-produced order.
+
+## Error Handling
+
+Invalid item boost configuration makes `Config.NewPolicies` return an error. Existing startup behavior remains unchanged: `loadRerankPolicySet` logs a warning and disables configured rerank policies for that process. No partial whitelist is accepted.
+
+## Verification
+
+Tests will cover:
+
+- decoding item boosts from YAML;
+- rejection of non-positive IDs, non-positive or non-finite weights, and duplicate IDs;
+- item whitelist score multiplication and stable reordering;
+- whitelist precedence over matching attribute boost rules;
+- unchanged attribute boost behavior for non-whitelisted items;
+- successful loading of `configs/sort/rerank.yaml` with an empty whitelist.
+
+Focused verification will run the rerank and rank package tests, the Sort service tests covering policy wiring, and the Sort service build.

--- a/docs/superpowers/specs/2026-08-26-item-id-whitelist-boost-design.md
+++ b/docs/superpowers/specs/2026-08-26-item-id-whitelist-boost-design.md
@@ -35,7 +35,7 @@ Each entry has two required fields:
 
 Duplicate `item_id` entries are invalid. Rejecting duplicates avoids implicit last-write-wins or accidental multiplicative behavior.
 
-The repository configuration will declare `item_boosts: []`. Production item IDs and weights remain operator-owned and are not invented by this change.
+The repository configuration omits `item_boosts`. Operators add the optional list only when production item IDs and weights are required.
 
 ## Runtime Behavior
 

--- a/rpc/sort/handler_test.go
+++ b/rpc/sort/handler_test.go
@@ -91,6 +91,42 @@ policies:
 	assert.False(t, staleSourceKept)
 }
 
+func TestApplyPostRankBoost_ItemWhitelistOverridesAttributeBoost(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rerank.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+policies:
+  - name: boost
+    item_boosts:
+      - item_id: 2
+        weight: 2
+    boost_rules:
+      - field: type
+        values: [supply]
+        weight: 3
+`), 0o644))
+
+	prev := itemRerankPolicies
+	itemRerankPolicies = loadRerankPolicySet(context.Background(), path, time.Now)
+	t.Cleanup(func() { itemRerankPolicies = prev })
+
+	ranked := []ranker.RankedItem{
+		{ItemID: 1, Score: 0.3},
+		{ItemID: 2, Score: 0.6},
+	}
+	itemMap := map[int64]sortDal.Item{
+		1: {ID: 1, Type: "supply"},
+		2: {ID: 2, Type: "supply"},
+	}
+
+	out := applyPostRankBoost(context.Background(), ranked, itemMap, nil)
+
+	require.Len(t, out, 2)
+	assert.Equal(t, int64(2), out[0].ItemID)
+	assert.InDelta(t, 1.2, out[0].Score, 1e-9)
+	assert.Equal(t, int64(1), out[1].ItemID)
+	assert.InDelta(t, 0.9, out[1].Score, 1e-9)
+}
+
 func TestLoadRerankPolicySet_BadConfigDisablesPolicies(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "rerank.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(`

--- a/rpc/sort/rerank/config.go
+++ b/rpc/sort/rerank/config.go
@@ -18,6 +18,7 @@ type PolicyConfig struct {
 	Name        string                    `yaml:"name"`
 	ItemRules   []ItemFreshnessRuleConfig `yaml:"item_rules"`
 	BoostRules  []BoostRuleConfig         `yaml:"boost_rules"`
+	ItemBoosts  []ItemBoostConfig         `yaml:"item_boosts"`
 	InjectRules []InjectRuleConfig        `yaml:"inject_rules"`
 	Source      string                    `yaml:"source"`
 	MaxFraction string                    `yaml:"max_fraction"`
@@ -48,6 +49,11 @@ type BoostRuleConfig struct {
 	Field  string   `yaml:"field"`
 	Values []string `yaml:"values"`
 	Weight float64  `yaml:"weight"`
+}
+
+type ItemBoostConfig struct {
+	ItemID int64   `yaml:"item_id"`
+	Weight float64 `yaml:"weight"`
 }
 
 // InjectRuleConfig declares a force-insertion rule: pull up to Count candidates
@@ -224,6 +230,11 @@ func (pc PolicyConfig) newFreshnessPolicy(now func() time.Time) (*FreshnessPolic
 }
 
 func (pc PolicyConfig) newBoostPolicy() (*BoostPolicy, error) {
+	itemWeights := make(map[int64]float64, len(pc.ItemBoosts))
+	for _, itemBoost := range pc.ItemBoosts {
+		itemWeights[itemBoost.ItemID] = itemBoost.Weight
+	}
+
 	rules := make([]BoostRule, 0, len(pc.BoostRules))
 	for _, rc := range pc.BoostRules {
 		if rc.Field != "type" && rc.Field != "source_type" && rc.Field != "content_class" {
@@ -241,7 +252,7 @@ func (pc PolicyConfig) newBoostPolicy() (*BoostPolicy, error) {
 			Weight: rc.Weight,
 		})
 	}
-	return &BoostPolicy{Rules: rules}, nil
+	return &BoostPolicy{Rules: rules, ItemWeights: itemWeights}, nil
 }
 
 func parseConfigDuration(s string) (time.Duration, error) {

--- a/rpc/sort/rerank/config.go
+++ b/rpc/sort/rerank/config.go
@@ -2,6 +2,7 @@ package rerank
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -232,6 +233,15 @@ func (pc PolicyConfig) newFreshnessPolicy(now func() time.Time) (*FreshnessPolic
 func (pc PolicyConfig) newBoostPolicy() (*BoostPolicy, error) {
 	itemWeights := make(map[int64]float64, len(pc.ItemBoosts))
 	for _, itemBoost := range pc.ItemBoosts {
+		if itemBoost.ItemID <= 0 {
+			return nil, fmt.Errorf("item boost has non-positive item_id %d", itemBoost.ItemID)
+		}
+		if itemBoost.Weight <= 0 || math.IsNaN(itemBoost.Weight) || math.IsInf(itemBoost.Weight, 0) {
+			return nil, fmt.Errorf("item boost for item_id %d has invalid weight %v", itemBoost.ItemID, itemBoost.Weight)
+		}
+		if _, exists := itemWeights[itemBoost.ItemID]; exists {
+			return nil, fmt.Errorf("item boost has duplicate item_id %d", itemBoost.ItemID)
+		}
 		itemWeights[itemBoost.ItemID] = itemBoost.Weight
 	}
 

--- a/rpc/sort/rerank/config_test.go
+++ b/rpc/sort/rerank/config_test.go
@@ -1,6 +1,7 @@
 package rerank
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,6 +97,53 @@ policies:
 	policy, ok := policies[0].(*BoostPolicy)
 	require.True(t, ok)
 	assert.Equal(t, map[int64]float64{123456: 2.0, 789012: 1.5}, policy.ItemWeights)
+}
+
+func TestLoadConfigRejectsInvalidItemBoosts(t *testing.T) {
+	tests := []struct {
+		name   string
+		boosts []ItemBoostConfig
+	}{
+		{
+			name:   "zero item ID",
+			boosts: []ItemBoostConfig{{ItemID: 0, Weight: 1.2}},
+		},
+		{
+			name:   "negative item ID",
+			boosts: []ItemBoostConfig{{ItemID: -1, Weight: 1.2}},
+		},
+		{
+			name:   "zero weight",
+			boosts: []ItemBoostConfig{{ItemID: 1, Weight: 0}},
+		},
+		{
+			name:   "negative weight",
+			boosts: []ItemBoostConfig{{ItemID: 1, Weight: -1}},
+		},
+		{
+			name:   "NaN weight",
+			boosts: []ItemBoostConfig{{ItemID: 1, Weight: math.NaN()}},
+		},
+		{
+			name:   "positive infinity weight",
+			boosts: []ItemBoostConfig{{ItemID: 1, Weight: math.Inf(1)}},
+		},
+		{
+			name: "duplicate item ID",
+			boosts: []ItemBoostConfig{
+				{ItemID: 1, Weight: 1.2},
+				{ItemID: 1, Weight: 1.3},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Policies: []PolicyConfig{{Name: "boost", ItemBoosts: tc.boosts}}}
+			_, err := cfg.NewPolicies(time.Now)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestLoadConfigParsesInjectRules(t *testing.T) {

--- a/rpc/sort/rerank/config_test.go
+++ b/rpc/sort/rerank/config_test.go
@@ -129,6 +129,10 @@ func TestLoadConfigRejectsInvalidItemBoosts(t *testing.T) {
 			boosts: []ItemBoostConfig{{ItemID: 1, Weight: math.Inf(1)}},
 		},
 		{
+			name:   "negative infinity weight",
+			boosts: []ItemBoostConfig{{ItemID: 1, Weight: math.Inf(-1)}},
+		},
+		{
 			name: "duplicate item ID",
 			boosts: []ItemBoostConfig{
 				{ItemID: 1, Weight: 1.2},

--- a/rpc/sort/rerank/config_test.go
+++ b/rpc/sort/rerank/config_test.go
@@ -74,6 +74,30 @@ policies:
 	assert.Equal(t, 1.2, policy.Rules[1].Weight)
 }
 
+func TestLoadConfigBuildsItemBoosts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rerank.yaml")
+	err := os.WriteFile(path, []byte(`
+policies:
+  - name: boost
+    item_boosts:
+      - item_id: 123456
+        weight: 2.0
+      - item_id: 789012
+        weight: 1.5
+`), 0o644)
+	require.NoError(t, err)
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	policies, err := cfg.NewPolicies(time.Now)
+	require.NoError(t, err)
+
+	require.Len(t, policies, 1)
+	policy, ok := policies[0].(*BoostPolicy)
+	require.True(t, ok)
+	assert.Equal(t, map[int64]float64{123456: 2.0, 789012: 1.5}, policy.ItemWeights)
+}
+
 func TestLoadConfigParsesInjectRules(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "rerank.yaml")
 	err := os.WriteFile(path, []byte(`

--- a/rpc/sort/rerank/policy_boost.go
+++ b/rpc/sort/rerank/policy_boost.go
@@ -22,7 +22,8 @@ type BoostRule struct {
 // The returned slice is re-sorted by descending score so callers can read the
 // new display order directly.
 type BoostPolicy struct {
-	Rules []BoostRule
+	Rules       []BoostRule
+	ItemWeights map[int64]float64
 }
 
 func (p *BoostPolicy) Name() string { return "boost" }

--- a/rpc/sort/rerank/policy_boost.go
+++ b/rpc/sort/rerank/policy_boost.go
@@ -1,9 +1,9 @@
 package rerank
 
 import (
-	"sort"
-
 	"eigenflux_server/rpc/sort/rank"
+	"sort"
+	"strconv"
 )
 
 // BoostRule multiplies the score of an item candidate whose Field value is in
@@ -29,7 +29,7 @@ type BoostPolicy struct {
 func (p *BoostPolicy) Name() string { return "boost" }
 
 func (p *BoostPolicy) Apply(cands []rank.Candidate) []rank.Candidate {
-	if len(cands) == 0 || len(p.Rules) == 0 {
+	if len(cands) == 0 || (len(p.Rules) == 0 && len(p.ItemWeights) == 0) {
 		return cands
 	}
 
@@ -39,6 +39,11 @@ func (p *BoostPolicy) Apply(cands []rank.Candidate) []rank.Candidate {
 		}
 		bc, ok := c.(*rank.BasicCandidate)
 		if !ok {
+			continue
+		}
+		if weight, ok := p.ItemWeights[c.ID()]; ok {
+			bc.SetScore(bc.Score() * weight)
+			bc.AddReason("boost:item_id=" + strconv.FormatInt(c.ID(), 10))
 			continue
 		}
 		fields, ok := itemBoostFields(bc.Source())

--- a/rpc/sort/rerank/policy_boost_test.go
+++ b/rpc/sort/rerank/policy_boost_test.go
@@ -42,6 +42,37 @@ func TestBoostPolicy_MultipliesAndResorts(t *testing.T) {
 	assert.Contains(t, supply.Reasons(), "boost:type=supply")
 }
 
+func TestBoostPolicy_ItemWhitelistMultipliesAndResorts(t *testing.T) {
+	cold := rank.NewCandidate(1, rank.CandidateItem, 1.0, nil, nil)
+	whitelisted := rank.NewCandidate(2, rank.CandidateItem, 0.6, nil, nil)
+
+	policy := &BoostPolicy{ItemWeights: map[int64]float64{2: 2}}
+	out := policy.Apply([]rank.Candidate{cold, whitelisted})
+
+	require.Len(t, out, 2)
+	assert.Equal(t, int64(2), out[0].ID())
+	assert.InDelta(t, 1.2, out[0].Score(), 1e-9)
+	assert.Equal(t, []string{"boost:item_id=2"}, whitelisted.Reasons())
+	assert.Equal(t, int64(1), out[1].ID())
+	assert.InDelta(t, 1.0, out[1].Score(), 1e-9)
+}
+
+func TestBoostPolicy_ItemWhitelistOverridesAttributeRules(t *testing.T) {
+	c := boostCand(7, 1.0, "supply", "ugc")
+	policy := &BoostPolicy{
+		ItemWeights: map[int64]float64{7: 2},
+		Rules: []BoostRule{
+			{Field: "type", Values: []string{"supply"}, Weight: 3},
+			{Field: "content_class", Values: []string{"ugc"}, Weight: 4},
+		},
+	}
+
+	policy.Apply([]rank.Candidate{c})
+
+	assert.InDelta(t, 2.0, c.Score(), 1e-9)
+	assert.Equal(t, []string{"boost:item_id=7"}, c.Reasons())
+}
+
 func TestBoostPolicy_RulesCompound(t *testing.T) {
 	// A UGC demand item matches both rules: ×1.3 ×1.2 = ×1.56.
 	c := boostCand(1, 1.0, "demand", "ugc")


### PR DESCRIPTION
## Summary
- add optional item-ID whitelist multipliers to the existing rerank boost policy
- make whitelist matches override all attribute boost rules and re-sort by final score
- validate positive unique IDs and positive finite weights
- omit `item_boosts` from the repository YAML; operators add it only when needed

## Verification
- `bash scripts/common/build.sh`
- `go test -count=1 ./rpc/sort/rank/... ./rpc/sort/rerank/... ./rpc/sort`
- `./tests/run.sh --skip-start sort`
- Sort startup with repository YAML omitted `item_boosts`: rerank config loaded successfully

## Scope
Boost-only branch based on latest `origin/main`; no commission changes.