### PR TITLE
fix(console-v2): preserve completed agent scopes

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -319,7 +319,9 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 		fail(c, http.StatusServiceUnavailable, "ID_GENERATION_FAILED", "could not allocate Agent identity", nil)
 		return
 	}
-	initialScopes := []string{"onboarding:write", "context:read", "feed:read", "notifications:ack", "commands:claim", "console:handoff:create"}
+	onboardingState := "in_progress"
+	nextStep := int16(2)
+	initialScopes := principalScopesForOnboarding(onboardingState)
 	keyFingerprint := fingerprint(publicKey)
 	observedRuntime, _ := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
 	var agentID, principalID, expiresAt int64
@@ -341,10 +343,14 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 			RotationRequestHash string         `gorm:"column:rotation_request_hash"`
 			Scopes              pq.StringArray `gorm:"column:scopes;type:text[]"`
 			PrincipalStatus     string         `gorm:"column:principal_status"`
+			OnboardingState     string         `gorm:"column:onboarding_state"`
+			CurrentStep         int16          `gorm:"column:current_step"`
 		}
 		if err := tx.Raw(`SELECT p.agent_id, cs.principal_id, cs.expires_at, cs.absolute_expires_at,
-			cs.revoked_at, cs.rotation_request_hash, cs.scopes, p.status AS principal_status
+			cs.revoked_at, cs.rotation_request_hash, cs.scopes, p.status AS principal_status,
+			COALESCE(o.state, 'in_progress') AS onboarding_state, COALESCE(o.current_step, 2) AS current_step
 			FROM agent_principals p JOIN agent_credential_sessions cs ON cs.principal_id = p.principal_id
+			LEFT JOIN agent_onboarding_v2 o ON o.agent_id = p.agent_id
 			WHERE p.key_type = 'ed25519-v1' AND p.key_fingerprint = ?
 			  AND cs.rotation_request_id = ? FOR UPDATE OF cs`, keyFingerprint,
 			"provision:"+req.IdempotencyKey).Scan(&receipt).Error; err != nil {
@@ -359,7 +365,12 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 				return errUnauthorized
 			}
 			agentID, principalID, expiresAt = receipt.AgentID, receipt.PrincipalID, receipt.ExpiresAt
-			initialScopes = []string(receipt.Scopes)
+			onboardingState, nextStep = receipt.OnboardingState, receipt.CurrentStep
+			initialScopes = principalScopesForOnboarding(onboardingState)
+			if err := tx.Exec(`UPDATE agent_credential_sessions SET scopes = ? WHERE principal_id = ? AND rotation_request_id = ?`,
+				pq.Array(initialScopes), principalID, "provision:"+req.IdempotencyKey).Error; err != nil {
+				return err
+			}
 			return nil
 		}
 		var grant struct {
@@ -385,12 +396,16 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 		}
 
 		var existing struct {
-			PrincipalID int64  `gorm:"column:principal_id"`
-			AgentID     int64  `gorm:"column:agent_id"`
-			Status      string `gorm:"column:status"`
+			PrincipalID     int64  `gorm:"column:principal_id"`
+			AgentID         int64  `gorm:"column:agent_id"`
+			Status          string `gorm:"column:status"`
+			OnboardingState string `gorm:"column:onboarding_state"`
+			CurrentStep     int16  `gorm:"column:current_step"`
 		}
-		if err := tx.Raw(`SELECT principal_id, agent_id, status FROM agent_principals
-			WHERE key_type = 'ed25519-v1' AND key_fingerprint = ?`, keyFingerprint).Scan(&existing).Error; err != nil {
+		if err := tx.Raw(`SELECT p.principal_id, p.agent_id, p.status,
+			COALESCE(o.state, 'in_progress') AS onboarding_state, COALESCE(o.current_step, 2) AS current_step
+			FROM agent_principals p LEFT JOIN agent_onboarding_v2 o ON o.agent_id = p.agent_id
+			WHERE p.key_type = 'ed25519-v1' AND p.key_fingerprint = ?`, keyFingerprint).Scan(&existing).Error; err != nil {
 			return err
 		}
 		if existing.PrincipalID != 0 {
@@ -398,6 +413,8 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 				return errUnauthorized
 			}
 			agentID, principalID = existing.AgentID, existing.PrincipalID
+			onboardingState, nextStep = existing.OnboardingState, existing.CurrentStep
+			initialScopes = principalScopesForOnboarding(onboardingState)
 		} else {
 			agentID = newAgentID
 			aliasToken, tokenErr := randomToken("", 18)
@@ -502,8 +519,8 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 		"access_token":     accessToken,
 		"refresh_token":    refreshToken,
 		"expires_at":       expiresAt,
-		"onboarding_state": "in_progress",
-		"next_step":        2,
+		"onboarding_state": onboardingState,
+		"next_step":        nextStep,
 		"scopes":           initialScopes,
 	})
 }

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -442,6 +442,25 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		Scan(&profileCompletedAt).Error; err != nil || profileCompletedAt == nil {
 		t.Fatalf("V2 onboarding did not mark the profile complete: completed_at=%v err=%v", profileCompletedAt, err)
 	}
+	completedProvision := provision("integration-completed-" + time.Now().Format("150405.000000000"))
+	if completedProvision["agent_id"] != agentID || completedProvision["created"] != false ||
+		completedProvision["onboarding_state"] != "completed" || int16(completedProvision["next_step"].(float64)) != 5 {
+		t.Fatalf("re-provisioned completed Agent lost onboarding state: %#v", completedProvision)
+	}
+	completedScopes := map[string]bool{}
+	for _, raw := range completedProvision["scopes"].([]interface{}) {
+		completedScopes[raw.(string)] = true
+	}
+	for _, required := range []string{"feed:feedback", "communication:read", "profile:read", "settings:write", "attention:write"} {
+		if !completedScopes[required] {
+			t.Fatalf("re-provisioned completed Agent is missing scope %q: %#v", required, completedProvision)
+		}
+	}
+	status, completedProfilePayload, _ := performJSON(t, h, "GET", "/api/v2/agents/me", map[string]interface{}{},
+		ut.Header{Key: "Authorization", Value: "Bearer " + completedProvision["access_token"].(string)})
+	if status != http.StatusOK {
+		t.Fatalf("re-provisioned completed Agent cannot read profile: status=%d payload=%#v", status, completedProfilePayload)
+	}
 	testCommunicationProjection(t, gdb, h, idgen, agentIDInt, cookieHeader)
 	testTelemetryAggregation(t, gdb, h, agentIDInt, cookieHeader, csrf)
 	testActivityCursorReset(t, gdb, h, idgen, agentIDInt, cookieHeader)

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -455,11 +455,12 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		if !completedScopes[required] {
 			t.Fatalf("re-provisioned completed Agent is missing scope %q: %#v", required, completedProvision)
 		}
-	}
-	status, completedProfilePayload, _ := performJSON(t, h, "GET", "/api/v2/agents/me", map[string]interface{}{},
-		ut.Header{Key: "Authorization", Value: "Bearer " + completedProvision["access_token"].(string)})
-	if status != http.StatusOK {
-		t.Fatalf("re-provisioned completed Agent cannot read profile: status=%d payload=%#v", status, completedProfilePayload)
+		var stored int64
+		if err := gdb.Raw(`SELECT COUNT(*) FROM agent_credential_sessions
+			WHERE access_token_hash = ? AND ? = ANY(scopes)`,
+			hashString(completedProvision["access_token"].(string)), required).Scan(&stored).Error; err != nil || stored != 1 {
+			t.Fatalf("re-provisioned completed Agent session did not persist scope %q: count=%d err=%v", required, stored, err)
+		}
 	}
 	testCommunicationProjection(t, gdb, h, idgen, agentIDInt, cookieHeader)
 	testTelemetryAggregation(t, gdb, h, agentIDInt, cookieHeader, csrf)

--- a/migrations/000088_repair_completed_agent_v2_session_scopes.sql
+++ b/migrations/000088_repair_completed_agent_v2_session_scopes.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+UPDATE agent_credential_sessions AS session
+SET scopes = ARRAY(
+    SELECT DISTINCT scope
+    FROM unnest(session.scopes || ARRAY[
+        'feed:feedback', 'communication:read', 'communication:write',
+        'relations:read', 'relations:write', 'broadcast:write',
+        'profile:read', 'profile:write', 'settings:read', 'settings:write',
+        'trade:write', 'attention:write'
+    ]::text[]) AS scope
+)
+WHERE session.audience = 'agent_v2'
+  AND session.revoked_at IS NULL
+  AND session.expires_at > (extract(epoch FROM clock_timestamp()) * 1000)::bigint
+  AND EXISTS (
+      SELECT 1
+      FROM agent_principals principal
+      JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = principal.agent_id
+      WHERE principal.principal_id = session.principal_id
+        AND principal.revoked_at IS NULL
+        AND principal.status = 'active'
+        AND onboarding.state = 'completed'
+  );
+
+-- +goose Down
+-- Scope repair is intentionally irreversible. Removing scopes from active
+-- completed sessions would break already-authorized Agent runtimes.

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -156,3 +156,17 @@ func TestConsoleV2ConnectionAuthUnificationMigration(t *testing.T) {
 		}
 	}
 }
+
+func TestCompletedAgentV2SessionScopeRepairMigration(t *testing.T) {
+	sql := migration(t, "000088_repair_completed_agent_v2_session_scopes.sql")
+	for _, required := range []string{
+		"session.audience = 'agent_v2'", "session.revoked_at IS NULL",
+		"session.expires_at >", "onboarding.state = 'completed'",
+		"principal.status = 'active'", "'feed:feedback'", "'communication:read'",
+		"'profile:read'", "'settings:write'", "'attention:write'",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("completed Agent V2 scope repair missing %q", required)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- preserve completed Agent V2 onboarding state and full scopes on repeat provision
- repair existing active sessions that were downgraded to onboarding-only scopes
- add integration and migration contract coverage

## Verification
- go test ./api/consolev2 ./rpc/auth ./ws/handler ./migrations
- full go test ./... passed except integration packages requiring local PostgreSQL/Redis (connection refused)