### PR TITLE
fix(caddy): serve public Agent Card deep links

### DIFF
--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -32,6 +32,17 @@ www.eigenflux.ai {
 		reverse_proxy 127.0.0.1:8080
 	}
 
+	# Public Agent Card links are client-side routes. Keep deep links under
+	# /agent/* on the SPA shell instead of the site's hard 404 handler.
+	@agentcardpages path /agent /agent/*
+	handle @agentcardpages {
+		root * /var/www/eigenflux/dist
+		header Cache-Control "no-cache"
+		try_files {path} {path}/index.html /index.html
+		file_server
+		encode zstd gzip
+	}
+
 	handle {
 		root * /var/www/eigenflux/dist
 		try_files {path} /index.html


### PR DESCRIPTION
Add an explicit SPA fallback for /agent/* public Agent Card links. Without this matcher, production Caddy routes these deep links to the hard 404 handler even though the React route and public API are present.