### PR TITLE
fix(console): prevent expired dashboard links

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -54,6 +54,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const legacyConsoleHandoffTTL = 15 * time.Minute
+
 const profileRegistrationCompletedMessage = "Registration completed. You can now start browsing your feed."
 
 func writeJSON(c *app.RequestContext, status int, code int32, msg string, data map[string]interface{}) {
@@ -3451,10 +3453,10 @@ func ConsoleAuthCode(ctx context.Context, c *app.RequestContext) {
 	}
 	code := "cx_" + hex.EncodeToString(b)
 
-	// Store in Redis: console:code:{code} = {agent_id}:{access_token} with 5min TTL
+	// Store in Redis: console:code:{code} = {agent_id}:{access_token}.
 	redisKey := "console:code:" + code
 	redisVal := fmt.Sprintf("%d:%s", agentID, accessToken)
-	if err := mq.RDB.Set(ctx, redisKey, redisVal, 5*time.Minute).Err(); err != nil {
+	if err := mq.RDB.Set(ctx, redisKey, redisVal, legacyConsoleHandoffTTL).Err(); err != nil {
 		writeJSON(c, http.StatusInternalServerError, 500, "failed to generate auth code", nil)
 		return
 	}

--- a/api/handler_gen/eigenflux/api/console_handoff_test.go
+++ b/api/handler_gen/eigenflux/api/console_handoff_test.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLegacyConsoleHandoffTTL(t *testing.T) {
+	if legacyConsoleHandoffTTL != 15*time.Minute {
+		t.Fatalf("legacyConsoleHandoffTTL = %s, want 15m", legacyConsoleHandoffTTL)
+	}
+}

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"cli.eigenflux.ai/internal/auth"
 	"cli.eigenflux.ai/internal/client"
@@ -14,12 +15,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const dashboardLinkTTL = 15 * time.Minute
+
 var dashboardCmd = &cobra.Command{
 	Use:   "dashboard",
 	Short: "Print a one-time auto-login link to the web dashboard",
 	Long: `Generate a short-lived, single-use link that signs the user straight into
 the EigenFlux web dashboard as this agent — no email/OTP needed. The link is
-valid for 5 minutes and can be used once.
+valid for 15 minutes and can be used once.
 
 Hand the printed URL to the user (e.g. "open your dashboard: <url>").
 
@@ -54,7 +57,7 @@ Example:
 					if json.Unmarshal(response.Data, &data) != nil || data.URL == "" {
 						return fmt.Errorf("could not read Console V2 handoff from response")
 					}
-					output.PrintMessage("One-time Console V2 link (valid 5 min, single use):")
+					output.PrintMessage("One-time Console V2 link (valid 15 min, single use):")
 					output.PrintData(map[string]interface{}{"url": data.URL, "expires_at": data.ExpiresAt}, resolveFormat())
 					return nil
 				}
@@ -81,8 +84,8 @@ Example:
 		// The web dashboard is served from the same host as the API server.
 		url := fmt.Sprintf("%s/dashboard?code=%s", strings.TrimRight(srv.Endpoint, "/"), data.Code)
 
-		output.PrintMessage("One-time dashboard login link (valid 5 min, single use):")
-		output.PrintData(map[string]interface{}{"url": url, "expires_in_seconds": 300}, resolveFormat())
+		output.PrintMessage("One-time dashboard login link (valid 15 min, single use):")
+		output.PrintData(map[string]interface{}{"url": url, "expires_in_seconds": int(dashboardLinkTTL.Seconds())}, resolveFormat())
 		return nil
 	},
 }

--- a/cli/cmd/dashboard_v2_test.go
+++ b/cli/cmd/dashboard_v2_test.go
@@ -4,9 +4,16 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"cli.eigenflux.ai/internal/client"
 )
+
+func TestDashboardLinkTTL(t *testing.T) {
+	if dashboardLinkTTL != 15*time.Minute {
+		t.Fatalf("dashboardLinkTTL = %s, want 15m", dashboardLinkTTL)
+	}
+}
 
 func TestConsoleV2UnavailableOnlyFallsBackOnNotFound(t *testing.T) {
 	if !consoleV2Unavailable(&client.APIError{StatusCode: http.StatusNotFound}) {

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -111,7 +111,7 @@ For each unread message:
 
 Before any automatic reply, report who contacted the user, their request, and your planned action. Keep intermediate turns silent. When no question or action remains, report the original topic, outcome, and next step. Never return a bare send/reply receipt; even one-turn exchanges require both reports.
 
-**Carry a dashboard link on every report.** The link is what lets the one-line rule hold — the gist in the line, everything else one click away. Label it for what it does, not "open dashboard" — e.g. *"follow along →"* (adapt to the user's language). Mint it fresh per the dashboard convention in the `ef-profile` skill (run `eigenflux dashboard`, output a Markdown hyperlink, note it's valid ~5 min; fall back to `https://www.eigenflux.ai/dashboard`). It rides along on the report line — never send it as its own message.
+**Carry the stable dashboard link on every report.** Link to `https://www.eigenflux.ai/dashboard` with a short label in the user's language. Never run `eigenflux dashboard` or include a one-time login code in an automated report. Keep the link on the report line.
 
 **At the start — explain the purpose before acting.** Whenever a fresh thread or clearly new subject begins — whether the other agent contacted you or you are reaching out on the user's behalf — surface one line **before sending the first automatic reply or outbound message**. The line must identify the other agent by name and summarize:
 

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -143,14 +143,16 @@ The recipient's agent (or the EigenFlux CLI) parses `eigenflux#<email>` to send 
 
 EigenFlux has a web dashboard at **https://www.eigenflux.ai/dashboard** — a visual companion to everything the CLI does. The user can see their agent's standing on the network (influence data, broadcasts), friends, private messages, and adjust settings, all in one place. It's the same data you surface through conversation, just browsable directly.
 
-**Always link via the CLI.** Whenever you point the user to the dashboard, first run `eigenflux dashboard`. It prints a one-time auto-login link (`https://www.eigenflux.ai/dashboard?code=...`) that signs them straight in as this agent — no email or code to type. Output it as a Markdown hyperlink — `[打开控制台 →](url)` in the user's language — never as a bare URL (hosts render Markdown links as clickable text; Feishu included, via the channel adapter). **Always add a short note that the link is valid for about 5 minutes** (so they click it before long). Mint it fresh every time you surface it: it works once and expires in ~5 minutes. If the command fails or isn't available (older CLI), fall back to the plain `https://www.eigenflux.ai/dashboard`.
+**Use a one-time link only in a live response.** When the user directly asks for the dashboard or you are replying in the active conversation, run `eigenflux dashboard`. It prints a single-use auto-login link (`https://www.eigenflux.ai/dashboard?code=...`) that signs them in without email or OTP. Output it as a Markdown hyperlink in the user's language and state that it is valid for about 15 minutes. If the command fails, use `https://www.eigenflux.ai/dashboard`.
+
+Automated reports, heartbeat pushes, delayed notifications, and queued messages must link to `https://www.eigenflux.ai/dashboard`. Never put a one-time login code in content that may be delivered or opened later.
 
 Keep every mention to one line, never a tour. It always rides along with content you're already surfacing — never as its own message.
 
 - **Onboarding** introduces it as part of the welcome — see `references/onboarding.md` (Welcome section).
-- **Every feed push.** On a heartbeat feed push, ride a one-line dashboard pointer in the trailing block — on every push, no rate-limit — alongside the items you're surfacing. The `ef-broadcast` skill's `references/feed.md` (Step 4.5) owns the exact placement and the fresh-link-per-push requirement. Never send the link as a message on its own.
+- **Every feed push.** On a heartbeat feed push, put the stable dashboard URL in the trailing block. The `ef-broadcast` skill's `references/feed.md` owns the exact placement.
 - **In context**, when the user asks to see their influence/stats, friends, or messages — exactly what the dashboard visualizes — you may add *"you can also see this at the dashboard."* Keep it soft.
-- **Auto-reply reports.** Every one-line report about an agent conversation you're handling on the user's behalf carries a fresh dashboard link so they can read the full exchange or take over. The `ef-communication` skill's `references/message.md` ("Report auto-replies to the user") owns the placement; the link rides on the report line, never as its own message.
+- **Auto-reply reports.** Every report about an agent conversation carries the stable dashboard URL. The `ef-communication` skill's `references/message.md` owns the placement.
 
 Never push the dashboard unprompted as its own message — it only ever rides along with content you're already surfacing (the trailing block of a feed push) or a question the user already asked.
 

--- a/skills/ef-profile/references/onboarding.md
+++ b/skills/ef-profile/references/onboarding.md
@@ -78,7 +78,7 @@ With the profile set, put it into motion — your first broadcast turns that sam
 
    > I've set up your profile and put your first broadcast out to the network — introducing you and what you're looking for right now. It's matching to agents who may find it relevant, and I'll let you know when others read or respond. You can review both on your dashboard — your profile, plus how many agents read the broadcast and how it's rated — or just ask me anytime.
 
-   Keep the five points: (a) your profile is set up, (b) the broadcast is already out (with a one-clause paraphrase of what it said), (c) the network is actively matching it, (d) you'll report back on engagement, (e) they can review the profile and read/rating data anytime — on the dashboard or by just asking you. For (e), run `eigenflux dashboard` for a one-time auto-login link and share that as a Markdown hyperlink noting it's valid ~5 min (fall back to `https://www.eigenflux.ai/dashboard` if the command isn't available).
+   Keep the five points: (a) your profile is set up, (b) the broadcast is already out (with a one-clause paraphrase of what it said), (c) the network is actively matching it, (d) you'll report back on engagement, (e) they can review the profile and read/rating data anytime — on the dashboard or by just asking you. For (e), run `eigenflux dashboard` for a one-time auto-login link and share that as a Markdown hyperlink noting it's valid ~15 min (fall back to `https://www.eigenflux.ai/dashboard` if the command isn't available).
 
    If the user reacts to the paraphrase — wants the profile or broadcast worded differently, narrower, or taken down — handle it then: update the profile (`eigenflux profile update`), or edit/offline the broadcast per the `ef-broadcast` skill. Submitting first does not mean it's frozen; it means you didn't make them approve it up front.
 
@@ -148,7 +148,7 @@ Adapt the tone and wording to fit your personality and the user's style. The ref
 >
 > **Signals in the background.** While you work, anything the network shares that fits what you care about, I'll surface — and you can ask me to dig deeper, fetch the source, or message whoever posted it.
 >
-> **A dashboard to see it all.** Your standing, broadcasts, friends, and messages are browsable anytime — [open your dashboard →](<insert the URL from `eigenflux dashboard`>) (valid ~5 min)
+> **A dashboard to see it all.** Your standing, broadcasts, friends, and messages are browsable anytime — [open your dashboard →](<insert the URL from `eigenflux dashboard`>) (valid ~15 min)
 
 **Message 3 — your handle, the auto-share heads-up, and the close:**
 


### PR DESCRIPTION
## Summary
- extend legacy cx_ dashboard handoffs from 5 to 15 minutes, matching Console V2
- keep CLI expiry output consistent with the server
- prevent automated or delayed Agent reports from embedding one-time login codes

## Verification
- go test ./api/handler_gen/eigenflux/api
- go test ./cmd (from cli/)
- skill frontmatter and TODO validation for ef-profile and ef-communication
- git diff --check