### PR TITLE
perf: snapshot PGC demand supply

### DIFF
--- a/migrations/000084_pgc_demand_supply_snapshot.sql
+++ b/migrations/000084_pgc_demand_supply_snapshot.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+-- The demand/supply view intentionally performs the privacy-sensitive joins
+-- behind an aggregate boundary. That query took 11.9s and touched 11.2M
+-- buffers when Grafana ran it directly. Preserve the original view as the
+-- calculation contract and expose its six anonymous rows through a snapshot.
+CREATE MATERIALIZED VIEW grafana_pgc_demand_supply_24h_snapshot AS
+SELECT demand_supply.*, now() AS snapshot_at
+FROM grafana_pgc_demand_supply_24h demand_supply;
+
+CREATE UNIQUE INDEX uq_grafana_pgc_demand_supply_24h_snapshot_ord
+    ON grafana_pgc_demand_supply_24h_snapshot (ord);
+
+REVOKE ALL ON grafana_pgc_demand_supply_24h_snapshot FROM PUBLIC;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        GRANT SELECT ON grafana_pgc_demand_supply_24h_snapshot TO grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+COMMENT ON MATERIALIZED VIEW grafana_pgc_demand_supply_24h_snapshot IS
+    'Anonymous 24-hour fixed-bucket demand and PGC exposure aggregates, '
+    'refreshed every fifteen minutes for Grafana.';
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        REVOKE SELECT ON grafana_pgc_demand_supply_24h_snapshot FROM grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+DROP MATERIALIZED VIEW IF EXISTS grafana_pgc_demand_supply_24h_snapshot;

--- a/pipeline/cron/main.go
+++ b/pipeline/cron/main.go
@@ -98,6 +98,7 @@ func main() {
 	go StartActivityCleanup(ctx, mq.RDB)
 	go StartConsoleV2Cleanup(ctx, mq.RDB)
 	go StartPGCFeedbackSnapshot(ctx, mq.RDB)
+	go StartPGCDemandSnapshot(ctx, mq.RDB)
 	profileCleanupDone := make(chan struct{})
 	go func() {
 		defer close(profileCleanupDone)

--- a/pipeline/cron/pgc_demand_snapshot.go
+++ b/pipeline/cron/pgc_demand_snapshot.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/logger"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	lockKeyPGCDemandSnapshot = "lock:cron:pgc_demand_snapshot"
+	pgcDemandRefreshInterval = 15 * time.Minute
+	pgcDemandRefreshLockTTL  = 20 * time.Minute
+)
+
+type pgcDemandRefreshFunc func(context.Context) error
+
+func StartPGCDemandSnapshot(ctx context.Context, rdb *redis.Client) {
+	refreshPGCDemandSnapshotWithLock(ctx, rdb, refreshPGCDemandSnapshot)
+	ticker := time.NewTicker(pgcDemandRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			refreshPGCDemandSnapshotWithLock(ctx, rdb, refreshPGCDemandSnapshot)
+		}
+	}
+}
+
+func refreshPGCDemandSnapshot(ctx context.Context) error {
+	return db.DB.WithContext(ctx).
+		Exec("REFRESH MATERIALIZED VIEW CONCURRENTLY grafana_pgc_demand_supply_24h_snapshot").
+		Error
+}
+
+func refreshPGCDemandSnapshotWithLock(
+	ctx context.Context,
+	rdb *redis.Client,
+	refresh pgcDemandRefreshFunc,
+) bool {
+	token, acquired, err := acquireLock(
+		ctx, rdb, lockKeyPGCDemandSnapshot, pgcDemandRefreshLockTTL,
+	)
+	if err != nil {
+		logger.Default().Warn("failed to acquire PGC demand snapshot lock", "err", err)
+		return false
+	}
+	if !acquired {
+		return false
+	}
+	defer releaseLock(rdb, lockKeyPGCDemandSnapshot, token)
+
+	started := time.Now()
+	if err := refresh(ctx); err != nil {
+		logger.Default().Error("failed to refresh PGC demand snapshot", "err", err)
+		return false
+	}
+	logger.Default().Info(
+		"PGC demand snapshot refreshed",
+		"duration", time.Since(started),
+	)
+	return true
+}

--- a/pipeline/cron/pgc_demand_snapshot_test.go
+++ b/pipeline/cron/pgc_demand_snapshot_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestPGCDemandSnapshotRefreshUsesDistributedLock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	ctx := context.Background()
+
+	called := 0
+	refresh := func(context.Context) error {
+		called++
+		return nil
+	}
+	if !refreshPGCDemandSnapshotWithLock(ctx, rdb, refresh) {
+		t.Fatal("first refresh did not run")
+	}
+	if called != 1 {
+		t.Fatalf("refresh calls = %d, want 1", called)
+	}
+	if mr.Exists(lockKeyPGCDemandSnapshot) {
+		t.Fatal("successful refresh left its lock behind")
+	}
+
+	if err := rdb.Set(ctx, lockKeyPGCDemandSnapshot, "other-owner", time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if refreshPGCDemandSnapshotWithLock(ctx, rdb, refresh) {
+		t.Fatal("refresh ran while another replica held the lock")
+	}
+	if called != 1 {
+		t.Fatalf("refresh calls = %d, want 1", called)
+	}
+}
+
+func TestPGCDemandSnapshotRefreshFailureReleasesLock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	refresh := func(context.Context) error { return errors.New("database unavailable") }
+	if refreshPGCDemandSnapshotWithLock(context.Background(), rdb, refresh) {
+		t.Fatal("failed refresh reported success")
+	}
+	if mr.Exists(lockKeyPGCDemandSnapshot) {
+		t.Fatal("failed refresh left its lock behind")
+	}
+}

--- a/tests/schema/pgc_demand_snapshot_contract_test.go
+++ b/tests/schema/pgc_demand_snapshot_contract_test.go
@@ -1,0 +1,55 @@
+package schema_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPGCDemandSnapshotMigrationContract(t *testing.T) {
+	b, err := os.ReadFile("../../migrations/000084_pgc_demand_supply_snapshot.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(b)
+	for _, want := range []string{
+		"CREATE MATERIALIZED VIEW grafana_pgc_demand_supply_24h_snapshot",
+		"FROM grafana_pgc_demand_supply_24h demand_supply",
+		"CREATE UNIQUE INDEX uq_grafana_pgc_demand_supply_24h_snapshot_ord",
+		"snapshot_at",
+		"REVOKE ALL ON grafana_pgc_demand_supply_24h_snapshot FROM PUBLIC",
+		"GRANT SELECT ON grafana_pgc_demand_supply_24h_snapshot TO grafana_ro_v2",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("migration missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"GRANT SELECT ON replay_logs",
+		"GRANT SELECT ON agent_profiles",
+		"GRANT SELECT ON raw_items",
+		"agent_id AS",
+		"item_id AS",
+	} {
+		if strings.Contains(sql, forbidden) {
+			t.Fatalf("migration exposes user-level data: %s", forbidden)
+		}
+	}
+}
+
+func TestPGCDemandSnapshotRuntimeContract(t *testing.T) {
+	b, err := os.ReadFile("../../pipeline/cron/pgc_demand_snapshot.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(b)
+	for _, want := range []string{
+		"REFRESH MATERIALIZED VIEW CONCURRENTLY grafana_pgc_demand_supply_24h_snapshot",
+		"pgcDemandRefreshInterval = 15 * time.Minute",
+		"refreshPGCDemandSnapshotWithLock",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("runtime missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Why\nThe Audience demand/supply panel took 11.9s and touched 11.2M buffers on each browser load.\n\n## What\n- add an anonymous materialized snapshot over the existing privacy-safe aggregate view\n- refresh it concurrently every 15 minutes from the existing cron service\n- use a separate distributed lock so feedback and demand refreshes cannot suppress each other\n- expose snapshot_at for live freshness checks\n\n## Verification\n- go test ./pipeline/cron -run '^TestPGC(Demand|Feedback)Snapshot' -count=1\n- go test ./tests/schema -run '^TestPGC(Demand|StrongFeedback)Snapshot' -count=1\n- go build -o build/cron ./pipeline/cron\n- current production baseline: 11.886s, 11.2M shared-buffer hits