### PR TITLE
Console V2: expose authoritative onboarding limits

### DIFF
--- a/api/consolev2/control_handlers.go
+++ b/api/consolev2/control_handlers.go
@@ -64,10 +64,18 @@ type networkGoalWriteRequest struct {
 	GoalText string `json:"goal_text"`
 }
 
+const (
+	onboardingNetworkGoalMaxChars       = 2000
+	onboardingIntentMaxItems            = 10
+	onboardingIntentWatchForMaxChars    = 1000
+	onboardingIntentTriggerWhenMaxChars = 1000
+	onboardingIntentInstructionMaxChars = 2000
+)
+
 func (s *Service) putNetworkGoal(_ context.Context, c *app.RequestContext) {
 	id, _ := agentID(c)
 	var req networkGoalWriteRequest
-	if err := decodeBody(c, &req); err != nil || validateContextWrite(req.ContextWriteRequest) != nil || strings.TrimSpace(req.GoalText) == "" || utf8.RuneCountInString(req.GoalText) > 2000 {
+	if err := decodeBody(c, &req); err != nil || validateContextWrite(req.ContextWriteRequest) != nil || strings.TrimSpace(req.GoalText) == "" || utf8.RuneCountInString(req.GoalText) > onboardingNetworkGoalMaxChars {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "valid goal_text, expected_context_revision, and idempotency_key are required", nil)
 		return
 	}
@@ -99,7 +107,9 @@ func validateIntent(fields IntentWriteFields) error {
 	if strings.TrimSpace(fields.WatchFor) == "" {
 		return errors.New("watch_for is required")
 	}
-	if utf8.RuneCountInString(fields.WatchFor) > 1000 || utf8.RuneCountInString(fields.TriggerWhen) > 1000 || utf8.RuneCountInString(fields.ActionInstruction) > 2000 {
+	if utf8.RuneCountInString(fields.WatchFor) > onboardingIntentWatchForMaxChars ||
+		utf8.RuneCountInString(fields.TriggerWhen) > onboardingIntentTriggerWhenMaxChars ||
+		utf8.RuneCountInString(fields.ActionInstruction) > onboardingIntentInstructionMaxChars {
 		return errors.New("intent text exceeds its length limit")
 	}
 	switch fields.ActionPolicy {

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -387,7 +387,7 @@ func (s *Service) getOnboardingDraft(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusInternalServerError, "DRAFT_READ_FAILED", "could not read onboarding draft", nil)
 		return
 	}
-	reply(c, http.StatusOK, map[string]interface{}{"onboarding": state, "draft": draft})
+	reply(c, http.StatusOK, map[string]interface{}{"onboarding": state, "draft": draft, "limits": onboardingLimits()})
 }
 
 type confirmStepRequest struct {
@@ -438,11 +438,11 @@ func validateDraftPayload(payload draftPayload) error {
 	if utf8.RuneCountInString(payload.IdentityCard.AgentName) > 100 || utf8.RuneCountInString(payload.IdentityCard.Bio) > 2000 {
 		return errors.New("identity card exceeds its length limit")
 	}
-	if utf8.RuneCountInString(payload.NetworkGoal) > 2000 {
-		return errors.New("network goal exceeds 2000 characters")
+	if utf8.RuneCountInString(payload.NetworkGoal) > onboardingNetworkGoalMaxChars {
+		return fmt.Errorf("network goal exceeds %d characters", onboardingNetworkGoalMaxChars)
 	}
-	if len(payload.IntentActions) > 10 {
-		return errors.New("at most 10 intent actions are allowed")
+	if len(payload.IntentActions) > onboardingIntentMaxItems {
+		return fmt.Errorf("at most %d intent actions are allowed", onboardingIntentMaxItems)
 	}
 	for _, intent := range payload.IntentActions {
 		if err := validateIntent(IntentWriteFields{
@@ -513,12 +513,12 @@ func validateDraftStep(payload draftPayload, step int16) error {
 		if strings.TrimSpace(payload.NetworkGoal) == "" {
 			return fmt.Errorf("%w: network_goal is required", errInvalidOnboardingDraft)
 		}
-		if utf8.RuneCountInString(payload.NetworkGoal) > 2000 {
-			return fmt.Errorf("%w: network goal exceeds 2000 characters", errInvalidOnboardingDraft)
+		if utf8.RuneCountInString(payload.NetworkGoal) > onboardingNetworkGoalMaxChars {
+			return fmt.Errorf("%w: network goal exceeds %d characters", errInvalidOnboardingDraft, onboardingNetworkGoalMaxChars)
 		}
 	case 4:
-		if len(payload.IntentActions) > 10 {
-			return fmt.Errorf("%w: at most 10 intent actions are allowed", errInvalidOnboardingDraft)
+		if len(payload.IntentActions) > onboardingIntentMaxItems {
+			return fmt.Errorf("%w: at most %d intent actions are allowed", errInvalidOnboardingDraft, onboardingIntentMaxItems)
 		}
 		for _, intent := range payload.IntentActions {
 			if err := validateIntent(IntentWriteFields{

--- a/api/consolev2/onboarding_limits.go
+++ b/api/consolev2/onboarding_limits.go
@@ -1,0 +1,52 @@
+package consolev2
+
+import "eigenflux_server/pkg/agentcard"
+
+type onboardingFieldLimit struct {
+	MaxChars     int  `json:"max_chars,omitempty"`
+	MaxItems     int  `json:"max_items,omitempty"`
+	MaxItemChars int  `json:"max_item_chars,omitempty"`
+	Required     bool `json:"required,omitempty"`
+}
+
+type onboardingLimitsPayload struct {
+	IdentityCard  map[string]onboardingFieldLimit `json:"identity_card"`
+	NetworkGoal   onboardingFieldLimit            `json:"network_goal"`
+	IntentActions struct {
+		MaxItems          int                  `json:"max_items"`
+		WatchFor          onboardingFieldLimit `json:"watch_for"`
+		TriggerWhen       onboardingFieldLimit `json:"trigger_when"`
+		ActionInstruction onboardingFieldLimit `json:"action_instruction"`
+	} `json:"intent_actions"`
+}
+
+func onboardingLimits() onboardingLimitsPayload {
+	limits := onboardingLimitsPayload{
+		IdentityCard: make(map[string]onboardingFieldLimit),
+		NetworkGoal: onboardingFieldLimit{
+			MaxChars: onboardingNetworkGoalMaxChars,
+			Required: true,
+		},
+	}
+	for _, spec := range agentcard.EditableFields {
+		if spec.Name == "current_focus" || spec.Name == "demands" {
+			continue
+		}
+		fieldLimit := onboardingFieldLimit{Required: spec.Name == "agent_name"}
+		if productLimit, ok := agentcard.ConsoleV2FieldLimits[spec.Name]; ok {
+			fieldLimit.MaxChars = productLimit
+		} else if spec.Kind == "string" {
+			fieldLimit.MaxChars = spec.MaxLen
+		}
+		if spec.Kind == "string_list" {
+			fieldLimit.MaxItems = spec.MaxItems
+			fieldLimit.MaxItemChars = spec.MaxLen
+		}
+		limits.IdentityCard[spec.Name] = fieldLimit
+	}
+	limits.IntentActions.MaxItems = onboardingIntentMaxItems
+	limits.IntentActions.WatchFor = onboardingFieldLimit{MaxChars: onboardingIntentWatchForMaxChars, Required: true}
+	limits.IntentActions.TriggerWhen = onboardingFieldLimit{MaxChars: onboardingIntentTriggerWhenMaxChars}
+	limits.IntentActions.ActionInstruction = onboardingFieldLimit{MaxChars: onboardingIntentInstructionMaxChars}
+	return limits
+}

--- a/api/consolev2/onboarding_limits_test.go
+++ b/api/consolev2/onboarding_limits_test.go
@@ -1,0 +1,20 @@
+package consolev2
+
+import "testing"
+
+func TestOnboardingLimitsExposeBackendValidationContract(t *testing.T) {
+	limits := onboardingLimits()
+	if got := limits.IdentityCard["seeking"]; got.MaxChars != 300 || got.MaxItemChars != 300 || got.MaxItems != 20 {
+		t.Fatalf("unexpected seeking limits: %#v", got)
+	}
+	if got := limits.IdentityCard["offering"]; got.MaxChars != 1000 || got.MaxItemChars != 100 || got.MaxItems != 20 {
+		t.Fatalf("unexpected offering limits: %#v", got)
+	}
+	if limits.NetworkGoal.MaxChars != 2000 || !limits.NetworkGoal.Required {
+		t.Fatalf("unexpected network goal limits: %#v", limits.NetworkGoal)
+	}
+	if limits.IntentActions.MaxItems != 10 || limits.IntentActions.WatchFor.MaxChars != 1000 ||
+		limits.IntentActions.TriggerWhen.MaxChars != 1000 || limits.IntentActions.ActionInstruction.MaxChars != 2000 {
+		t.Fatalf("unexpected intent limits: %#v", limits.IntentActions)
+	}
+}

--- a/pkg/agentcard/console_v2_limits.go
+++ b/pkg/agentcard/console_v2_limits.go
@@ -5,14 +5,13 @@ import (
 	"unicode/utf8"
 )
 
-// ConsoleV2FieldLimits are additive product limits for the new console only.
-// The legacy registry remains unchanged so V1 clients keep their old contract.
+// ConsoleV2FieldLimits are additive product limits for the new console.
 var ConsoleV2FieldLimits = map[string]int{
 	"agent_name":         40,
 	"agent_description":  500,
 	"human_description":  500,
 	"working_languages":  100,
-	"seeking":            1000,
+	"seeking":            300,
 	"offering":           1000,
 	"agent_status":       1000,
 	"human_status":       1000,

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -48,7 +48,7 @@ var EditableFields = []FieldSpec{
 	{Name: "agent_description", Public: true, Storage: StorageAgents, Kind: "string", MaxLen: 4000},
 	{Name: "human_description", Public: true, Storage: StorageProfileData, Kind: "string", MaxLen: 2000},
 	{Name: "working_languages", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 32, MaxItems: 10},
-	{Name: "seeking", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 20},
+	{Name: "seeking", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 300, MaxItems: 20},
 	{Name: "offering", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 20},
 
 	{Name: "geo", Public: false, Storage: StorageProfileData, Kind: "string", MaxLen: 100},

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -48,7 +48,7 @@ var EditableFields = []FieldSpec{
 	{Name: "agent_description", Public: true, Storage: StorageAgents, Kind: "string", MaxLen: 4000},
 	{Name: "human_description", Public: true, Storage: StorageProfileData, Kind: "string", MaxLen: 2000},
 	{Name: "working_languages", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 32, MaxItems: 10},
-	{Name: "seeking", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 20},
+	{Name: "seeking", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 20},
 	{Name: "offering", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 20},
 
 	{Name: "geo", Public: false, Storage: StorageProfileData, Kind: "string", MaxLen: 100},

--- a/pkg/agentcard/registry_test.go
+++ b/pkg/agentcard/registry_test.go
@@ -61,11 +61,11 @@ func TestValidateValue(t *testing.T) {
 	if _, err := ValidateValue(listSpec, json.RawMessage(`["AI infra","agent collaboration"]`)); err != nil {
 		t.Errorf("valid list rejected: %v", err)
 	}
-	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 1000)+`"]`)); err != nil {
-		t.Errorf("1000-character seeking item rejected: %v", err)
+	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 300)+`"]`)); err != nil {
+		t.Errorf("300-character seeking item rejected: %v", err)
 	}
-	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 1001)+`"]`)); err == nil {
-		t.Error("1001-character seeking item accepted")
+	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 301)+`"]`)); err == nil {
+		t.Error("301-character seeking item accepted")
 	}
 	if _, err := ValidateValue(listSpec, json.RawMessage(`"not a list"`)); err == nil {
 		t.Error("string accepted for a list field")

--- a/pkg/agentcard/registry_test.go
+++ b/pkg/agentcard/registry_test.go
@@ -61,6 +61,12 @@ func TestValidateValue(t *testing.T) {
 	if _, err := ValidateValue(listSpec, json.RawMessage(`["AI infra","agent collaboration"]`)); err != nil {
 		t.Errorf("valid list rejected: %v", err)
 	}
+	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 1000)+`"]`)); err != nil {
+		t.Errorf("1000-character seeking item rejected: %v", err)
+	}
+	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 1001)+`"]`)); err == nil {
+		t.Error("1001-character seeking item accepted")
+	}
 	if _, err := ValidateValue(listSpec, json.RawMessage(`"not a list"`)); err == nil {
 		t.Error("string accepted for a list field")
 	}


### PR DESCRIPTION
## Summary
- expose backend-owned onboarding field limits in the draft response
- set seeking to 300 characters
- centralize goal and intent limits

## Verification
- go test ./pkg/agentcard ./api/consolev2