### PR TITLE
feat: expose privacy-bounded console DAU aggregate

### DIFF
--- a/migrations/000090_grafana_console_dau_daily.sql
+++ b/migrations/000090_grafana_console_dau_daily.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+
+CREATE VIEW grafana_console_dau_daily
+WITH (security_barrier = true) AS
+SELECT
+    (to_timestamp(usage.time_bucket / 1000.0) AT TIME ZONE 'Asia/Shanghai')::date AS activity_date,
+    count(DISTINCT usage.agent_id) AS human_dau
+FROM console_usage_sessions usage
+JOIN agents agent ON agent.agent_id = usage.agent_id
+WHERE usage.visible_duration_ms > 0
+  AND agent.email NOT LIKE '%bot.eigenflux%'
+  AND agent.email NOT LIKE '%pgc.eigenflux%'
+  AND agent.email <> 'fmw19990718@gmail.com'
+GROUP BY 1;
+
+REVOKE ALL ON grafana_console_dau_daily FROM PUBLIC;
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        GRANT SELECT ON grafana_console_dau_daily TO grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+COMMENT ON VIEW grafana_console_dau_daily IS
+    'Privacy-bounded daily count of real users with visible Console usage, bucketed in Asia/Shanghai for the User Growth dashboard.';
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'grafana_ro_v2') THEN
+        REVOKE SELECT ON grafana_console_dau_daily FROM grafana_ro_v2;
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+DROP VIEW IF EXISTS grafana_console_dau_daily;

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -170,3 +170,24 @@ func TestCompletedAgentV2SessionScopeRepairMigration(t *testing.T) {
 		}
 	}
 }
+
+func TestGrafanaConsoleDAUViewIsAggregatedAndPrivacyBounded(t *testing.T) {
+	sql := migration(t, "000090_grafana_console_dau_daily.sql")
+	for _, required := range []string{
+		"CREATE VIEW grafana_console_dau_daily",
+		"count(DISTINCT usage.agent_id) AS human_dau",
+		"usage.visible_duration_ms > 0",
+		"AT TIME ZONE 'Asia/Shanghai'",
+		"REVOKE ALL ON grafana_console_dau_daily FROM PUBLIC",
+		"GRANT SELECT ON grafana_console_dau_daily TO grafana_ro_v2",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("Grafana Console DAU view contract missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"session_id", "time_bucket AS", "agent_id AS"} {
+		if strings.Contains(sql, forbidden) {
+			t.Fatalf("Grafana Console DAU view exposes private row-level field %q", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
为 User Growth 看板提供真人 DAU 数据源。\n\n- 新增按 Asia/Shanghai 自然日聚合的 grafana_console_dau_daily 视图\n- 仅输出 activity_date 与 human_dau，不暴露 session_id、agent_id 或使用时长明细\n- 仅向 grafana_ro_v2 授予 SELECT\n- 增加 migration 隐私与口径契约测试\n\n验证：Goose migrations validate；go test ./migrations