### PR TITLE
fix(console-v2): remove heartbeat contract availability gate

### DIFF
--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -20,6 +20,7 @@ const (
 )
 
 var skillRevisionPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
+var heartbeatContractPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
 
 type heartbeatCompatibilityReport struct {
 	ContractVersion string `json:"heartbeat_contract_version"`
@@ -49,7 +50,7 @@ func (s *Service) reportHeartbeatCompatibility(ctx context.Context, c *app.Reque
 	var req heartbeatCompatibilityReport
 	clientInfo := reqinfo.ClientFromContext(ctx)
 	if decodeBody(c, &req) != nil || strings.TrimSpace(clientInfo.CLIVer) == "" ||
-		req.ContractVersion != heartbeatContractV1 || !skillRevisionPattern.MatchString(req.SkillRevision) {
+		!heartbeatContractPattern.MatchString(req.ContractVersion) || !skillRevisionPattern.MatchString(req.SkillRevision) {
 		fail(c, http.StatusBadRequest, "INVALID_HEARTBEAT_REPORT", "heartbeat compatibility report is invalid", nil)
 		return
 	}
@@ -119,8 +120,6 @@ func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string,
 			status, reason, available = "unknown", "report_missing", false
 		case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
 			status, reason, available = "upgrade_required", "cli_outdated", false
-		case heartbeatContract != heartbeatContractV1:
-			status, reason, available = "upgrade_required", "heartbeat_outdated", false
 		case strings.TrimSpace(skillRevision) == "":
 			status, reason, available = "upgrade_required", "skills_unknown", false
 		}

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -29,7 +29,7 @@ func TestConsoleV2CompatibilityGate(t *testing.T) {
 	}{
 		{name: "missing report", status: "unknown", reason: "report_missing"},
 		{name: "old cli", cli: "0.0.33", contract: heartbeatContractV1, revision: "r1", status: "upgrade_required", reason: "cli_outdated"},
-		{name: "old heartbeat", cli: "0.0.34", contract: "legacy", revision: "r1", status: "upgrade_required", reason: "heartbeat_outdated"},
+		{name: "old heartbeat is accepted", cli: "0.0.34", contract: "legacy", revision: "r1", status: "ready", available: true},
 		{name: "missing skills", cli: "0.0.34", contract: heartbeatContractV1, status: "upgrade_required", reason: "skills_unknown"},
 		{name: "minimum ready", cli: "0.0.34", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
 		{name: "completed onboarding bypasses missing report", onboardingCompleted: true, status: "ready", available: true},


### PR DESCRIPTION
Remove the legacy Heartbeat contract version from the Console availability gate. Keep recording the reported contract and validate its format, while allowing CLI >= 0.0.34 with a known Skills revision to use the Console.

Test: go test ./api/consolev2