### PR TITLE
fix(console-v2): remove Skills revision availability gate

### DIFF
--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -120,8 +120,6 @@ func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string,
 			status, reason, available = "unknown", "report_missing", false
 		case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
 			status, reason, available = "upgrade_required", "cli_outdated", false
-		case strings.TrimSpace(skillRevision) == "":
-			status, reason, available = "upgrade_required", "skills_unknown", false
 		}
 	}
 	return map[string]interface{}{

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -30,7 +30,7 @@ func TestConsoleV2CompatibilityGate(t *testing.T) {
 		{name: "missing report", status: "unknown", reason: "report_missing"},
 		{name: "old cli", cli: "0.0.33", contract: heartbeatContractV1, revision: "r1", status: "upgrade_required", reason: "cli_outdated"},
 		{name: "old heartbeat is accepted", cli: "0.0.34", contract: "legacy", revision: "r1", status: "ready", available: true},
-		{name: "missing skills", cli: "0.0.34", contract: heartbeatContractV1, status: "upgrade_required", reason: "skills_unknown"},
+		{name: "missing skills is accepted", cli: "0.0.34", contract: heartbeatContractV1, status: "ready", available: true},
 		{name: "minimum ready", cli: "0.0.34", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
 		{name: "completed onboarding bypasses missing report", onboardingCompleted: true, status: "ready", available: true},
 	}


### PR DESCRIPTION
Allow Console V2 availability when CLI meets the minimum and the legacy Heartbeat contract is tolerated, without requiring a reported Skills revision. Continue returning Skills revision telemetry.

Test: go test ./api/consolev2