### PR TITLE
perf: snapshot PGC feedback trend

### DIFF
--- a/migrations/000083_pgc_strong_feedback_snapshot.sql
+++ b/migrations/000083_pgc_strong_feedback_snapshot.sql
@@ -1,0 +1,151 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- The daily strong-feedback panel used to execute the full 90-day join on
+-- every Grafana refresh. Production evidence on 2026-08-28 showed one read
+-- touching 7.2M buffers and taking 4.86s. Keep the anonymous aggregate, but
+-- compute it once per refresh instead of once per viewer.
+DROP VIEW IF EXISTS grafana_pgc_strong_feedback_daily;
+
+CREATE MATERIALIZED VIEW grafana_pgc_strong_feedback_daily AS
+WITH bounds AS (
+    SELECT
+        (now() AT TIME ZONE 'Asia/Shanghai')::date AS today,
+        ((extract(epoch FROM now()) * 1000)::BIGINT - 7862400000) AS since_ms,
+        now() AS snapshot_at
+), calendar AS (
+    SELECT generate_series(today - 89, today, interval '1 day')::date AS day
+    FROM bounds
+), feedback AS MATERIALIZED (
+    SELECT
+        (to_timestamp(f.feedback_at / 1000.0)
+            AT TIME ZONE 'Asia/Shanghai')::date AS day,
+        f.agent_id,
+        f.score
+    FROM feedback_logs f
+    JOIN agents consumer ON consumer.agent_id = f.agent_id
+    JOIN raw_items i USING (item_id)
+    JOIN agents author ON author.agent_id = i.author_agent_id,
+         bounds
+    WHERE f.feedback_at >= bounds.since_ms
+      AND lower(author.email) LIKE '%@pgc.eigenflux.one'
+      AND lower(consumer.email) NOT LIKE '%bot.eigenflux%'
+      AND lower(consumer.email) NOT LIKE '%pgc.eigenflux%'
+), daily AS (
+    SELECT
+        day,
+        count(*) AS feedback_events,
+        count(*) FILTER (WHERE score = 2) AS strong_positive_events,
+        count(DISTINCT agent_id) AS feedback_agents
+    FROM feedback
+    GROUP BY day
+)
+SELECT
+    c.day,
+    COALESCE(d.feedback_events, 0) AS feedback_events,
+    COALESCE(d.strong_positive_events, 0) AS strong_positive_events,
+    COALESCE(d.feedback_agents, 0) AS feedback_agents,
+    round(
+        100.0 * COALESCE(d.strong_positive_events, 0)
+            / NULLIF(d.feedback_events, 0),
+        1
+    ) AS strong_positive_rate,
+    b.snapshot_at
+FROM calendar c
+LEFT JOIN daily d USING (day)
+CROSS JOIN bounds b
+ORDER BY c.day;
+
+CREATE UNIQUE INDEX uq_grafana_pgc_strong_feedback_daily_day
+    ON grafana_pgc_strong_feedback_daily (day);
+
+REVOKE ALL ON grafana_pgc_strong_feedback_daily FROM PUBLIC;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        GRANT SELECT ON grafana_pgc_strong_feedback_daily TO grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+COMMENT ON MATERIALIZED VIEW grafana_pgc_strong_feedback_daily IS
+    'Anonymous daily PGC score=2 feedback totals, refreshed every five minutes. '
+    'Days use Asia/Shanghai event time; user-level feedback remains private.';
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        REVOKE SELECT ON grafana_pgc_strong_feedback_daily FROM grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+DROP MATERIALIZED VIEW IF EXISTS grafana_pgc_strong_feedback_daily;
+
+CREATE VIEW grafana_pgc_strong_feedback_daily
+WITH (security_barrier = true) AS
+WITH bounds AS (
+    SELECT
+        (now() AT TIME ZONE 'Asia/Shanghai')::date AS today,
+        ((extract(epoch FROM now()) * 1000)::BIGINT - 7862400000) AS since_ms
+), calendar AS (
+    SELECT generate_series(today - 89, today, interval '1 day')::date AS day
+    FROM bounds
+), feedback AS MATERIALIZED (
+    SELECT
+        (to_timestamp(f.feedback_at / 1000.0)
+            AT TIME ZONE 'Asia/Shanghai')::date AS day,
+        f.agent_id,
+        f.score
+    FROM feedback_logs f
+    JOIN agents consumer ON consumer.agent_id = f.agent_id
+    JOIN raw_items i USING (item_id)
+    JOIN agents author ON author.agent_id = i.author_agent_id,
+         bounds
+    WHERE f.feedback_at >= bounds.since_ms
+      AND lower(author.email) LIKE '%@pgc.eigenflux.one'
+      AND lower(consumer.email) NOT LIKE '%bot.eigenflux%'
+      AND lower(consumer.email) NOT LIKE '%pgc.eigenflux%'
+), daily AS (
+    SELECT
+        day,
+        count(*) AS feedback_events,
+        count(*) FILTER (WHERE score = 2) AS strong_positive_events,
+        count(DISTINCT agent_id) AS feedback_agents
+    FROM feedback
+    GROUP BY day
+)
+SELECT
+    c.day,
+    COALESCE(d.feedback_events, 0) AS feedback_events,
+    COALESCE(d.strong_positive_events, 0) AS strong_positive_events,
+    COALESCE(d.feedback_agents, 0) AS feedback_agents,
+    round(
+        100.0 * COALESCE(d.strong_positive_events, 0)
+            / NULLIF(d.feedback_events, 0),
+        1
+    ) AS strong_positive_rate
+FROM calendar c
+LEFT JOIN daily d USING (day)
+ORDER BY c.day;
+
+REVOKE ALL ON grafana_pgc_strong_feedback_daily FROM PUBLIC;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        GRANT SELECT ON grafana_pgc_strong_feedback_daily TO grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd

--- a/pipeline/cron/main.go
+++ b/pipeline/cron/main.go
@@ -97,6 +97,7 @@ func main() {
 	go StartSuggestionBackfill(ctx, cfg, mq.RDB, llmClient)
 	go StartActivityCleanup(ctx, mq.RDB)
 	go StartConsoleV2Cleanup(ctx, mq.RDB)
+	go StartPGCFeedbackSnapshot(ctx, mq.RDB)
 	profileCleanupDone := make(chan struct{})
 	go func() {
 		defer close(profileCleanupDone)

--- a/pipeline/cron/pgc_feedback_snapshot.go
+++ b/pipeline/cron/pgc_feedback_snapshot.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/logger"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	lockKeyPGCFeedbackSnapshot = "lock:cron:pgc_feedback_snapshot"
+	pgcFeedbackRefreshInterval = 5 * time.Minute
+	pgcFeedbackRefreshLockTTL  = 10 * time.Minute
+)
+
+type pgcFeedbackRefreshFunc func(context.Context) error
+
+func StartPGCFeedbackSnapshot(ctx context.Context, rdb *redis.Client) {
+	refreshPGCFeedbackSnapshotWithLock(ctx, rdb, refreshPGCFeedbackSnapshot)
+	ticker := time.NewTicker(pgcFeedbackRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refreshPGCFeedbackSnapshotWithLock(ctx, rdb, refreshPGCFeedbackSnapshot)
+		}
+	}
+}
+
+func refreshPGCFeedbackSnapshot(ctx context.Context) error {
+	return db.DB.WithContext(ctx).
+		Exec("REFRESH MATERIALIZED VIEW CONCURRENTLY grafana_pgc_strong_feedback_daily").
+		Error
+}
+
+func refreshPGCFeedbackSnapshotWithLock(
+	ctx context.Context,
+	rdb *redis.Client,
+	refresh pgcFeedbackRefreshFunc,
+) bool {
+	token, acquired, err := acquireLock(
+		ctx, rdb, lockKeyPGCFeedbackSnapshot, pgcFeedbackRefreshLockTTL,
+	)
+	if err != nil {
+		logger.Default().Warn("failed to acquire PGC feedback snapshot lock", "err", err)
+		return false
+	}
+	if !acquired {
+		return false
+	}
+	defer releaseLock(rdb, lockKeyPGCFeedbackSnapshot, token)
+
+	started := time.Now()
+	if err := refresh(ctx); err != nil {
+		logger.Default().Error("failed to refresh PGC feedback snapshot", "err", err)
+		return false
+	}
+	logger.Default().Info(
+		"PGC feedback snapshot refreshed",
+		"duration", time.Since(started),
+	)
+	return true
+}

--- a/pipeline/cron/pgc_feedback_snapshot_test.go
+++ b/pipeline/cron/pgc_feedback_snapshot_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestPGCFeedbackSnapshotRefreshUsesDistributedLock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	ctx := context.Background()
+
+	called := 0
+	refresh := func(context.Context) error {
+		called++
+		return nil
+	}
+	if !refreshPGCFeedbackSnapshotWithLock(ctx, rdb, refresh) {
+		t.Fatal("first refresh did not run")
+	}
+	if called != 1 {
+		t.Fatalf("refresh calls = %d, want 1", called)
+	}
+	if mr.Exists(lockKeyPGCFeedbackSnapshot) {
+		t.Fatal("successful refresh left its lock behind")
+	}
+
+	if err := rdb.Set(ctx, lockKeyPGCFeedbackSnapshot, "other-owner", time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if refreshPGCFeedbackSnapshotWithLock(ctx, rdb, refresh) {
+		t.Fatal("refresh ran while another replica held the lock")
+	}
+	if called != 1 {
+		t.Fatalf("refresh calls = %d, want 1", called)
+	}
+}
+
+func TestPGCFeedbackSnapshotRefreshFailureReleasesLock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	refresh := func(context.Context) error { return errors.New("database unavailable") }
+	if refreshPGCFeedbackSnapshotWithLock(context.Background(), rdb, refresh) {
+		t.Fatal("failed refresh reported success")
+	}
+	if mr.Exists(lockKeyPGCFeedbackSnapshot) {
+		t.Fatal("failed refresh left its lock behind")
+	}
+}

--- a/tests/schema/pgc_strong_feedback_snapshot_contract_test.go
+++ b/tests/schema/pgc_strong_feedback_snapshot_contract_test.go
@@ -1,0 +1,54 @@
+package schema_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPGCStrongFeedbackSnapshotMigrationContract(t *testing.T) {
+	b, err := os.ReadFile("../../migrations/000083_pgc_strong_feedback_snapshot.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(b)
+	for _, want := range []string{
+		"CREATE MATERIALIZED VIEW grafana_pgc_strong_feedback_daily",
+		"CREATE UNIQUE INDEX uq_grafana_pgc_strong_feedback_daily_day",
+		"snapshot_at",
+		"REVOKE ALL ON grafana_pgc_strong_feedback_daily FROM PUBLIC",
+		"GRANT SELECT ON grafana_pgc_strong_feedback_daily TO grafana_ro_v2",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("migration missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"GRANT SELECT ON feedback_logs",
+		"GRANT SELECT ON raw_items",
+		"GRANT SELECT ON agents",
+		"agent_id AS",
+		"item_id AS",
+	} {
+		if strings.Contains(sql, forbidden) {
+			t.Fatalf("migration exposes user-level data: %s", forbidden)
+		}
+	}
+}
+
+func TestPGCStrongFeedbackSnapshotRuntimeContract(t *testing.T) {
+	b, err := os.ReadFile("../../pipeline/cron/pgc_feedback_snapshot.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(b)
+	for _, want := range []string{
+		"REFRESH MATERIALIZED VIEW CONCURRENTLY grafana_pgc_strong_feedback_daily",
+		"pgcFeedbackRefreshInterval = 5 * time.Minute",
+		"refreshPGCFeedbackSnapshotWithLock",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("runtime missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Why\nThe PGC strong-feedback panel took 4.86s per load in production and touched 7.2M buffers because its view recomputed 90 days of feedback joins for every viewer.\n\n## What\n- replace the anonymous daily view with a materialized snapshot\n- refresh it concurrently every five minutes from the existing cron service\n- serialize refreshes across replicas with the existing Redis lock\n- expose snapshot_at for freshness checks while keeping user-level rows private\n\n## Verification\n- go test ./pipeline/cron -run '^TestPGCFeedbackSnapshot' -count=1\n- go test ./tests/schema -run '^TestPGCStrongFeedbackSnapshot' -count=1\n- go build -o build/cron ./pipeline/cron\n- current production EXPLAIN ANALYZE baseline: 4861ms, 7.2M shared-buffer hits\n\nFull pipeline/cron package tests need local Postgres; the new tests pass without external services.