### PR TITLE
fix(console-v2): preserve existing Agent name

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -299,6 +299,12 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	req.Draft = normalizedDraft
+	// The draft is the source of truth for the Agent Card prefill. The CLI keeps
+	// a legacy top-level agent_name flag for compatibility and defaults it to
+	// "EigenFlux Agent"; allowing that default to win would discard a name
+	// supplied in the V2 draft. Existing key-bound identities never enter the
+	// creation path below, so their persisted name remains unchanged.
+	req.AgentName = effectiveProvisionAgentName(req.AgentName, draftObject)
 	initialProvenance, err := json.Marshal(deriveInitialProvenance(draftObject, provenanceAgent, req.FieldProvenance, wallNow))
 	if err != nil {
 		fail(c, http.StatusBadRequest, "INVALID_DRAFT", "could not derive onboarding field sources", nil)
@@ -524,6 +530,18 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 		"next_step":        nextStep,
 		"scopes":           initialScopes,
 	})
+}
+
+func effectiveProvisionAgentName(topLevelName string, draft map[string]interface{}) string {
+	if value, exists := draftPathValue(draft, "identity_card.agent_name"); exists {
+		if draftName, ok := value.(string); ok && strings.TrimSpace(draftName) != "" {
+			return draftName
+		}
+	}
+	if strings.TrimSpace(topLevelName) != "" {
+		return topLevelName
+	}
+	return "EigenFlux Agent"
 }
 
 func insertProvisionedAgent(tx *gorm.DB, agentID int64, alias, agentName string, now int64) error {

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -95,6 +95,42 @@ func TestProvisionTranscriptVerifiesAndCoversMutableFields(t *testing.T) {
 	}
 }
 
+func TestEffectiveProvisionAgentNamePrefersDraftName(t *testing.T) {
+	tests := []struct {
+		name     string
+		topLevel string
+		draft    map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "draft name wins over CLI default",
+			topLevel: "EigenFlux Agent",
+			draft: map[string]interface{}{
+				"identity_card": map[string]interface{}{"agent_name": "Codex Agent"},
+			},
+			expected: "Codex Agent",
+		},
+		{
+			name:     "explicit top-level name remains a fallback",
+			topLevel: "Explicit Agent",
+			draft:    map[string]interface{}{"identity_card": map[string]interface{}{}},
+			expected: "Explicit Agent",
+		},
+		{
+			name:     "empty request uses the V2 default",
+			draft:    map[string]interface{}{},
+			expected: "EigenFlux Agent",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveProvisionAgentName(tt.topLevel, tt.draft); got != tt.expected {
+				t.Fatalf("effectiveProvisionAgentName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizeDeviceName(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary\n- prefer the V2 onboarding draft's identity_card.agent_name over the legacy CLI default\n- keep the top-level name only as a fallback\n- add regression coverage for draft/default precedence\n\n## Verification\n- go test ./api/consolev2\n- git diff --check