### PR TITLE
fix(console-v2): extend browser session lifetime

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -1014,7 +1014,7 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 					 status, scopes, issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method)
 				VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, 'handoff')`, sessionID, hashString(sessionSecret),
 			agentIDValue, principalID, hashString(csrfSecret), pq.Array([]string(scopes)), now,
-			now+int64(30*time.Minute/time.Millisecond), now+int64(12*time.Hour/time.Millisecond), now).Error
+			now+int64(consoleIdleTTL/time.Millisecond), now+int64(consoleAbsoluteTTL/time.Millisecond), now).Error
 	})
 	if errors.Is(err, errUnauthorized) {
 		fail(c, http.StatusUnauthorized, "HANDOFF_INVALID", "handoff is invalid, consumed, or expired", nil)
@@ -1024,8 +1024,8 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusInternalServerError, "HANDOFF_EXCHANGE_FAILED", "could not establish Console V2 session", nil)
 		return
 	}
-	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int((12*time.Hour)/time.Second))
-	s.setCSRFCookie(c, csrfSecret, int((12*time.Hour)/time.Second))
+	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setCSRFCookie(c, csrfSecret, int(consoleAbsoluteTTL/time.Second))
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":   fmt.Sprintf("%d", agentIDValue),
 		"csrf_token": csrfSecret,

--- a/api/consolev2/email_handlers.go
+++ b/api/consolev2/email_handlers.go
@@ -733,7 +733,7 @@ func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {
 			VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, 'email_otp', ?)`, sessionID, hashString(sessionSecret),
 			recoveredAgentID, principal.PrincipalID, hashString(csrfSecret),
 			pq.Array([]string{"console:onboarding", "console:read", "console:write"}), now,
-			now+int64(30*time.Minute/time.Millisecond), now+int64(12*time.Hour/time.Millisecond), now, now).Error
+			now+int64(consoleIdleTTL/time.Millisecond), now+int64(consoleAbsoluteTTL/time.Millisecond), now, now).Error
 	})
 	if errors.Is(err, errUnauthorized) || (!validOTP && err == nil) {
 		fail(c, http.StatusUnauthorized, "OTP_INVALID", "verification code is invalid or expired", nil)
@@ -743,8 +743,8 @@ func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusInternalServerError, "EMAIL_LOGIN_FAILED", "could not establish Console V2 session", nil)
 		return
 	}
-	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int((12*time.Hour)/time.Second))
-	s.setCSRFCookie(c, csrfSecret, int((12*time.Hour)/time.Second))
+	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setCSRFCookie(c, csrfSecret, int(consoleAbsoluteTTL/time.Second))
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id": fmt.Sprintf("%d", recoveredAgentID), "csrf_token": csrfSecret,
 	})

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -42,14 +42,19 @@ import (
 const (
 	consoleCookieName = "ef_console_v2"
 	csrfCookieName    = "ef_console_v2_csrf"
-	accessTTL         = 15 * time.Minute
-	refreshTTL        = 30 * 24 * time.Hour
-	handoffTTL        = 15 * time.Minute
-	grantTTL          = 5 * time.Minute
-	proofClockSkew    = 5 * time.Minute
-	maxRequestBytes   = 256 << 10
-	maxAgentStreams   = 3
-	maxProcessStreams = 1000
+	// Browser sessions use a long idle window while retaining a hard upper
+	// bound. Keep these values centralized so handoff and email-OTP login
+	// cannot drift apart.
+	consoleIdleTTL     = 30 * 24 * time.Hour
+	consoleAbsoluteTTL = 180 * 24 * time.Hour
+	accessTTL          = 15 * time.Minute
+	refreshTTL         = 30 * 24 * time.Hour
+	handoffTTL         = 15 * time.Minute
+	grantTTL           = 5 * time.Minute
+	proofClockSkew     = 5 * time.Minute
+	maxRequestBytes    = 256 << 10
+	maxAgentStreams    = 3
+	maxProcessStreams  = 1000
 )
 
 var (
@@ -617,7 +622,7 @@ func (s *Service) consoleAuth(requireCSRF bool) app.HandlerFunc {
 		}
 		// Sliding activity is throttled to one write per five minutes.
 		if now-session.LastSeenAt >= int64(5*time.Minute/time.Millisecond) {
-			idle := now + int64(30*time.Minute/time.Millisecond)
+			idle := now + int64(consoleIdleTTL/time.Millisecond)
 			if idle > session.AbsoluteExpiry {
 				idle = session.AbsoluteExpiry
 			}


### PR DESCRIPTION
将 Console V2 浏览器会话统一调整为空闲 30 天、绝对 180 天，并同步延长会话/CSRF Cookie Max-Age。handoff 与邮箱 OTP 使用同一策略。已通过 go test ./api/consolev2。