### PR TITLE
Expose PGC strong-feedback trend

### DIFF
--- a/docs/dev/infra.md
+++ b/docs/dev/infra.md
@@ -102,6 +102,9 @@ purpose-built `grafana_*` security-barrier views that expose fixed anonymous
 aggregates. The production Grafana role receives `SELECT` on those views only;
 adding a dashboard query is not a reason to broaden its table grants. Migration
 `000075_pgc_audience_aggregate_views.sql` defines the PGC audience, demand,
-feedback, surface, and profile-completeness contract.
+feedback, surface, and profile-completeness contract. Migration
+`000082_pgc_strong_feedback_trend.sql` adds the event-time daily score=2 trend;
+it exposes only 90 aggregate rows and never grants Grafana access to an
+individual feedback event.
 
 When the app server and monitor server are separate hosts, ensure the app server's firewall allows inbound on the metrics ports listed above from the monitor server, and set `MONITOR_ENABLED=true` in the app server's `.env` to enable distributed tracing alongside metrics. Cross-host bindings and deployment are documented in the observability repository.

--- a/migrations/000082_pgc_strong_feedback_trend.sql
+++ b/migrations/000082_pgc_strong_feedback_trend.sql
@@ -1,0 +1,84 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- The owner dashboard needs the time at which feedback happened, not the
+-- publication date of the scored item. Keep that event-level data private and
+-- expose only one anonymous daily aggregate for PGC-authored content.
+CREATE VIEW grafana_pgc_strong_feedback_daily
+WITH (security_barrier = true) AS
+WITH bounds AS (
+    SELECT
+        (now() AT TIME ZONE 'Asia/Shanghai')::date AS today,
+        ((extract(epoch FROM now()) * 1000)::BIGINT - 7862400000) AS since_ms
+), calendar AS (
+    SELECT generate_series(today - 89, today, interval '1 day')::date AS day
+    FROM bounds
+), feedback AS MATERIALIZED (
+    SELECT
+        (to_timestamp(f.feedback_at / 1000.0)
+            AT TIME ZONE 'Asia/Shanghai')::date AS day,
+        f.agent_id,
+        f.score
+    FROM feedback_logs f
+    JOIN agents consumer ON consumer.agent_id = f.agent_id
+    JOIN raw_items i USING (item_id)
+    JOIN agents author ON author.agent_id = i.author_agent_id,
+         bounds
+    WHERE f.feedback_at >= bounds.since_ms
+      AND lower(author.email) LIKE '%@pgc.eigenflux.one'
+      AND lower(consumer.email) NOT LIKE '%bot.eigenflux%'
+      AND lower(consumer.email) NOT LIKE '%pgc.eigenflux%'
+), daily AS (
+    SELECT
+        day,
+        count(*) AS feedback_events,
+        count(*) FILTER (WHERE score = 2) AS strong_positive_events,
+        count(DISTINCT agent_id) AS feedback_agents
+    FROM feedback
+    GROUP BY day
+)
+SELECT
+    c.day,
+    COALESCE(d.feedback_events, 0) AS feedback_events,
+    COALESCE(d.strong_positive_events, 0) AS strong_positive_events,
+    COALESCE(d.feedback_agents, 0) AS feedback_agents,
+    round(
+        100.0 * COALESCE(d.strong_positive_events, 0)
+            / NULLIF(d.feedback_events, 0),
+        1
+    ) AS strong_positive_rate
+FROM calendar c
+LEFT JOIN daily d USING (day)
+ORDER BY c.day;
+
+REVOKE ALL ON grafana_pgc_strong_feedback_daily FROM PUBLIC;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        GRANT SELECT ON grafana_pgc_strong_feedback_daily TO grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+COMMENT ON VIEW grafana_pgc_strong_feedback_daily IS
+    'Anonymous daily PGC score=2 feedback totals for the owner dashboard. '
+    'Days use Asia/Shanghai event time; user-level feedback remains private.';
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        REVOKE SELECT ON grafana_pgc_strong_feedback_daily FROM grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+DROP VIEW IF EXISTS grafana_pgc_strong_feedback_daily;

--- a/tests/schema/pgc_strong_feedback_trend_view_contract_test.go
+++ b/tests/schema/pgc_strong_feedback_trend_view_contract_test.go
@@ -1,0 +1,41 @@
+package schema_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPGCStrongFeedbackTrendKeepsEventRowsPrivate(t *testing.T) {
+	const migration = "../../migrations/000082_pgc_strong_feedback_trend.sql"
+	contents, err := os.ReadFile(migration)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	sql := string(contents)
+
+	for _, required := range []string{
+		"CREATE VIEW grafana_pgc_strong_feedback_daily\nWITH (security_barrier = true)",
+		"AT TIME ZONE 'Asia/Shanghai'",
+		"count(*) FILTER (WHERE score = 2) AS strong_positive_events",
+		"count(DISTINCT agent_id) AS feedback_agents",
+		"REVOKE ALL ON grafana_pgc_strong_feedback_daily FROM PUBLIC",
+		"GRANT SELECT ON grafana_pgc_strong_feedback_daily TO grafana_ro_v2",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Errorf("missing privacy/trend contract: %s", required)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"GRANT SELECT ON feedback_logs",
+		"GRANT SELECT ON raw_items",
+		"GRANT SELECT ON agents",
+		"agent_id AS",
+		"item_id AS",
+	} {
+		if strings.Contains(sql, forbidden) {
+			t.Errorf("migration exposes user-level data: %s", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a privacy-safe daily aggregate of PGC score=2 feedback by feedback event time
- retain 90 daily rows and keep user-level feedback private
- add schema contract coverage and document the Grafana boundary

## Validation
- `go test ./tests/schema/...`
- `go test ./migrations` (included in partial repository run)
- Goose validates all SQL migrations from a SQL-only temporary directory
- exact aggregate query reconciled against production read-only data

## Notes
The full `go test ./...` run reached unrelated integration packages that require local PostgreSQL, Redis, and API services; those failed/blocked because this host has no local stack. No runtime Go code changes are included.