### PR TITLE
feat(console): allow 1000-character Agent descriptions

### DIFF
--- a/api/consolev2/onboarding_limits_test.go
+++ b/api/consolev2/onboarding_limits_test.go
@@ -4,6 +4,9 @@ import "testing"
 
 func TestOnboardingLimitsExposeBackendValidationContract(t *testing.T) {
 	limits := onboardingLimits()
+	if got := limits.IdentityCard["agent_description"]; got.MaxChars != 1000 {
+		t.Fatalf("unexpected agent_description limits: %#v", got)
+	}
 	if got := limits.IdentityCard["seeking"]; got.MaxChars != 300 || got.MaxItemChars != 300 || got.MaxItems != 20 {
 		t.Fatalf("unexpected seeking limits: %#v", got)
 	}

--- a/pkg/agentcard/console_v2_limits.go
+++ b/pkg/agentcard/console_v2_limits.go
@@ -8,7 +8,7 @@ import (
 // ConsoleV2FieldLimits are additive product limits for the new console.
 var ConsoleV2FieldLimits = map[string]int{
 	"agent_name":         40,
-	"agent_description":  500,
+	"agent_description":  1000,
 	"human_description":  500,
 	"working_languages":  100,
 	"seeking":            300,

--- a/pkg/agentcard/console_v2_limits_test.go
+++ b/pkg/agentcard/console_v2_limits_test.go
@@ -14,6 +14,15 @@ func TestValidateConsoleV2ValueUsesUnicodeRuneLimits(t *testing.T) {
 	}
 }
 
+func TestValidateConsoleV2AgentDescriptionAllowsOneThousandCharacters(t *testing.T) {
+	if err := ValidateConsoleV2Value("agent_description", strings.Repeat("描", 1000)); err != nil {
+		t.Fatalf("exact agent_description limit rejected: %v", err)
+	}
+	if err := ValidateConsoleV2Value("agent_description", strings.Repeat("描", 1001)); err == nil {
+		t.Fatal("agent_description limit+1 was accepted")
+	}
+}
+
 func TestValidateConsoleV2ValueAggregatesListCharacters(t *testing.T) {
 	if err := ValidateConsoleV2Value("working_languages", []string{strings.Repeat("中", 50), strings.Repeat("文", 50)}); err != nil {
 		t.Fatalf("exact aggregate limit rejected: %v", err)


### PR DESCRIPTION
## Change
- raise Console V2 agent_description product limit from 500 to 1000 Unicode characters
- expose the same 1000-character limit through onboarding limits
- cover exact-limit and limit-plus-one validation

## Verification
- go test ./pkg/agentcard ./api/consolev2
- bash scripts/common/build.sh