### PR TITLE
fix(console-v2): restore Today runtime states

### DIFF
--- a/api/consolev2/today_handlers.go
+++ b/api/consolev2/today_handlers.go
@@ -85,7 +85,13 @@ func todayEmptyModuleState(hasData, firstScanCompleted, connected, runtimeKnown 
 	if firstScanCompleted {
 		return "complete_empty"
 	}
-	return "starting"
+	if connected {
+		return "starting"
+	}
+	if runtimeKnown {
+		return "offline"
+	}
+	return "waiting"
 }
 
 func todayObservationState(hasResult, firstScanCompleted, connected, runtimeKnown bool) string {

--- a/api/consolev2/today_handlers_test.go
+++ b/api/consolev2/today_handlers_test.go
@@ -120,8 +120,8 @@ func TestTodayObservationStateUsesDurableMilestones(t *testing.T) {
 		hasData, scanDone, connected, runtimeSeen bool
 		want                                      string
 	}{
-		{name: "starting before first runtime", want: "starting"},
-		{name: "runtime offline does not replace module state", runtimeSeen: true, want: "starting"},
+		{name: "waiting before first runtime", want: "waiting"},
+		{name: "offline after runtime freshness expires", runtimeSeen: true, want: "offline"},
 		{name: "starting while first scan runs", connected: true, runtimeSeen: true, want: "starting"},
 		{name: "confirmed empty only after scan completion", scanDone: true, connected: true, runtimeSeen: true, want: "complete_empty"},
 		{name: "completed scan remains empty while runtime is offline", scanDone: true, runtimeSeen: true, want: "complete_empty"},

--- a/api/consolev2/today_status_handlers.go
+++ b/api/consolev2/today_status_handlers.go
@@ -16,21 +16,31 @@ type todayStatusFacts struct {
 
 func (s *Service) getTodayStatus(_ context.Context, c *app.RequestContext) {
 	agentIDValue, _ := agentID(c)
+	now := time.Now().UTC()
+	var privateCard string
+	if err := s.db.Raw(`SELECT COALESCE(
+		(SELECT private_card FROM agent_cards WHERE agent_id = ?),
+		'{}'::jsonb
+	)::text AS private_card`, agentIDValue).Scan(&privateCard).Error; err != nil {
+		fail(c, http.StatusInternalServerError, "TODAY_STATUS_READ_FAILED", "could not load Agent timezone", nil)
+		return
+	}
+	todayStart := todayStartFromPrivateCard(privateCard, now)
 	var facts todayStatusFacts
 	if err := s.db.Raw(`SELECT
 		COALESCE((SELECT MAX(last_heartbeat_at) FROM agent_runtime_leases WHERE agent_id = ?), 0)::bigint AS last_heartbeat_at,
-		COALESCE((SELECT MIN(created_at) FROM agent_activity_log WHERE agent_id = ? AND event_type = 'feed_pull'), 0)::bigint AS first_scan_completed_at,
-		COALESCE((SELECT MAX(created_at) FROM agent_activity_log WHERE agent_id = ? AND event_type = 'feed_pull'), 0)::bigint AS last_scan_at`,
-		agentIDValue, agentIDValue, agentIDValue).Scan(&facts).Error; err != nil {
+		COALESCE((SELECT MIN(created_at) FROM agent_activity_log WHERE agent_id = ? AND event_type = 'feed_pull' AND created_at >= ?), 0)::bigint AS first_scan_completed_at,
+		COALESCE((SELECT MAX(created_at) FROM agent_activity_log WHERE agent_id = ? AND event_type = 'feed_pull' AND created_at >= ?), 0)::bigint AS last_scan_at`,
+		agentIDValue, agentIDValue, todayStart, agentIDValue, todayStart).Scan(&facts).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "TODAY_STATUS_READ_FAILED", "could not load Today status", nil)
 		return
 	}
-	now := time.Now().UTC().UnixMilli()
-	runtimeState := consoleRuntimeState(facts.LastHeartbeatAt, now)
-	observationState := "starting"
+	nowMillis := now.UnixMilli()
+	runtimeState := consoleRuntimeState(facts.LastHeartbeatAt, nowMillis)
+	firstScanCompleted := facts.FirstScanCompletedAt > 0
+	observationState := todayObservationState(false, firstScanCompleted, runtimeState == "active", runtimeState != "not_started")
 	firstScanState := "not_started"
-	if facts.FirstScanCompletedAt > 0 {
-		observationState = "complete_empty"
+	if firstScanCompleted {
 		firstScanState = "completed"
 	} else if runtimeState == "active" {
 		firstScanState = "running"


### PR DESCRIPTION
Restores waiting, starting, and offline semantics from runtime heartbeat facts. Keeps completed Today milestones durable and scopes status polling scans to the current local day.\n\nVerified: go test ./api/consolev2; standard backend build.