### PR TITLE
fix(console): restore V1 compatibility probe

### DIFF
--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -34,6 +34,16 @@ type heartbeatCompatibilityState struct {
 	OnboardingState   string `gorm:"column:onboarding_state"`
 }
 
+const loadConsoleV2CompatibilityQuery = `SELECT
+		COALESCE(settings.cli_version, '') AS cli_version,
+		COALESCE(settings.heartbeat_contract_version, '') AS heartbeat_contract_version,
+		COALESCE(settings.skill_revision, '') AS skill_revision,
+		COALESCE(settings.heartbeat_reported_at, 0) AS heartbeat_reported_at,
+		COALESCE(onboarding.state, 'not_started') AS onboarding_state
+		FROM (SELECT CAST(? AS BIGINT) AS agent_id) current_agent
+		LEFT JOIN agent_settings settings ON settings.agent_id = current_agent.agent_id
+		LEFT JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = current_agent.agent_id`
+
 func (s *Service) reportHeartbeatCompatibility(ctx context.Context, c *app.RequestContext) {
 	agentIDValue, _ := agentID(c)
 	var req heartbeatCompatibilityReport
@@ -58,15 +68,7 @@ func (s *Service) reportHeartbeatCompatibility(ctx context.Context, c *app.Reque
 
 func (s *Service) loadConsoleV2Compatibility(agentIDValue int64) (map[string]interface{}, string, error) {
 	var state heartbeatCompatibilityState
-	err := s.db.Raw(`SELECT
-		COALESCE(settings.cli_version, '') AS cli_version,
-		COALESCE(settings.heartbeat_contract_version, '') AS heartbeat_contract_version,
-		COALESCE(settings.skill_revision, '') AS skill_revision,
-		COALESCE(settings.heartbeat_reported_at, 0) AS heartbeat_reported_at,
-		COALESCE(onboarding.state, 'not_started') AS onboarding_state
-		FROM (SELECT ? AS agent_id) current_agent
-		LEFT JOIN agent_settings settings ON settings.agent_id = current_agent.agent_id
-		LEFT JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = current_agent.agent_id`, agentIDValue).Scan(&state).Error
+	err := s.db.Raw(loadConsoleV2CompatibilityQuery, agentIDValue).Scan(&state).Error
 	if err != nil {
 		return nil, "", err
 	}

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -4,12 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestLoadConsoleV2CompatibilityQueryTypesAgentIDAsBigInt(t *testing.T) {
+	if !strings.Contains(loadConsoleV2CompatibilityQuery, "CAST(? AS BIGINT)") {
+		t.Fatalf("compatibility query must cast the bound Agent ID to BIGINT: %s", loadConsoleV2CompatibilityQuery)
+	}
+	if strings.Contains(loadConsoleV2CompatibilityQuery, "SELECT ? AS agent_id") {
+		t.Fatal("compatibility query must not leave the Agent ID bind parameter untyped")
+	}
+}
 
 func TestConsoleV2CompatibilityGate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- type the compatibility probe Agent ID as BIGINT before joining PostgreSQL BIGINT columns
- add a regression contract that rejects an untyped Agent ID bind

## Production evidence
- GET /api/v1/console/compatibility returns 500
- PostgreSQL reports operator does not exist: bigint = text
- broadcasts data endpoints remain healthy

## Verification
- go test ./api/consolev2 -count=1
- targeted compatibility tests
- git diff --check