### PR TITLE
feat(agent-card): expose top broadcasts with engagement

### DIFF
--- a/migrations/000089_agentcard_top5_all_scores_index.sql
+++ b/migrations/000089_agentcard_top5_all_scores_index.sql
@@ -1,0 +1,35 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- Agent Card Top 5 must include completed broadcasts with zero score. The
+-- older partial index only covered positive scores and therefore cannot serve
+-- the complete per-agent ordering.
+SET lock_timeout = '5s';
+SET statement_timeout = '30min';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_item_stats_author_top_score
+    ON item_stats(author_agent_id, total_score DESC, item_id ASC);
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class AS c
+        JOIN pg_index AS i ON i.indexrelid = c.oid
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'idx_item_stats_author_top_score'
+          AND i.indrelid = 'public.item_stats'::regclass
+          AND NOT i.indisvalid
+    ) THEN
+        RAISE EXCEPTION 'idx_item_stats_author_top_score is invalid; run scripts/common/migrate_up.sh to repair it';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+SET lock_timeout = '5s';
+SET statement_timeout = '30min';
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_item_stats_author_top_score;

--- a/pkg/agentcard/builder.go
+++ b/pkg/agentcard/builder.go
@@ -29,9 +29,12 @@ const rebuildLockTTL = 2 * time.Minute
 
 // TopItem is one entry of influence.top_items.
 type TopItem struct {
-	ItemID  string `json:"item_id"`
-	Score   int64  `json:"score"`
-	Summary string `json:"summary,omitempty"`
+	ItemID      string `json:"item_id"`
+	Score       int64  `json:"score"`
+	Summary     string `json:"summary,omitempty"`
+	Content     string `json:"content,omitempty"`
+	PraiseCount int64  `json:"praise_count"`
+	PublishedAt int64  `json:"published_at"`
 }
 
 type agentInfluenceFacts struct {
@@ -184,7 +187,7 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 	if err != nil {
 		return err
 	}
-	topItems, err := loadTopItems(gdb, agentID, 10)
+	topItems, err := loadTopItems(gdb, agentID, 5)
 	if err != nil {
 		return err
 	}
@@ -393,18 +396,29 @@ func loadAgentInfluence(gdb *gorm.DB, agentID int64) (agentInfluenceFacts, error
 	}, nil
 }
 
-// loadTopItems returns the agent's highest-scored broadcasts. Query failures
-// abort the rebuild so a partial snapshot cannot overwrite a complete card.
+// loadTopItems returns the agent's highest-scored broadcasts. Score is the
+// weighted influence metric; praise_count remains the network's established
+// count of Agents who gave positive feedback. Query failures abort the rebuild
+// so a partial snapshot cannot overwrite a complete card.
 func loadTopItems(gdb *gorm.DB, agentID int64, limit int) ([]TopItem, error) {
 	var rows []struct {
-		ItemID     int64
-		TotalScore int64
-		Summary    string
+		ItemID      int64
+		TotalScore  int64
+		Summary     string
+		Content     string
+		PraiseCount int64
+		PublishedAt int64
 	}
 	err := gdb.Table("item_stats").
-		Select("item_stats.item_id, item_stats.total_score, COALESCE(processed_items.summary, '') as summary").
-		Joins("LEFT JOIN processed_items ON processed_items.item_id = item_stats.item_id").
-		Where("item_stats.author_agent_id = ? AND item_stats.total_score > 0 AND processed_items.status = ?", agentID, itemdal.StatusCompleted).
+		Select(`item_stats.item_id,
+			item_stats.total_score,
+			COALESCE(processed_items.summary, '') AS summary,
+			raw_items.raw_content AS content,
+			(item_stats.score_1_count + item_stats.score_2_count) AS praise_count,
+			raw_items.created_at AS published_at`).
+		Joins("INNER JOIN processed_items ON processed_items.item_id = item_stats.item_id").
+		Joins("INNER JOIN raw_items ON raw_items.item_id = item_stats.item_id").
+		Where("item_stats.author_agent_id = ? AND processed_items.status = ?", agentID, itemdal.StatusCompleted).
 		Order("item_stats.total_score DESC, item_stats.item_id ASC").
 		Limit(limit).
 		Scan(&rows).Error
@@ -418,9 +432,12 @@ func loadTopItems(gdb *gorm.DB, agentID int64, limit int) ([]TopItem, error) {
 			summary = string(rs[:200])
 		}
 		out = append(out, TopItem{
-			ItemID:  strconv.FormatInt(r.ItemID, 10),
-			Score:   r.TotalScore,
-			Summary: summary,
+			ItemID:      strconv.FormatInt(r.ItemID, 10),
+			Score:       r.TotalScore,
+			Summary:     summary,
+			Content:     r.Content,
+			PraiseCount: r.PraiseCount,
+			PublishedAt: r.PublishedAt,
 		})
 	}
 	return out, nil

--- a/pkg/agentcard/public_card_postgres_test.go
+++ b/pkg/agentcard/public_card_postgres_test.go
@@ -2,6 +2,7 @@ package agentcard_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -56,5 +57,104 @@ func TestEveryPersistedAgentCanBuildAPublicCardOnFirstRead(t *testing.T) {
 	}
 	if card.PublicCard == "" || card.SchemaVersion != agentcard.SchemaVersion {
 		t.Fatalf("invalid public Card projection: %#v", card)
+	}
+}
+
+func TestCardTopItemsExposeFiveHighestScoredBroadcasts(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for PostgreSQL integration semantics")
+	}
+	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := gdb.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	t.Cleanup(func() { _ = tx.Rollback().Error })
+
+	redisServer := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	now := time.Now().UnixMilli()
+	agentID := now*100 + 41
+	itemBase := agentID * 10
+	if err := tx.Exec(`INSERT INTO agents
+		(agent_id, short_id, email, agent_name, bio, created_at, updated_at)
+		VALUES (?, 'TpFiv', ?, 'top-five', '', ?, ?)`, agentID, fmt.Sprintf("top-five-%d@example.test", agentID), now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	type fixture struct {
+		itemID      int64
+		score       int64
+		praiseCount int64
+		content     string
+		publishedAt int64
+	}
+	fixtures := []fixture{
+		{itemID: itemBase + 6, score: 0, praiseCount: 0, content: "sixth zero-score broadcast", publishedAt: now - 6000},
+		{itemID: itemBase + 5, score: 0, praiseCount: 0, content: "fifth zero-score broadcast", publishedAt: now - 5000},
+		{itemID: itemBase + 4, score: 4, praiseCount: 1, content: "fourth broadcast", publishedAt: now - 4000},
+		{itemID: itemBase + 3, score: 12, praiseCount: 5, content: "third broadcast", publishedAt: now - 3000},
+		{itemID: itemBase + 2, score: 8, praiseCount: 3, content: "second broadcast", publishedAt: now - 2000},
+		{itemID: itemBase + 1, score: 15, praiseCount: 7, content: "first broadcast", publishedAt: now - 1000},
+	}
+	for _, f := range fixtures {
+		if err := tx.Exec(`INSERT INTO raw_items(item_id, author_agent_id, raw_content, created_at)
+			VALUES (?, ?, ?, ?)`, f.itemID, agentID, f.content, f.publishedAt).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Exec(`INSERT INTO processed_items(item_id, status, summary, updated_at)
+			VALUES (?, ?, ?, ?)`, f.itemID, 3, "summary-"+f.content, f.publishedAt).Error; err != nil {
+			t.Fatal(err)
+		}
+		// Stats can be created later than the broadcast; published_at must remain
+		// anchored to raw_items.created_at.
+		if err := tx.Exec(`INSERT INTO item_stats(item_id, author_agent_id, score_1_count, total_score, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?)`, f.itemID, agentID, f.praiseCount, f.score, f.publishedAt+500, f.publishedAt+500).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := agentcard.Rebuild(context.Background(), tx, rdb, agentID); err != nil {
+		t.Fatalf("rebuild card: %v", err)
+	}
+	card, err := profiledal.GetAgentCard(tx, agentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projection struct {
+		Influence struct {
+			TopItems []struct {
+				ItemID      string `json:"item_id"`
+				Score       int64  `json:"score"`
+				Summary     string `json:"summary"`
+				Content     string `json:"content"`
+				PraiseCount int64  `json:"praise_count"`
+				PublishedAt int64  `json:"published_at"`
+			} `json:"top_items"`
+		} `json:"influence"`
+	}
+	if err := json.Unmarshal([]byte(card.PublicCard), &projection); err != nil {
+		t.Fatal(err)
+	}
+	got := projection.Influence.TopItems
+	if len(got) != 5 {
+		t.Fatalf("top_items count=%d, want 5", len(got))
+	}
+	// The fifth entry proves completed zero-score broadcasts fill the list when
+	// fewer than five positive-score broadcasts exist. item_id breaks the tie.
+	want := []fixture{fixtures[5], fixtures[3], fixtures[4], fixtures[2], fixtures[1]}
+	for i, f := range want {
+		if got[i].ItemID != fmt.Sprint(f.itemID) || got[i].Score != f.score || got[i].Content != f.content || got[i].PraiseCount != f.praiseCount || got[i].PublishedAt != f.publishedAt {
+			t.Fatalf("top_items[%d]=%+v, want item=%d score=%d content=%q praise=%d published=%d", i, got[i], f.itemID, f.score, f.content, f.praiseCount, f.publishedAt)
+		}
+		if got[i].Summary != "summary-"+f.content {
+			t.Fatalf("top_items[%d] summary=%q, want backward-compatible summary", i, got[i].Summary)
+		}
 	}
 }

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SchemaVersion is the Card JSON schema revision served to clients.
-const SchemaVersion int32 = 4
+const SchemaVersion int32 = 5
 
 // FieldStorage says which fact table owns an editable field. The Card itself
 // is never a fact source.


### PR DESCRIPTION
Summary: expand V2 Agent Card top_items to the highest-scored five broadcasts with original content, Agent praise count, and canonical publish time; preserve existing fields; bump card schema for existing-card rebuilds; add a concurrent supporting index. Compatibility: V1 routes and response contracts are unchanged. Tests: go test -count=1 ./pkg/agentcard ./migrations ./api/agentcard ./api/handler_gen/eigenflux/api; Web contract tests run separately.