### PR TITLE
fix(console-v2): bypass upgrade gate after onboarding

### DIFF
--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -1,0 +1,162 @@
+package consolev2
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	consoledal "eigenflux_server/api/dal"
+	"eigenflux_server/pkg/reqinfo"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"gorm.io/gorm"
+)
+
+const (
+	heartbeatContractV1 = "eigenflux_heartbeat.v1"
+	minimumConsoleV2CLI = "0.0.34"
+)
+
+var skillRevisionPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
+
+type heartbeatCompatibilityReport struct {
+	ContractVersion string `json:"heartbeat_contract_version"`
+	SkillRevision   string `json:"skill_revision"`
+}
+
+type heartbeatCompatibilityState struct {
+	CLIVersion        string `gorm:"column:cli_version"`
+	HeartbeatContract string `gorm:"column:heartbeat_contract_version"`
+	SkillRevision     string `gorm:"column:skill_revision"`
+	ReportedAt        int64  `gorm:"column:heartbeat_reported_at"`
+	OnboardingState   string `gorm:"column:onboarding_state"`
+}
+
+func (s *Service) reportHeartbeatCompatibility(ctx context.Context, c *app.RequestContext) {
+	agentIDValue, _ := agentID(c)
+	var req heartbeatCompatibilityReport
+	clientInfo := reqinfo.ClientFromContext(ctx)
+	if decodeBody(c, &req) != nil || strings.TrimSpace(clientInfo.CLIVer) == "" ||
+		req.ContractVersion != heartbeatContractV1 || !skillRevisionPattern.MatchString(req.SkillRevision) {
+		fail(c, http.StatusBadRequest, "INVALID_HEARTBEAT_REPORT", "heartbeat compatibility report is invalid", nil)
+		return
+	}
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		return consoledal.UpdateHeartbeatCompatibility(tx, agentIDValue, clientInfo.CLIVer, req.ContractVersion, req.SkillRevision)
+	}); err != nil {
+		fail(c, http.StatusInternalServerError, "HEARTBEAT_REPORT_FAILED", "could not save heartbeat compatibility report", nil)
+		return
+	}
+	reply(c, http.StatusOK, map[string]interface{}{
+		"heartbeat_contract_version": req.ContractVersion,
+		"skill_revision":             req.SkillRevision,
+		"cli_version":                clientInfo.CLIVer,
+	})
+}
+
+func (s *Service) loadConsoleV2Compatibility(agentIDValue int64) (map[string]interface{}, string, error) {
+	var state heartbeatCompatibilityState
+	err := s.db.Raw(`SELECT
+		COALESCE(settings.cli_version, '') AS cli_version,
+		COALESCE(settings.heartbeat_contract_version, '') AS heartbeat_contract_version,
+		COALESCE(settings.skill_revision, '') AS skill_revision,
+		COALESCE(settings.heartbeat_reported_at, 0) AS heartbeat_reported_at,
+		COALESCE(onboarding.state, 'not_started') AS onboarding_state
+		FROM (SELECT ? AS agent_id) current_agent
+		LEFT JOIN agent_settings settings ON settings.agent_id = current_agent.agent_id
+		LEFT JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = current_agent.agent_id`, agentIDValue).Scan(&state).Error
+	if err != nil {
+		return nil, "", err
+	}
+	return consoleV2Compatibility(
+		state.CLIVersion,
+		state.HeartbeatContract,
+		state.SkillRevision,
+		state.ReportedAt,
+		state.OnboardingState == "completed",
+	), state.OnboardingState, nil
+}
+
+// LegacyConsoleCompatibilityHandler is an additive, read-only endpoint for a
+// V1 bearer session. It never changes or gates any existing V1 API.
+func (s *Service) LegacyConsoleCompatibilityHandler() app.HandlerFunc {
+	return func(_ context.Context, c *app.RequestContext) {
+		agentIDValue, ok := agentID(c)
+		if !ok {
+			c.JSON(http.StatusUnauthorized, map[string]interface{}{
+				"code": 401, "msg": "missing authenticated Agent", "data": nil,
+			})
+			return
+		}
+		compatibility, onboardingState, err := s.loadConsoleV2Compatibility(agentIDValue)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, map[string]interface{}{
+				"code": 500, "msg": "could not read Console V2 compatibility", "data": nil,
+			})
+			return
+		}
+		c.Header("Cache-Control", "private, no-store")
+		c.JSON(http.StatusOK, map[string]interface{}{
+			"code": 0, "msg": "success", "data": map[string]interface{}{
+				"compatibility": compatibility,
+				"onboarding":    map[string]interface{}{"state": onboardingState},
+			},
+		})
+	}
+}
+
+func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string, reportedAt int64, onboardingCompleted bool) map[string]interface{} {
+	status := "ready"
+	reason := ""
+	available := true
+	if !onboardingCompleted {
+		switch {
+		case strings.TrimSpace(cliVersion) == "":
+			status, reason, available = "unknown", "report_missing", false
+		case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
+			status, reason, available = "upgrade_required", "cli_outdated", false
+		case heartbeatContract != heartbeatContractV1:
+			status, reason, available = "upgrade_required", "heartbeat_outdated", false
+		case strings.TrimSpace(skillRevision) == "":
+			status, reason, available = "upgrade_required", "skills_unknown", false
+		}
+	}
+	return map[string]interface{}{
+		"available":                           available,
+		"status":                              status,
+		"reason":                              reason,
+		"cli_version":                         cliVersion,
+		"minimum_cli_version":                 minimumConsoleV2CLI,
+		"heartbeat_contract_version":          heartbeatContract,
+		"required_heartbeat_contract_version": heartbeatContractV1,
+		"skill_revision":                      skillRevision,
+		"reported_at":                         reportedAt,
+	}
+}
+
+func compareConsoleCLIVersion(left, right string) int {
+	parse := func(value string) [3]int {
+		var result [3]int
+		value = strings.TrimPrefix(strings.TrimSpace(value), "v")
+		if cut := strings.IndexAny(value, "-+"); cut >= 0 {
+			value = value[:cut]
+		}
+		parts := strings.Split(value, ".")
+		for index := 0; index < len(parts) && index < len(result); index++ {
+			result[index], _ = strconv.Atoi(parts[index])
+		}
+		return result
+	}
+	a, b := parse(left), parse(right)
+	for index := range a {
+		if a[index] < b[index] {
+			return -1
+		}
+		if a[index] > b[index] {
+			return 1
+		}
+	}
+	return 0
+}

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -1,0 +1,126 @@
+package consolev2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestConsoleV2CompatibilityGate(t *testing.T) {
+	tests := []struct {
+		name, cli, contract, revision, status, reason string
+		onboardingCompleted                           bool
+		available                                     bool
+	}{
+		{name: "missing report", status: "unknown", reason: "report_missing"},
+		{name: "old cli", cli: "0.0.33", contract: heartbeatContractV1, revision: "r1", status: "upgrade_required", reason: "cli_outdated"},
+		{name: "old heartbeat", cli: "0.0.34", contract: "legacy", revision: "r1", status: "upgrade_required", reason: "heartbeat_outdated"},
+		{name: "missing skills", cli: "0.0.34", contract: heartbeatContractV1, status: "upgrade_required", reason: "skills_unknown"},
+		{name: "minimum ready", cli: "0.0.34", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
+		{name: "completed onboarding bypasses missing report", onboardingCompleted: true, status: "ready", available: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := consoleV2Compatibility(test.cli, test.contract, test.revision, 123, test.onboardingCompleted)
+			if got["available"] != test.available || got["status"] != test.status || got["reason"] != test.reason {
+				t.Fatalf("compatibility = %#v", got)
+			}
+			if got["minimum_cli_version"] != minimumConsoleV2CLI || got["required_heartbeat_contract_version"] != heartbeatContractV1 {
+				t.Fatalf("gate requirements = %#v", got)
+			}
+		})
+	}
+}
+
+func TestCompareConsoleCLIVersion(t *testing.T) {
+	for _, test := range []struct {
+		left, right string
+		want        int
+	}{
+		{"0.0.33", "0.0.34", -1}, {"v0.0.34", "0.0.34", 0}, {"0.0.35-dev.1", "0.0.34", 1},
+	} {
+		if got := compareConsoleCLIVersion(test.left, test.right); got != test.want {
+			t.Fatalf("compare(%q,%q)=%d want %d", test.left, test.right, got, test.want)
+		}
+	}
+}
+
+func TestLegacyConsoleCompatibilityHandlerBypassesCompletedOnboarding(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE agent_settings (
+			agent_id INTEGER PRIMARY KEY, cli_version TEXT,
+			heartbeat_contract_version TEXT, skill_revision TEXT,
+			heartbeat_reported_at INTEGER
+		)`,
+		`CREATE TABLE agent_onboarding_v2 (agent_id INTEGER PRIMARY KEY, state TEXT)`,
+		`INSERT INTO agent_settings
+			(agent_id, cli_version, heartbeat_contract_version, skill_revision, heartbeat_reported_at)
+			VALUES (42, '', '', '', 0)`,
+		`INSERT INTO agent_onboarding_v2 (agent_id, state) VALUES (42, 'completed')`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	service := &Service{db: db}
+	request := app.NewContext(0)
+	request.Set("agent_id", int64(42))
+	service.LegacyConsoleCompatibilityHandler()(context.Background(), request)
+
+	if request.Response.StatusCode() != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", request.Response.StatusCode(), request.Response.Body())
+	}
+	var envelope struct {
+		Code int `json:"code"`
+		Data struct {
+			Compatibility map[string]interface{} `json:"compatibility"`
+			Onboarding    struct {
+				State string `json:"state"`
+			} `json:"onboarding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(request.Response.Body(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Code != 0 || envelope.Data.Onboarding.State != "completed" || envelope.Data.Compatibility["available"] != true {
+		t.Fatalf("unexpected compatibility envelope: %#v", envelope)
+	}
+}
+
+func TestLegacyConsoleCompatibilityHandlerStillGatesIncompleteOnboarding(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE agent_settings (
+			agent_id INTEGER PRIMARY KEY, cli_version TEXT,
+			heartbeat_contract_version TEXT, skill_revision TEXT,
+			heartbeat_reported_at INTEGER
+		)`,
+		`CREATE TABLE agent_onboarding_v2 (agent_id INTEGER PRIMARY KEY, state TEXT)`,
+		`INSERT INTO agent_onboarding_v2 (agent_id, state) VALUES (43, 'in_progress')`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	compatibility, onboardingState, err := (&Service{db: db}).loadConsoleV2Compatibility(43)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if onboardingState != "in_progress" || compatibility["available"] != false || compatibility["reason"] != "report_missing" {
+		t.Fatalf("unexpected incomplete compatibility: state=%q compatibility=%#v", onboardingState, compatibility)
+	}
+}

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -99,18 +99,22 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	var identity struct {
-		AgentName      string `gorm:"column:agent_name"`
-		ShortID        string `gorm:"column:short_id"`
-		Bio            string `gorm:"column:bio"`
-		CreatedAt      int64  `gorm:"column:created_at"`
-		IsOfficial     bool   `gorm:"column:is_official"`
-		BoundEmail     string `gorm:"column:bound_email"`
-		EmailVerified  bool   `gorm:"column:email_verified"`
-		RuntimeName    string `gorm:"column:runtime_name"`
-		RuntimeVersion string `gorm:"column:runtime_version"`
-		RuntimeMode    string `gorm:"column:runtime_mode"`
-		ClientHost     string `gorm:"column:client_host"`
-		DeviceName     string `gorm:"column:device_name"`
+		AgentName           string `gorm:"column:agent_name"`
+		ShortID             string `gorm:"column:short_id"`
+		Bio                 string `gorm:"column:bio"`
+		CreatedAt           int64  `gorm:"column:created_at"`
+		IsOfficial          bool   `gorm:"column:is_official"`
+		BoundEmail          string `gorm:"column:bound_email"`
+		EmailVerified       bool   `gorm:"column:email_verified"`
+		RuntimeName         string `gorm:"column:runtime_name"`
+		RuntimeVersion      string `gorm:"column:runtime_version"`
+		RuntimeMode         string `gorm:"column:runtime_mode"`
+		ClientHost          string `gorm:"column:client_host"`
+		DeviceName          string `gorm:"column:device_name"`
+		CLIVersion          string `gorm:"column:cli_version"`
+		HeartbeatContract   string `gorm:"column:heartbeat_contract_version"`
+		SkillRevision       string `gorm:"column:skill_revision"`
+		HeartbeatReportedAt int64  `gorm:"column:heartbeat_reported_at"`
 	}
 	if err := s.db.Raw(`SELECT a.agent_name, a.short_id, a.bio, a.created_at, a.is_official,
 		COALESCE(b.normalized_email, '') AS bound_email,
@@ -119,7 +123,11 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		COALESCE(settings.runtime_version, '') AS runtime_version,
 		COALESCE(settings.mode, '') AS runtime_mode,
 		COALESCE(settings.client_host, '') AS client_host,
-		COALESCE(settings.device_name, '') AS device_name
+		COALESCE(settings.device_name, '') AS device_name,
+		COALESCE(settings.cli_version, '') AS cli_version,
+		COALESCE(settings.heartbeat_contract_version, '') AS heartbeat_contract_version,
+		COALESCE(settings.skill_revision, '') AS skill_revision,
+		COALESCE(settings.heartbeat_reported_at, 0) AS heartbeat_reported_at
 		FROM agents a
 		LEFT JOIN agent_email_bindings b ON b.agent_id = a.agent_id
 			AND b.status = 'active' AND b.verification_state = 'verified'
@@ -153,6 +161,7 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		"runtime_version":    runtimeVersion,
 		"runtime_mode":       identity.RuntimeMode,
 		"device_name":        identity.DeviceName,
+		"compatibility":      consoleV2Compatibility(identity.CLIVersion, identity.HeartbeatContract, identity.SkillRevision, identity.HeartbeatReportedAt, state.State == "completed"),
 		"onboarding":         state,
 	})
 }

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -321,6 +321,7 @@ func (s *Service) Register(h *server.Hertz) {
 	h.GET("/api/v2/agents/me/principals", s.consoleAuth(false), s.listPrincipals)
 	h.DELETE("/api/v2/agents/me/principals/:principal_id", s.consoleAuth(true), s.revokePrincipal)
 	h.POST("/api/v2/console/handoffs", s.agentAuth("console:handoff:create"), s.createHandoff)
+	h.PUT("/api/v2/agent-settings/heartbeat-compatibility", s.agentAuth("commands:claim"), s.requireCompleted, s.reportHeartbeatCompatibility)
 	h.POST("/api/v2/console/handoffs/exchange", s.requireSameOrigin(), s.exchangeHandoff)
 	h.GET("/api/v2/console/session", s.consoleAuth(false), s.getConsoleSession)
 	h.DELETE("/api/v2/console/session", s.consoleAuth(true), s.deleteConsoleSession)

--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -61,8 +61,11 @@ type AgentSettings struct {
 	// runtime — plugin or CLI-direct — and shown on the dashboard runtime card.
 	// An axis independent of client_host: a plugin's client_host carries the
 	// host+version ("openclaw/1.2.3"), while cli_version is the CLI's own build.
-	CLIVersion       string `gorm:"column:cli_version"`
-	OfficialPMOptout bool   `gorm:"column:official_pm_optout;default:false"`
+	CLIVersion               string `gorm:"column:cli_version"`
+	HeartbeatContractVersion string `gorm:"column:heartbeat_contract_version"`
+	SkillRevision            string `gorm:"column:skill_revision"`
+	HeartbeatReportedAt      int64  `gorm:"column:heartbeat_reported_at"`
+	OfficialPMOptout         bool   `gorm:"column:official_pm_optout;default:false"`
 	// Lang is the user's dashboard display language ("zh"/"en"), console-owned.
 	// Empty means never set; official-account generation falls back to
 	// guessing from the counterpart's content.
@@ -151,6 +154,22 @@ func UpdateAgentReported(db *gorm.DB, agentID int64, feedPref, mode *string, rec
 		vals["show_add_friend"] = *showAddFriend
 	}
 	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).Updates(vals).Error
+}
+
+// UpdateHeartbeatCompatibility records evidence from a successful Heartbeat
+// plan. The CLI version comes from authenticated request metadata.
+func UpdateHeartbeatCompatibility(db *gorm.DB, agentID int64, cliVersion, contractVersion, skillRevision string) error {
+	if _, err := GetSettings(db, agentID); err != nil {
+		return err
+	}
+	now := time.Now().UnixMilli()
+	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).Updates(map[string]interface{}{
+		"cli_version":                cliVersion,
+		"heartbeat_contract_version": contractVersion,
+		"skill_revision":             skillRevision,
+		"heartbeat_reported_at":      now,
+		"updated_at":                 now,
+	}).Error
 }
 
 // UpdateDerivedRuntimeIfNotSuperseded persists request-derived runtime metadata

--- a/api/main.go
+++ b/api/main.go
@@ -348,6 +348,10 @@ func main() {
 	log.Print("Public Agent Card routes registered")
 
 	if consoleV2Service != nil {
+		// Existing V1 bearer sessions use this additive read-only endpoint to
+		// decide whether the new Console bundle should show the runtime upgrade
+		// screen. Existing V1 routes remain unchanged and ungated.
+		h.GET("/api/v1/console/compatibility", middleware.AuthMiddleware(), consoleV2Service.LegacyConsoleCompatibilityHandler())
 		consoleV2Service.Register(h)
 		registerConsoleV2BusinessBFF(h, consoleV2Service, cfg)
 		log.Print("Console V2 routes registered")

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -54,6 +54,7 @@ default local endpoint is `http://localhost:8090/api/v1`.
 | POST | `/api/v1/relations/block` | Bearer | Block user |
 | POST | `/api/v1/relations/unblock` | Bearer | Unblock user |
 | POST | `/api/v1/relations/remark` | Bearer | Update remark/note for a friend |
+| GET | `/api/v1/console/compatibility` | Bearer | Read the additive Console V2 onboarding and runtime compatibility status for an existing V1 session; this endpoint never gates V1 APIs |
 | GET | `/skill.md` | None | Main skill document (index + overview + caching instructions) |
 | GET | `/references/{module}.md` | None | Skill reference modules: `auth`, `onboarding`, `feed`, `publish`, `message` |
 | POST | `/api/v1/agti/quiz/new` | None | AgentRapport quiz: start a session, returns 10 random questions (IP rate limited, 10/min) |

--- a/migrations/000085_console_v2_heartbeat_compatibility.sql
+++ b/migrations/000085_console_v2_heartbeat_compatibility.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+ALTER TABLE agent_settings
+    ADD COLUMN IF NOT EXISTS heartbeat_contract_version VARCHAR(64) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS skill_revision VARCHAR(128) NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS heartbeat_reported_at BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE agent_settings
+    DROP COLUMN IF EXISTS heartbeat_reported_at,
+    DROP COLUMN IF EXISTS skill_revision,
+    DROP COLUMN IF EXISTS heartbeat_contract_version;

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -104,3 +104,23 @@ func TestAttentionContractPersistsItemAndCommandProtocol(t *testing.T) {
 		}
 	}
 }
+
+func TestHeartbeatCompatibilityMigrationIsAdditive(t *testing.T) {
+	sql := migration(t, "000085_console_v2_heartbeat_compatibility.sql")
+	up, _, ok := strings.Cut(sql, "-- +goose Down")
+	if !ok {
+		t.Fatal("heartbeat compatibility migration has no Down boundary")
+	}
+	for _, required := range []string{
+		"ADD COLUMN IF NOT EXISTS heartbeat_contract_version",
+		"ADD COLUMN IF NOT EXISTS skill_revision",
+		"ADD COLUMN IF NOT EXISTS heartbeat_reported_at",
+	} {
+		if !strings.Contains(up, required) {
+			t.Fatalf("heartbeat compatibility migration missing %q", required)
+		}
+	}
+	if strings.Contains(up, "DROP ") || strings.Contains(up, "UPDATE ") {
+		t.Fatal("heartbeat compatibility Up must remain additive and avoid table rewrites")
+	}
+}


### PR DESCRIPTION
## Summary
- add an authenticated, read-only V1 compatibility endpoint for the new Console bundle
- report completed Console V2 onboarding in the compatibility response and allow completed accounts even without new Heartbeat evidence
- add additive heartbeat compatibility columns and the Agent report endpoint
- leave every existing V1 route and behavior unchanged

## Verification
- go test ./api/... ./migrations -count=1
- go build -o build/api ./api
- migration contract test confirms additive Up with no UPDATE or DROP
- completed and incomplete onboarding compatibility tests