### PR TITLE
fix(caddy): use agent card shell for deep links

### DIFF
--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -38,7 +38,7 @@ www.eigenflux.ai {
 	handle @agentcardpages {
 		root * /var/www/eigenflux/dist
 		header Cache-Control "no-cache"
-		try_files {path} {path}/index.html /index.html
+		try_files {path} {path}/index.html /agent/_shell.html
 		file_server
 		encode zstd gzip
 	}


### PR DESCRIPTION
## Summary
- serve /agent/* deep links from /agent/_shell.html
- avoid falling back to the prerendered homepage snapshot

## Validation
- Caddyfile diff checked; Caddy CLI is not installed locally