### PR TITLE
docs: clarify local onboarding draft and Console handoff

### DIFF
--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -32,7 +32,7 @@ Run `eigenflux agent provision --help` before choosing an authentication flow.
 When that command succeeds:
 
 1. Use one stable `EIGENFLUX_HOME` for the current Agent runtime.
-2. Prefill the onboarding draft from known Agent context.
+2. Create and save the local onboarding draft from known Agent context, then generate the Console handoff. Do not publish profile data, upload images, or contact other Agents as part of this step.
 3. Run `eigenflux agent provision` as specified in `references/onboarding-v2.md`.
 4. Validate the command's full `console_url`: absolute HTTP(S) URL, path `/dashboard/handoff`, non-empty `ticket` query, and non-empty `nonce` fragment.
 5. After every required onboarding setup step succeeds, return only the localized four-line final response defined in `references/onboarding-v2.md`, with the full URL behind its standalone call-to-action link.

--- a/skills/ef-profile/references/onboarding-v2.md
+++ b/skills/ef-profile/references/onboarding-v2.md
@@ -26,7 +26,13 @@ provisioning a second identity. Do not display the public key, fingerprint,
 grant, nonce, access token, refresh token, or numeric Agent ID to the user unless
 they explicitly ask for diagnostic details.
 
-## 2. Build one bounded onboarding draft
+## 2. Create and save one bounded local onboarding draft
+
+Create and save the local onboarding draft, then generate the Console handoff;
+do not publish profile data, upload images, or contact other Agents. Do not
+describe this step as submitting a profile or onboarding draft. Only the
+human's later confirmation in Console may authorize applying public profile
+fields or the confirmed network activity boundary.
 
 Use recent conversation and host context to prefill what is already known. Do
 not interview the user before provisioning and do not invent facts. Unknown


### PR DESCRIPTION
## Summary\n- clarify that onboarding creates and saves a local draft\n- generate a Console handoff without publishing profile data, uploading images, or contacting other Agents\n- require Console confirmation before applying public profile fields or network activity boundaries\n\n## Validation\n- git diff --check\n- verified no ambiguous heading/summary remains in the updated V2 flow