### PR TITLE
fix(console-v2): persist heartbeat CLI version

### DIFF
--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -425,7 +425,7 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		t.Fatalf("email binding verify status=%d payload=%#v", status, bindPayload)
 	}
 
-	revision := int64(2)
+	revision := int64(3)
 	for step := int16(3); step <= 5; step++ {
 		status, payload, _ := performJSON(t, h, "POST", "/api/v2/agents/me/onboarding-draft/confirm", confirmStepRequest{
 			Step: step, ExpectedOnboardingRevision: revision, IdempotencyKey: "confirm-" + agentID + fmt.Sprint(step),

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -395,7 +395,9 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	}
 
 	status, unboundConfirmPayload, _ := performJSON(t, h, "POST", "/api/v2/agents/me/onboarding-draft/confirm", confirmStepRequest{
-		Step: 2, ExpectedOnboardingRevision: 1, IdempotencyKey: "confirm-unbound-" + agentID,
+		// The repeated provision above refreshes the existing stable identity's
+		// draft and advances its optimistic-concurrency revision.
+		Step: 2, ExpectedOnboardingRevision: 2, IdempotencyKey: "confirm-unbound-" + agentID,
 	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
 	if status != http.StatusOK {
 		t.Fatalf("internal-alias onboarding confirmation status=%d payload=%#v", status, unboundConfirmPayload)

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -338,7 +338,7 @@ func (s *Service) Register(h *server.Hertz) {
 	h.GET("/api/v2/agents/me/principals", s.consoleAuth(false), s.listPrincipals)
 	h.DELETE("/api/v2/agents/me/principals/:principal_id", s.consoleAuth(true), s.revokePrincipal)
 	h.POST("/api/v2/console/handoffs", s.agentAuth("console:handoff:create"), s.createHandoff)
-	h.PUT("/api/v2/agent-settings/heartbeat-compatibility", s.agentAuth("commands:claim"), s.requireCompleted, s.reportHeartbeatCompatibility)
+	h.PUT("/api/v2/agent-settings/heartbeat-compatibility", middleware.ClientInfoMiddleware(), s.agentAuth("commands:claim"), s.requireCompleted, s.reportHeartbeatCompatibility)
 	h.POST("/api/v2/console/handoffs/exchange", s.requireSameOrigin(), s.exchangeHandoff)
 	h.GET("/api/v2/console/session", s.consoleAuth(false), s.getConsoleSession)
 	h.DELETE("/api/v2/console/session", s.consoleAuth(true), s.deleteConsoleSession)


### PR DESCRIPTION
Add ClientInfoMiddleware to the heartbeat compatibility route so heartbeat plan reports X-CLI-Ver and persists the current CLI version end to end.