### PR TITLE
fix(console-v2): report CLI version during handoff

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -503,7 +503,8 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 	// Provision is the first authenticated request in Console V2 onboarding.
 	// Persist its validated, self-reported product identity synchronously so the
 	// claim page can name the actual runtime before the first settings heartbeat.
-	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName); err != nil {
+	cliVersion := strings.TrimSpace(string(c.GetHeader("X-CLI-Ver")))
+	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName, cliVersion); err != nil {
 		fail(c, http.StatusInternalServerError, "PROVISION_CLIENT_REPORT_FAILED", "could not record Agent client identity", nil)
 		return
 	}
@@ -835,7 +836,8 @@ func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_DEVICE_NAME", "device name is invalid", nil)
 		return
 	}
-	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName); err != nil {
+	cliVersion := strings.TrimSpace(string(c.GetHeader("X-CLI-Ver")))
+	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName, cliVersion); err != nil {
 		fail(c, http.StatusInternalServerError, "HANDOFF_CLIENT_REPORT_FAILED", "could not record Console client identity", nil)
 		return
 	}

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -227,6 +227,7 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		req.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, transcript))
 		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agent-identities/provision", req,
 			ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.3.14"},
+			ut.Header{Key: "X-CLI-Ver", Value: "0.0.34"},
 			ut.Header{Key: "X-Client-Device-Name", Value: "Provision-MacBook"})
 		if status != 200 {
 			t.Fatalf("provision status=%d payload=%#v", status, payload)
@@ -243,6 +244,10 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	t.Cleanup(func() { gdb.Exec(`DELETE FROM agents WHERE agent_id = ?`, agentID) })
 	if first["created"] != true {
 		t.Fatal("first provision did not create the Agent")
+	}
+	var provisionedCLIVersion string
+	if err := gdb.Raw(`SELECT cli_version FROM agent_settings WHERE agent_id = ?`, agentIDInt).Scan(&provisionedCLIVersion).Error; err != nil || provisionedCLIVersion != "0.0.34" {
+		t.Fatalf("provisioned CLI version=%q err=%v", provisionedCLIVersion, err)
 	}
 	provisionReplay := provision(firstEntitlement)
 	if provisionReplay["agent_id"] != agentID || provisionReplay["access_token"] != originalAccessToken ||
@@ -362,6 +367,7 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	status, handoffPayload, _ := performJSON(t, h, "POST", "/api/v2/console/handoffs", map[string]interface{}{"browser_nonce": browserNonce},
 		ut.Header{Key: "Authorization", Value: "Bearer " + accessToken},
 		ut.Header{Key: "X-Client-Host", Value: "codex"},
+		ut.Header{Key: "X-CLI-Ver", Value: "0.0.35"},
 		ut.Header{Key: "X-Client-Device-Name", Value: "Lynn-MacBook-Pro"})
 	if status != 201 {
 		t.Fatalf("handoff status=%d payload=%#v", status, handoffPayload)
@@ -436,6 +442,10 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	}
 	if session["device_name"] != "Lynn-MacBook-Pro" {
 		t.Fatalf("console session did not expose the handoff computer name: %#v", session)
+	}
+	compatibility := session["compatibility"].(map[string]interface{})
+	if compatibility["cli_version"] != "0.0.35" {
+		t.Fatalf("console session did not expose the handoff CLI version: %#v", compatibility)
 	}
 	var profileCompletedAt *int64
 	if err := gdb.Raw(`SELECT profile_completed_at FROM agents WHERE agent_id = ?`, agentIDInt).

--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -225,14 +225,17 @@ func UpdateRuntimeIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersi
 }
 
 // UpdateHandoffClientIdentity records the computer that generated a Console
-// handoff and, when present, the current Agent product identity in one write.
-func UpdateHandoffClientIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion, deviceName string) error {
+// handoff and, when present, the current Agent product and CLI identity in one write.
+func UpdateHandoffClientIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion, deviceName, cliVersion string) error {
 	vals := map[string]interface{}{}
 	now := time.Now().UnixMilli()
 	if runtimeName != "" {
 		vals["runtime_name"] = runtimeName
 		vals["runtime_version"] = runtimeVersion
 		vals["runtime_reported_at"] = now
+	}
+	if cliVersion != "" {
+		vals["cli_version"] = cliVersion
 	}
 	// The provision/handoff represents the current computer. Clear a stale value
 	// when an older CLI cannot report it instead of displaying another machine.

--- a/api/dal/runtime_identity_fence_test.go
+++ b/api/dal/runtime_identity_fence_test.go
@@ -46,3 +46,35 @@ func TestUpdateDerivedRuntimeIfNotSuperseded(t *testing.T) {
 		t.Fatalf("old feed overwrote explicit identity: %+v", current)
 	}
 }
+
+func TestUpdateHandoffClientIdentityReportsCLIVersion(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.AutoMigrate(&AgentSettings{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Create(&AgentSettings{AgentID: 102, CLIVersion: "0.0.33"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateHandoffClientIdentity(database, 102, "codex", "1.2.3", "Lynn-MacBook-Pro", "0.0.35"); err != nil {
+		t.Fatal(err)
+	}
+	var current AgentSettings
+	if err := database.First(&current, "agent_id = ?", 102).Error; err != nil {
+		t.Fatal(err)
+	}
+	if current.CLIVersion != "0.0.35" || current.RuntimeName != "codex" || current.DeviceName != "Lynn-MacBook-Pro" {
+		t.Fatalf("handoff identity = %#v", current)
+	}
+	if err := UpdateHandoffClientIdentity(database, 102, "codex", "1.2.3", "Lynn-MacBook-Pro", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.First(&current, "agent_id = ?", 102).Error; err != nil {
+		t.Fatal(err)
+	}
+	if current.CLIVersion != "0.0.35" {
+		t.Fatalf("headerless handoff cleared CLI version: %#v", current)
+	}
+}


### PR DESCRIPTION
## Summary
- persist X-CLI-Ver during Agent V2 provision
- refresh CLI version when generating a Console handoff
- preserve the previous version when older clients omit the header

## Tests
- GOCACHE=/private/tmp/eigenflux-go-cache go test ./api/dal
- GOCACHE=/private/tmp/eigenflux-go-cache go test ./api/consolev2