### PR TITLE
feat(console-v2): connect trade and earnings BFF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -309,3 +309,7 @@ GOOGLE_ADS_API_VERSION=v22
 GOOGLE_ADS_OAUTH_REDIRECT_URI=https://www.eigenflux.ai/api/v1/install/google-ads/oauth/callback
 # Random admin-only value required as Bearer auth to start one-time OAuth authorization.
 GOOGLE_ADS_OAUTH_ADMIN_TOKEN=
+# Commission Console BFF. Private key is base64url Ed25519 seed/private key.
+COMMISSION_ENDPOINT=http://127.0.0.1:8090
+COMMISSION_DELEGATION_KEY_ID=
+COMMISSION_DELEGATION_PRIVATE_KEY=

--- a/api/main.go
+++ b/api/main.go
@@ -270,7 +270,7 @@ func main() {
 
 	if consoleV2Service != nil {
 		consoleV2Service.Register(h)
-		registerConsoleV2BusinessBFF(h, consoleV2Service)
+		registerConsoleV2BusinessBFF(h, consoleV2Service, cfg)
 		log.Print("Console V2 routes registered")
 	}
 
@@ -282,8 +282,16 @@ func main() {
 	h.Spin()
 }
 
-func registerConsoleV2BusinessBFF(h *server.Hertz, service *consolev2.Service) {
-	trade := tradebff.New()
+func registerConsoleV2BusinessBFF(h *server.Hertz, service *consolev2.Service, cfg *config.Config) {
+	trade, err := tradebff.New(tradebff.Config{
+		Endpoint:             cfg.CommissionAPIEndpoint,
+		DelegationKeyID:      cfg.CommissionDelegateKID,
+		DelegationPrivateKey: cfg.CommissionDelegatePrivate,
+	})
+	if err != nil {
+		log.Printf("Commission BFF disabled: %v", err)
+		trade = tradebff.NewUnavailable("")
+	}
 	read := func(path string, handler app.HandlerFunc) {
 		h.GET("/api/v2/console/bff/"+path, service.ConsoleBFFHandlers(false, handler)...)
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -32,6 +32,7 @@ import (
 	"eigenflux_server/api/install"
 	"eigenflux_server/api/middleware"
 	router_gen "eigenflux_server/api/router_gen"
+	"eigenflux_server/api/tradebff"
 	"eigenflux_server/kitex_gen/eigenflux/auth/authservice"
 	"eigenflux_server/kitex_gen/eigenflux/feed/feedservice"
 	"eigenflux_server/kitex_gen/eigenflux/item/itemservice"
@@ -282,6 +283,7 @@ func main() {
 }
 
 func registerConsoleV2BusinessBFF(h *server.Hertz, service *consolev2.Service) {
+	trade := tradebff.New()
 	read := func(path string, handler app.HandlerFunc) {
 		h.GET("/api/v2/console/bff/"+path, service.ConsoleBFFHandlers(false, handler)...)
 	}
@@ -325,6 +327,17 @@ func registerConsoleV2BusinessBFF(h *server.Hertz, service *consolev2.Service) {
 	write(http.MethodPost, "pm/send", apihandler.SendPM)
 	write(http.MethodPost, "pm/read", apihandler.MarkConvRead)
 	read("items/:item_id", apihandler.GetItem)
+
+	read("trade/overview", trade.TradeOverview)
+	read("trade/commissions", trade.TradeCommissions)
+	read("trade/orders", trade.TradeOrders)
+	read("trade/orders/:order_id", trade.TradeOrder)
+	read("earnings/summary", trade.EarningsSummary)
+	read("earnings/records", trade.EarningsRecords)
+	read("payout-method", trade.PayoutMethod)
+	write(http.MethodPost, "payout-method/authorization", trade.MutatePayoutMethod)
+	write(http.MethodPost, "withdrawals", trade.CreateWithdrawal)
+	read("withdrawals/:withdrawal_id", trade.Withdrawal)
 }
 
 func splitEtcdEndpoints(raw string) []string {

--- a/api/tradebff/client.go
+++ b/api/tradebff/client.go
@@ -1,0 +1,110 @@
+package tradebff
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type CommissionClient struct {
+	baseURL *url.URL
+	http    *http.Client
+}
+
+type commissionEnvelope struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data json.RawMessage `json:"data"`
+}
+
+type UpstreamError struct {
+	Status int
+	Code   int
+	Msg    string
+}
+
+func (e *UpstreamError) Error() string { return "Commission request failed" }
+
+func NewCommissionClient(endpoint string) (*CommissionClient, error) {
+	baseURL, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil || baseURL.Host == "" || (baseURL.Scheme != "https" && !(baseURL.Scheme == "http" && localHost(baseURL.Hostname()))) {
+		return nil, fmt.Errorf("invalid Commission endpoint")
+	}
+	baseURL.Path = strings.TrimRight(baseURL.Path, "/")
+	return &CommissionClient{baseURL: baseURL, http: &http.Client{
+		Timeout:       5 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}}, nil
+}
+
+func (c *CommissionClient) Do(ctx context.Context, token, method, path string, query url.Values, body []byte, idempotencyKey string) (json.RawMessage, error) {
+	if c == nil || token == "" || !strings.HasPrefix(path, "/") {
+		return nil, fmt.Errorf("invalid Commission request")
+	}
+	target := *c.baseURL
+	target.Path = strings.TrimRight(c.baseURL.Path, "/") + path
+	target.RawQuery = query.Encode()
+	request, err := http.NewRequestWithContext(ctx, method, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create Commission request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Accept", "application/json")
+	if len(body) > 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if key := strings.TrimSpace(idempotencyKey); key != "" {
+		request.Header.Set("Idempotency-Key", key)
+	}
+	response, err := c.http.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("call Commission: %w", err)
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(response.Body, 2<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read Commission response: %w", err)
+	}
+	var envelope commissionEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, fmt.Errorf("decode Commission response: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 || envelope.Code != 0 {
+		status := response.StatusCode
+		if status < 400 || status > 599 {
+			status = http.StatusBadGateway
+		}
+		return nil, &UpstreamError{Status: status, Code: envelope.Code, Msg: envelope.Msg}
+	}
+	if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
+		return json.RawMessage(`{}`), nil
+	}
+	return envelope.Data, nil
+}
+
+func localHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func upstreamStatus(err error) int {
+	var upstream *UpstreamError
+	if errors.As(err, &upstream) {
+		switch upstream.Status {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusConflict, http.StatusTooManyRequests:
+			return upstream.Status
+		}
+	}
+	return http.StatusServiceUnavailable
+}

--- a/api/tradebff/delegation.go
+++ b/api/tradebff/delegation.go
@@ -1,0 +1,127 @@
+package tradebff
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	delegationPrefix   = "efd1_"
+	delegationDomain   = "eigenflux-console-delegation:v1"
+	delegationIssuer   = "eigenflux-api"
+	delegationAudience = "eigenflux-commission"
+)
+
+type DelegationRequest struct {
+	AgentID        int64
+	Scope          string
+	Method         string
+	Operation      string
+	Body           []byte
+	IdempotencyKey string
+	BindMutation   bool
+}
+
+type delegationClaims struct {
+	Version              int    `json:"ver"`
+	Issuer               string `json:"iss"`
+	Audience             string `json:"aud"`
+	Subject              string `json:"sub"`
+	Scope                string `json:"scope"`
+	IssuedAt             int64  `json:"iat"`
+	ExpiresAt            int64  `json:"exp"`
+	TokenID              string `json:"jti"`
+	Method               string `json:"method"`
+	Operation            string `json:"operation"`
+	BodySHA256           string `json:"body_sha256,omitempty"`
+	IdempotencyKeySHA256 string `json:"idempotency_key_sha256,omitempty"`
+}
+
+type Delegator struct {
+	kid        string
+	privateKey ed25519.PrivateKey
+	now        func() time.Time
+	random     io.Reader
+}
+
+func NewDelegator(kid, encodedPrivateKey string) (*Delegator, error) {
+	kid = strings.TrimSpace(kid)
+	if !validDelegationKeyID(kid) {
+		return nil, fmt.Errorf("invalid Commission delegation key id")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(encodedPrivateKey))
+	if err != nil {
+		return nil, fmt.Errorf("decode Commission delegation private key")
+	}
+	var privateKey ed25519.PrivateKey
+	switch len(decoded) {
+	case ed25519.SeedSize:
+		privateKey = ed25519.NewKeyFromSeed(decoded)
+	case ed25519.PrivateKeySize:
+		privateKey = ed25519.PrivateKey(decoded)
+	default:
+		return nil, fmt.Errorf("invalid Commission delegation private key length")
+	}
+	return &Delegator{kid: kid, privateKey: privateKey, now: time.Now, random: rand.Reader}, nil
+}
+
+func (d *Delegator) Token(request DelegationRequest) (string, error) {
+	if d == nil || request.AgentID <= 0 || request.Scope == "" || request.Operation == "" || request.Method == "" {
+		return "", fmt.Errorf("invalid Commission delegation request")
+	}
+	if request.BindMutation && strings.TrimSpace(request.IdempotencyKey) == "" {
+		return "", fmt.Errorf("idempotency key is required")
+	}
+	var random [16]byte
+	if _, err := io.ReadFull(d.random, random[:]); err != nil {
+		return "", fmt.Errorf("create delegation token id: %w", err)
+	}
+	now := d.now().UTC()
+	claims := delegationClaims{
+		Version: 1, Issuer: delegationIssuer, Audience: delegationAudience,
+		Subject: strconv.FormatInt(request.AgentID, 10), Scope: request.Scope,
+		IssuedAt: now.Unix(), ExpiresAt: now.Add(30 * time.Second).Unix(),
+		TokenID: hex.EncodeToString(random[:]), Method: strings.ToUpper(request.Method), Operation: request.Operation,
+	}
+	if request.BindMutation {
+		claims.BodySHA256 = delegationDigest(request.Body)
+		claims.IdempotencyKeySHA256 = delegationDigest([]byte(strings.TrimSpace(request.IdempotencyKey)))
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal delegation claims: %w", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	signature := ed25519.Sign(d.privateKey, delegationTranscript(d.kid, encoded))
+	return delegationPrefix + d.kid + "." + encoded + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func delegationTranscript(kid, payload string) []byte {
+	return []byte(delegationDomain + "\n" + kid + "\n" + payload)
+}
+
+func delegationDigest(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}
+
+func validDelegationKeyID(value string) bool {
+	if value == "" || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return false
+		}
+	}
+	return true
+}

--- a/api/tradebff/delegation_test.go
+++ b/api/tradebff/delegation_test.go
@@ -1,0 +1,31 @@
+package tradebff
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestDelegationGoldenVector(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	for index := range seed {
+		seed[index] = byte(index)
+	}
+	delegator, err := NewDelegator("test-2026", base64.RawURLEncoding.EncodeToString(seed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delegator.now = func() time.Time { return time.Unix(1_800_000_000, 0) }
+	delegator.random = bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
+	token, err := delegator.Token(DelegationRequest{AgentID: 42, Scope: "wallet:read", Method: http.MethodGet, Operation: "wallet.balance.read"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expected = "efd1_test-2026.eyJ2ZXIiOjEsImlzcyI6ImVpZ2VuZmx1eC1hcGkiLCJhdWQiOiJlaWdlbmZsdXgtY29tbWlzc2lvbiIsInN1YiI6IjQyIiwic2NvcGUiOiJ3YWxsZXQ6cmVhZCIsImlhdCI6MTgwMDAwMDAwMCwiZXhwIjoxODAwMDAwMDMwLCJqdGkiOiIwMDAxMDIwMzA0MDUwNjA3MDgwOTBhMGIwYzBkMGUwZiIsIm1ldGhvZCI6IkdFVCIsIm9wZXJhdGlvbiI6IndhbGxldC5iYWxhbmNlLnJlYWQifQ.u6kMcXsVSO_SlRUOitPDYgsot5_tkLB0uWNuQcE-I8zCb2WIhHXA1y-Gm0NNUjBKsap-YO5XLHR6zyuf3yf7AA"
+	if token != expected {
+		t.Fatalf("token contract drifted:\n%s", token)
+	}
+}

--- a/api/tradebff/handlers.go
+++ b/api/tradebff/handlers.go
@@ -1,0 +1,113 @@
+package tradebff
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+const unavailableReason = "Commission 尚未提供 Console V2 会话到资金账户的可信身份委托契约"
+
+type Service struct{}
+
+func New() *Service { return &Service{} }
+
+func agentID(c *app.RequestContext) (int64, bool) {
+	value, exists := c.Get("agent_id")
+	identifier, ok := value.(int64)
+	return identifier, exists && ok && identifier > 0
+}
+
+func reply(c *app.RequestContext, status int, data interface{}) {
+	c.Header("Cache-Control", "private, no-store")
+	c.JSON(status, map[string]interface{}{"data": data})
+}
+
+func unavailable(c *app.RequestContext, capability string) {
+	c.Header("Cache-Control", "private, no-store")
+	c.JSON(http.StatusServiceUnavailable, map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "COMMISSION_IDENTITY_DELEGATION_REQUIRED",
+			"message": unavailableReason,
+			"details": map[string]interface{}{"capability": capability},
+		},
+	})
+}
+
+func base() map[string]interface{} {
+	return map[string]interface{}{
+		"available":          false,
+		"unavailable_reason": unavailableReason,
+		"todo_code":          "COMMISSION_IDENTITY_DELEGATION_REQUIRED",
+	}
+}
+
+func (s *Service) TradeOverview(_ context.Context, c *app.RequestContext) {
+	_, ok := agentID(c)
+	if !ok {
+		unavailable(c, "trade.overview")
+		return
+	}
+	data := base()
+	data["capabilities_count"] = nil
+	data["accepted_orders_count"] = nil
+	data["outgoing_orders_count"] = nil
+	data["total_fen"] = nil
+	data["withdrawable_fen"] = nil
+	reply(c, http.StatusOK, data)
+}
+
+func (s *Service) TradeCommissions(_ context.Context, c *app.RequestContext) {
+	data := base()
+	data["items"] = []interface{}{}
+	data["next_cursor"] = ""
+	reply(c, http.StatusOK, data)
+}
+
+func (s *Service) TradeOrders(_ context.Context, c *app.RequestContext) {
+	data := base()
+	data["role"] = string(c.Query("role"))
+	data["items"] = []interface{}{}
+	data["next_cursor"] = ""
+	reply(c, http.StatusOK, data)
+}
+
+func (s *Service) TradeOrder(_ context.Context, c *app.RequestContext) {
+	unavailable(c, "trade.order_detail")
+}
+
+func (s *Service) EarningsSummary(_ context.Context, c *app.RequestContext) {
+	data := base()
+	data["total_fen"] = nil
+	data["unmatured_fen"] = nil
+	data["reserved_fen"] = nil
+	data["withdrawn_fen"] = nil
+	data["withdrawable_fen"] = nil
+	reply(c, http.StatusOK, data)
+}
+
+func (s *Service) EarningsRecords(_ context.Context, c *app.RequestContext) {
+	data := base()
+	data["items"] = []interface{}{}
+	data["next_cursor"] = ""
+	reply(c, http.StatusOK, data)
+}
+
+func (s *Service) PayoutMethod(_ context.Context, c *app.RequestContext) {
+	data := base()
+	data["method"] = nil
+	reply(c, http.StatusOK, data)
+}
+
+func (s *Service) MutatePayoutMethod(_ context.Context, c *app.RequestContext) {
+	unavailable(c, "payout_method.bind")
+}
+
+func (s *Service) CreateWithdrawal(_ context.Context, c *app.RequestContext) {
+	unavailable(c, "withdrawal.create")
+}
+
+func (s *Service) Withdrawal(_ context.Context, c *app.RequestContext) {
+	unavailable(c, "withdrawal.detail")
+}

--- a/api/tradebff/handlers.go
+++ b/api/tradebff/handlers.go
@@ -1,17 +1,52 @@
 package tradebff
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/cloudwego/hertz/pkg/app"
 )
 
-const unavailableReason = "Commission 尚未提供 Console V2 会话到资金账户的可信身份委托契约"
+const unavailableReason = "Commission 交易服务尚未配置可信主体委托"
 
-type Service struct{}
+type Config struct {
+	Endpoint             string
+	DelegationKeyID      string
+	DelegationPrivateKey string
+}
 
-func New() *Service { return &Service{} }
+type Service struct {
+	client    *CommissionClient
+	delegator *Delegator
+	reason    string
+}
+
+func New(config Config) (*Service, error) {
+	client, err := NewCommissionClient(config.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	delegator, err := NewDelegator(config.DelegationKeyID, config.DelegationPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{client: client, delegator: delegator}, nil
+}
+
+func NewUnavailable(reason string) *Service {
+	if strings.TrimSpace(reason) == "" {
+		reason = unavailableReason
+	}
+	return &Service{reason: reason}
+}
 
 func agentID(c *app.RequestContext) (int64, bool) {
 	value, exists := c.Get("agent_id")
@@ -24,90 +59,349 @@ func reply(c *app.RequestContext, status int, data interface{}) {
 	c.JSON(status, map[string]interface{}{"data": data})
 }
 
-func unavailable(c *app.RequestContext, capability string) {
+func replyError(c *app.RequestContext, status int, code, message string) {
 	c.Header("Cache-Control", "private, no-store")
-	c.JSON(http.StatusServiceUnavailable, map[string]interface{}{
-		"error": map[string]interface{}{
-			"code":    "COMMISSION_IDENTITY_DELEGATION_REQUIRED",
-			"message": unavailableReason,
-			"details": map[string]interface{}{"capability": capability},
-		},
-	})
+	c.JSON(status, map[string]interface{}{"error": map[string]interface{}{"code": code, "message": message}})
 }
 
-func base() map[string]interface{} {
-	return map[string]interface{}{
-		"available":          false,
-		"unavailable_reason": unavailableReason,
-		"todo_code":          "COMMISSION_IDENTITY_DELEGATION_REQUIRED",
+func (s *Service) unavailable(c *app.RequestContext) {
+	reason := ""
+	if s != nil {
+		reason = s.reason
 	}
+	if reason == "" {
+		reason = unavailableReason
+	}
+	replyError(c, http.StatusServiceUnavailable, "COMMISSION_UNAVAILABLE", reason)
 }
 
-func (s *Service) TradeOverview(_ context.Context, c *app.RequestContext) {
-	_, ok := agentID(c)
+func (s *Service) fetch(ctx context.Context, agentID int64, scope, operation, method, path string, query url.Values, body []byte, idempotencyKey string, bindMutation bool) (json.RawMessage, error) {
+	if s == nil || s.client == nil || s.delegator == nil {
+		return nil, fmt.Errorf("Commission BFF is not configured")
+	}
+	token, err := s.delegator.Token(DelegationRequest{AgentID: agentID, Scope: scope, Method: method, Operation: operation, Body: body, IdempotencyKey: idempotencyKey, BindMutation: bindMutation})
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, token, method, path, query, body, idempotencyKey)
+}
+
+func (s *Service) proxy(ctx context.Context, c *app.RequestContext, scope, operation, method, path string, query url.Values, body []byte, bindMutation bool) {
+	identifier, ok := agentID(c)
 	if !ok {
-		unavailable(c, "trade.overview")
+		replyError(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console Session 无效")
 		return
 	}
-	data := base()
-	data["capabilities_count"] = nil
-	data["accepted_orders_count"] = nil
-	data["outgoing_orders_count"] = nil
-	data["total_fen"] = nil
-	data["withdrawable_fen"] = nil
+	if s == nil || s.client == nil || s.delegator == nil {
+		s.unavailable(c)
+		return
+	}
+	key := string(c.GetHeader("Idempotency-Key"))
+	if bindMutation && strings.TrimSpace(key) == "" {
+		replyError(c, http.StatusBadRequest, "IDEMPOTENCY_KEY_REQUIRED", "Idempotency-Key 不能为空")
+		return
+	}
+	data, err := s.fetch(ctx, identifier, scope, operation, method, path, query, body, key, bindMutation)
+	if err != nil {
+		status := upstreamStatus(err)
+		replyError(c, status, "COMMISSION_REQUEST_FAILED", http.StatusText(status))
+		return
+	}
 	reply(c, http.StatusOK, data)
 }
 
-func (s *Service) TradeCommissions(_ context.Context, c *app.RequestContext) {
-	data := base()
-	data["items"] = []interface{}{}
-	data["next_cursor"] = ""
-	reply(c, http.StatusOK, data)
+func (s *Service) TradeOverview(ctx context.Context, c *app.RequestContext) {
+	identifier, ok := agentID(c)
+	if !ok {
+		replyError(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console Session 无效")
+		return
+	}
+	if s == nil || s.client == nil || s.delegator == nil {
+		s.unavailable(c)
+		return
+	}
+	type result struct {
+		data json.RawMessage
+		err  error
+	}
+	summaryResult, balanceResult := make(chan result, 1), make(chan result, 1)
+	go func() {
+		data, err := s.fetch(ctx, identifier, "trade:summary:read", "trade.summary.read", http.MethodGet, "/api/v1/trade/summary", nil, nil, "", false)
+		summaryResult <- result{data, err}
+	}()
+	go func() {
+		data, err := s.fetch(ctx, identifier, "wallet:read", "wallet.balance.read", http.MethodGet, "/api/v1/wallet/balance", nil, nil, "", false)
+		balanceResult <- result{data, err}
+	}()
+	summary, balance := <-summaryResult, <-balanceResult
+	if balance.err != nil {
+		replyError(c, upstreamStatus(balance.err), "COMMISSION_BALANCE_UNAVAILABLE", "钱包余额暂不可用")
+		return
+	}
+	out := map[string]interface{}{"capabilities_count": nil, "accepted_orders_count": nil, "outgoing_orders_count": nil}
+	mergeNested(out, balance.data, "balance")
+	if summary.err == nil {
+		mergeNested(out, summary.data, "summary")
+	} else {
+		out["warnings"] = []map[string]string{{"code": "TRADE_SUMMARY_UNAVAILABLE"}}
+	}
+	reply(c, http.StatusOK, out)
 }
 
-func (s *Service) TradeOrders(_ context.Context, c *app.RequestContext) {
-	data := base()
-	data["role"] = string(c.Query("role"))
-	data["items"] = []interface{}{}
-	data["next_cursor"] = ""
-	reply(c, http.StatusOK, data)
+func (s *Service) TradeCommissions(ctx context.Context, c *app.RequestContext) {
+	s.proxy(ctx, c, "commissions:mine:read", "console.trade.commissions.list", http.MethodGet, "/api/v2/console/trade/commissions", selectedQuery(c, "status", "cursor", "limit"), nil, false)
 }
 
-func (s *Service) TradeOrder(_ context.Context, c *app.RequestContext) {
-	unavailable(c, "trade.order_detail")
+func (s *Service) TradeOrders(ctx context.Context, c *app.RequestContext) {
+	s.proxy(ctx, c, "orders:read", "console.trade.orders.list", http.MethodGet, "/api/v2/console/trade/orders", selectedQuery(c, "role", "state", "cursor", "limit"), nil, false)
 }
 
-func (s *Service) EarningsSummary(_ context.Context, c *app.RequestContext) {
-	data := base()
-	data["total_fen"] = nil
-	data["unmatured_fen"] = nil
-	data["reserved_fen"] = nil
-	data["withdrawn_fen"] = nil
-	data["withdrawable_fen"] = nil
-	reply(c, http.StatusOK, data)
+func (s *Service) TradeOrder(ctx context.Context, c *app.RequestContext) {
+	orderID := string(c.Param("order_id"))
+	if !positiveDecimal(orderID) {
+		replyError(c, http.StatusBadRequest, "INVALID_ORDER_ID", "订单号无效")
+		return
+	}
+	s.proxy(ctx, c, "orders:read", "console.trade.orders.get", http.MethodGet, "/api/v2/console/trade/orders/"+url.PathEscape(orderID), nil, nil, false)
 }
 
-func (s *Service) EarningsRecords(_ context.Context, c *app.RequestContext) {
-	data := base()
-	data["items"] = []interface{}{}
-	data["next_cursor"] = ""
-	reply(c, http.StatusOK, data)
+func (s *Service) EarningsSummary(ctx context.Context, c *app.RequestContext) {
+	s.proxy(ctx, c, "wallet:read", "wallet.balance.read", http.MethodGet, "/api/v1/wallet/balance", nil, nil, false)
 }
 
-func (s *Service) PayoutMethod(_ context.Context, c *app.RequestContext) {
-	data := base()
-	data["method"] = nil
-	reply(c, http.StatusOK, data)
+func (s *Service) EarningsRecords(ctx context.Context, c *app.RequestContext) {
+	identifier, ok := agentID(c)
+	if !ok {
+		replyError(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console Session 无效")
+		return
+	}
+	if s == nil || s.client == nil || s.delegator == nil {
+		s.unavailable(c)
+		return
+	}
+	recordType := strings.TrimSpace(string(c.Query("type")))
+	if recordType == "" {
+		recordType = "all"
+	}
+	if recordType != "all" && recordType != "income" && recordType != "withdrawal" {
+		replyError(c, http.StatusBadRequest, "INVALID_RECORD_TYPE", "资金记录类型无效")
+		return
+	}
+	query := selectedQuery(c, "cursor", "limit")
+	if recordType == "income" {
+		data, err := s.fetch(ctx, identifier, "wallet:read", "wallet.credits.list", http.MethodGet, "/api/v1/wallet/credits", query, nil, "", false)
+		s.replyIncomeRecords(c, data, err, true)
+		return
+	}
+	if recordType == "withdrawal" {
+		data, err := s.fetch(ctx, identifier, "withdrawals:read", "wallet.withdrawals.list", http.MethodGet, "/api/v1/wallet/withdrawals", query, nil, "", false)
+		s.replyWithdrawalRecords(c, data, err, true)
+		return
+	}
+	// The combined tab is intentionally first-page only. Advancing two
+	// independent upstream cursors after emitting one merged page loses data.
+	query.Del("cursor")
+	credits, creditErr := s.fetch(ctx, identifier, "wallet:read", "wallet.credits.list", http.MethodGet, "/api/v1/wallet/credits", query, nil, "", false)
+	withdrawals, withdrawalErr := s.fetch(ctx, identifier, "withdrawals:read", "wallet.withdrawals.list", http.MethodGet, "/api/v1/wallet/withdrawals", query, nil, "", false)
+	if creditErr != nil || withdrawalErr != nil {
+		err := creditErr
+		if err == nil {
+			err = withdrawalErr
+		}
+		replyError(c, upstreamStatus(err), "COMMISSION_RECORDS_UNAVAILABLE", "资金记录暂不可用")
+		return
+	}
+	items := append(incomeItems(credits), withdrawalItems(withdrawals)...)
+	sort.SliceStable(items, func(i, j int) bool {
+		return numberValue(items[i]["occurred_at"]) > numberValue(items[j]["occurred_at"])
+	})
+	limit := queryLimit(query)
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	reply(c, http.StatusOK, map[string]interface{}{"items": items, "next_cursor": ""})
 }
 
-func (s *Service) MutatePayoutMethod(_ context.Context, c *app.RequestContext) {
-	unavailable(c, "payout_method.bind")
+func (s *Service) PayoutMethod(ctx context.Context, c *app.RequestContext) {
+	identifier, ok := agentID(c)
+	if !ok {
+		replyError(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console Session 无效")
+		return
+	}
+	if s == nil || s.client == nil || s.delegator == nil {
+		s.unavailable(c)
+		return
+	}
+	data, err := s.fetch(ctx, identifier, "payout:read", "wallet.binding.read", http.MethodGet, "/api/v1/wallet/binding", nil, nil, "", false)
+	if err != nil {
+		status := upstreamStatus(err)
+		replyError(c, status, "COMMISSION_REQUEST_FAILED", http.StatusText(status))
+		return
+	}
+	object := decodeObject(data)
+	reply(c, http.StatusOK, map[string]interface{}{"method": normalizeBinding(object["binding"])})
 }
 
-func (s *Service) CreateWithdrawal(_ context.Context, c *app.RequestContext) {
-	unavailable(c, "withdrawal.create")
+func (s *Service) MutatePayoutMethod(ctx context.Context, c *app.RequestContext) {
+	s.proxy(ctx, c, "payout:bind", "wallet.binding.bind", http.MethodPost, "/api/v1/wallet/binding", nil, append([]byte(nil), c.Request.Body()...), true)
 }
 
-func (s *Service) Withdrawal(_ context.Context, c *app.RequestContext) {
-	unavailable(c, "withdrawal.detail")
+func (s *Service) CreateWithdrawal(ctx context.Context, c *app.RequestContext) {
+	s.proxy(ctx, c, "withdrawals:create", "wallet.withdrawals.create", http.MethodPost, "/api/v1/wallet/withdrawals", nil, append([]byte(nil), c.Request.Body()...), true)
+}
+
+func (s *Service) Withdrawal(ctx context.Context, c *app.RequestContext) {
+	withdrawalID := string(c.Param("withdrawal_id"))
+	if !positiveDecimal(withdrawalID) {
+		replyError(c, http.StatusBadRequest, "INVALID_WITHDRAWAL_ID", "提现单号无效")
+		return
+	}
+	s.proxy(ctx, c, "withdrawals:read", "wallet.withdrawals.get", http.MethodGet, "/api/v1/wallet/withdrawals/"+url.PathEscape(withdrawalID), nil, nil, false)
+}
+
+func (s *Service) replyIncomeRecords(c *app.RequestContext, data json.RawMessage, err error, includeCursor bool) {
+	if err != nil {
+		replyError(c, upstreamStatus(err), "COMMISSION_RECORDS_UNAVAILABLE", "收益记录暂不可用")
+		return
+	}
+	object := decodeObject(data)
+	next := ""
+	if includeCursor {
+		next = stringValue(object["next_cursor"])
+	}
+	reply(c, http.StatusOK, map[string]interface{}{"items": incomeItems(data), "next_cursor": next})
+}
+
+func (s *Service) replyWithdrawalRecords(c *app.RequestContext, data json.RawMessage, err error, includeCursor bool) {
+	if err != nil {
+		replyError(c, upstreamStatus(err), "COMMISSION_RECORDS_UNAVAILABLE", "提现记录暂不可用")
+		return
+	}
+	object := decodeObject(data)
+	next := ""
+	if includeCursor {
+		next = stringValue(object["next_cursor"])
+	}
+	reply(c, http.StatusOK, map[string]interface{}{"items": withdrawalItems(data), "next_cursor": next})
+}
+
+func incomeItems(data json.RawMessage) []map[string]interface{} {
+	items := objectItems(data, "credits")
+	for _, item := range items {
+		item["record_type"] = "income"
+		item["record_id"] = stringValue(item["credit_id"])
+		item["status"] = item["settlement_state"]
+		item["title"] = item["title_snapshot"]
+	}
+	return items
+}
+
+func withdrawalItems(data json.RawMessage) []map[string]interface{} {
+	items := objectItems(data, "withdrawals")
+	for _, item := range items {
+		item["record_type"] = "withdrawal"
+		item["withdrawal_id"] = stringValue(item["withdrawal_id"])
+		item["record_id"] = item["withdrawal_id"]
+		item["status"] = item["state"]
+		item["occurred_at"] = item["created_at"]
+		item["provider_operation_ref"] = item["provider_operation_reference"]
+	}
+	return items
+}
+
+func objectItems(data json.RawMessage, key string) []map[string]interface{} {
+	object := decodeObject(data)
+	raw, _ := object[key].([]interface{})
+	items := make([]map[string]interface{}, 0, len(raw))
+	for _, entry := range raw {
+		if item, ok := entry.(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func decodeObject(data json.RawMessage) map[string]interface{} {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var object map[string]interface{}
+	if decoder.Decode(&object) != nil || object == nil {
+		return map[string]interface{}{}
+	}
+	return object
+}
+
+func mergeNested(target map[string]interface{}, data json.RawMessage, key string) {
+	object := decodeObject(data)
+	if nested, ok := object[key].(map[string]interface{}); ok {
+		for name, value := range nested {
+			target[name] = value
+		}
+	}
+}
+
+func selectedQuery(c *app.RequestContext, names ...string) url.Values {
+	values := make(url.Values)
+	for _, name := range names {
+		if value := strings.TrimSpace(string(c.Query(name))); value != "" {
+			values.Set(name, value)
+		}
+	}
+	return values
+}
+
+func positiveDecimal(value string) bool {
+	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	return err == nil && parsed > 0 && strconv.FormatInt(parsed, 10) == strings.TrimSpace(value)
+}
+
+func queryLimit(values url.Values) int {
+	limit, err := strconv.Atoi(values.Get("limit"))
+	if err != nil || limit <= 0 || limit > 100 {
+		return 20
+	}
+	return limit
+}
+
+func stringValue(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case json.Number:
+		return typed.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func numberValue(value interface{}) int64 {
+	switch typed := value.(type) {
+	case json.Number:
+		result, _ := typed.Int64()
+		return result
+	case float64:
+		return int64(typed)
+	case int64:
+		return typed
+	default:
+		return 0
+	}
+}
+
+func normalizeBinding(value interface{}) interface{} {
+	binding, ok := value.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for _, field := range []string{"cooling_until", "updated_at"} {
+		milliseconds := numberValue(binding[field])
+		if milliseconds > 0 {
+			binding[field] = time.UnixMilli(milliseconds).UTC().Format(time.RFC3339)
+		} else {
+			binding[field] = nil
+		}
+	}
+	return binding
 }

--- a/api/tradebff/handlers_test.go
+++ b/api/tradebff/handlers_test.go
@@ -2,30 +2,128 @@ package tradebff
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/hertz/pkg/app"
 )
 
-func TestTradeOverviewDoesNotInventUnavailableMoney(t *testing.T) {
+func TestUnavailableTradeOverviewDoesNotInventMoney(t *testing.T) {
 	ctx := app.NewContext(0)
 	ctx.Request.SetRequestURI("/api/v2/console/bff/trade/overview")
 	ctx.Set("agent_id", int64(42))
-	New().TradeOverview(context.Background(), ctx)
-	if ctx.Response.StatusCode() != 200 {
+	NewUnavailable("").TradeOverview(context.Background(), ctx)
+	if ctx.Response.StatusCode() != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d", ctx.Response.StatusCode())
 	}
-	var envelope struct {
-		Data map[string]interface{} `json:"data"`
+	if strings.Contains(string(ctx.Response.Body()), "total_fen") || strings.Contains(string(ctx.Response.Body()), "withdrawable_fen") {
+		t.Fatalf("unavailable response invented money: %s", ctx.Response.Body())
 	}
-	if err := json.Unmarshal(ctx.Response.Body(), &envelope); err != nil {
+}
+
+func TestTradeCommissionsDelegatesAuthenticatedSubject(t *testing.T) {
+	var authorization, requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization, requestPath = r.Header.Get("Authorization"), r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"code":0,"msg":"ok","data":{"items":[{"commission_id":"9007199254740993"}],"page":{"next_cursor":"22","total":1}}}`)
+	}))
+	defer server.Close()
+	service := configuredService(t, server.URL)
+	ctx := app.NewContext(0)
+	ctx.Request.SetRequestURI("/api/v2/console/bff/trade/commissions?cursor=11&limit=20")
+	ctx.Set("agent_id", int64(42))
+	service.TradeCommissions(context.Background(), ctx)
+	if ctx.Response.StatusCode() != http.StatusOK {
+		t.Fatalf("status = %d body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if !strings.HasPrefix(authorization, "Bearer "+delegationPrefix+"current.") {
+		t.Fatalf("authorization = %q", authorization)
+	}
+	if requestPath != "/api/v2/console/trade/commissions?cursor=11&limit=20" {
+		t.Fatalf("request path = %q", requestPath)
+	}
+	claims := tokenClaims(t, strings.TrimPrefix(authorization, "Bearer "))
+	if claims.Subject != "42" || claims.Scope != "commissions:mine:read" || claims.Operation != "console.trade.commissions.list" {
+		t.Fatalf("claims = %#v", claims)
+	}
+}
+
+func TestWithdrawalDelegationBindsBodyAndIdempotencyKey(t *testing.T) {
+	var authorization, idempotency string
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization, idempotency = r.Header.Get("Authorization"), r.Header.Get("Idempotency-Key")
+		receivedBody, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, `{"code":0,"msg":"ok","data":{"withdrawal":{"withdrawal_id":"9","amount_fen":3100}}}`)
+	}))
+	defer server.Close()
+	service := configuredService(t, server.URL)
+	ctx := app.NewContext(0)
+	ctx.Request.SetRequestURI("/api/v2/console/bff/withdrawals")
+	ctx.Request.Header.SetMethod(http.MethodPost)
+	ctx.Request.Header.Set("Idempotency-Key", "idem-1")
+	ctx.Request.SetBodyString(`{"amount_fen":3100}`)
+	ctx.Set("agent_id", int64(42))
+	service.CreateWithdrawal(context.Background(), ctx)
+	if ctx.Response.StatusCode() != http.StatusOK || idempotency != "idem-1" {
+		t.Fatalf("status=%d idempotency=%q body=%s", ctx.Response.StatusCode(), idempotency, ctx.Response.Body())
+	}
+	claims := tokenClaims(t, strings.TrimPrefix(authorization, "Bearer "))
+	if claims.BodySHA256 != delegationDigest(receivedBody) || claims.IdempotencyKeySHA256 != delegationDigest([]byte("idem-1")) {
+		t.Fatalf("mutation binding mismatch: %#v", claims)
+	}
+}
+
+func TestWithdrawalRejectsMissingIdempotencyKeyBeforeCommission(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+	defer server.Close()
+	service := configuredService(t, server.URL)
+	ctx := app.NewContext(0)
+	ctx.Request.SetRequestURI("/api/v2/console/bff/withdrawals")
+	ctx.Request.Header.SetMethod(http.MethodPost)
+	ctx.Request.SetBodyString(`{"amount_fen":3100}`)
+	ctx.Set("agent_id", int64(42))
+	service.CreateWithdrawal(context.Background(), ctx)
+	if ctx.Response.StatusCode() != http.StatusBadRequest || called {
+		t.Fatalf("status=%d called=%v body=%s", ctx.Response.StatusCode(), called, ctx.Response.Body())
+	}
+}
+
+func configuredService(t *testing.T, endpoint string) *Service {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if envelope.Data["available"] != false || envelope.Data["withdrawable_fen"] != nil {
-		t.Fatalf("unexpected response: %#v", envelope.Data)
+	service, err := New(Config{Endpoint: endpoint, DelegationKeyID: "current", DelegationPrivateKey: base64.RawURLEncoding.EncodeToString(privateKey)})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if envelope.Data["todo_code"] != "COMMISSION_IDENTITY_DELEGATION_REQUIRED" {
-		t.Fatalf("todo_code = %#v", envelope.Data["todo_code"])
+	return service
+}
+
+func tokenClaims(t *testing.T, token string) delegationClaims {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("invalid token %q", token)
 	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims delegationClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatal(err)
+	}
+	return claims
 }

--- a/api/tradebff/handlers_test.go
+++ b/api/tradebff/handlers_test.go
@@ -1,0 +1,31 @@
+package tradebff
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+func TestTradeOverviewDoesNotInventUnavailableMoney(t *testing.T) {
+	ctx := app.NewContext(0)
+	ctx.Request.SetRequestURI("/api/v2/console/bff/trade/overview")
+	ctx.Set("agent_id", int64(42))
+	New().TradeOverview(context.Background(), ctx)
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("status = %d", ctx.Response.StatusCode())
+	}
+	var envelope struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Data["available"] != false || envelope.Data["withdrawable_fen"] != nil {
+		t.Fatalf("unexpected response: %#v", envelope.Data)
+	}
+	if envelope.Data["todo_code"] != "COMMISSION_IDENTITY_DELEGATION_REQUIRED" {
+		t.Fatalf("todo_code = %#v", envelope.Data["todo_code"])
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,6 +123,9 @@ type Config struct {
 	ReplayLogRetentionDays      int      // replay_logs rows older than this are purged by cron (default 30)
 	ReplayLogCleanupIntervalSec int      // replay_logs cleanup cron interval (default 86400 = daily)
 	MqStreamMaxLen              int64    // approximate cap on Redis Stream length applied by mq.Publish (default 20000, <=0 disables); ingestion streams are exempt
+	CommissionAPIEndpoint       string
+	CommissionDelegateKID       string
+	CommissionDelegatePrivate   string
 
 	// Official account (singleton new-user guide / first contact)
 	OfficialAgentEmail           string   // email identifying the official account; resolved to agent_id at runtime
@@ -299,6 +302,9 @@ func Load() *Config {
 		ReplayLogRetentionDays:       getEnvInt("REPLAY_LOG_RETENTION_DAYS", 30),
 		ReplayLogCleanupIntervalSec:  getEnvInt("REPLAY_LOG_CLEANUP_INTERVAL_SEC", 86400),
 		MqStreamMaxLen:               getEnvInt64("MQ_STREAM_MAXLEN", 20000),
+		CommissionAPIEndpoint:        getEnv("COMMISSION_ENDPOINT", "http://127.0.0.1:8090"),
+		CommissionDelegateKID:        getEnv("COMMISSION_DELEGATION_KEY_ID", ""),
+		CommissionDelegatePrivate:    getEnv("COMMISSION_DELEGATION_PRIVATE_KEY", ""),
 		OfficialAgentEmail:           getEnv("OFFICIAL_AGENT_EMAIL", "eigenfluxofficial@gmail.com"),
 		OfficialAgentName:            getEnv("OFFICIAL_AGENT_NAME", "eigenflux 官方助手"),
 		OfficialAgentBio:             getEnv("OFFICIAL_AGENT_BIO", "你好，我是 Vic 老师，有什么可以帮助你的？"),


### PR DESCRIPTION
## Summary
- add the 10 additive Console V2 trade/earnings BFF routes under the existing Console session middleware
- call Commission over a typed HTTP client with short-lived scoped Ed25519 delegation
- bind payout/withdrawal mutations to body and Idempotency-Key
- fail closed with explicit 503 when Commission delegation is not configured; existing routes and services are unchanged

## Scope control
- rebased from current origin/main
- 8 files only; no CLI, skill, migration, database, or legacy API changes
- Commission verifier dependency is merged in eigenflux-commission#1

## Verification
- go test ./api/tradebff ./api/consolev2 ./api ./pkg/config
- go vet ./api/tradebff ./api/consolev2 ./api ./pkg/config
- git diff --check origin/main...HEAD