### PR TITLE
fix(agentcard): allow 1000 char recent status items

### DIFF
--- a/api/consolev2/onboarding_limits_test.go
+++ b/api/consolev2/onboarding_limits_test.go
@@ -13,6 +13,9 @@ func TestOnboardingLimitsExposeBackendValidationContract(t *testing.T) {
 	if got := limits.IdentityCard["offering"]; got.MaxChars != 1000 || got.MaxItemChars != 100 || got.MaxItems != 20 {
 		t.Fatalf("unexpected offering limits: %#v", got)
 	}
+	if got := limits.IdentityCard["agent_status"]; got.MaxChars != 1000 || got.MaxItemChars != 1000 || got.MaxItems != 20 {
+		t.Fatalf("unexpected agent_status limits: %#v", got)
+	}
 	if limits.NetworkGoal.MaxChars != 2000 || !limits.NetworkGoal.Required {
 		t.Fatalf("unexpected network goal limits: %#v", limits.NetworkGoal)
 	}

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -55,8 +55,8 @@ var EditableFields = []FieldSpec{
 	{Name: "timezone", Public: false, Storage: StorageProfileData, Kind: "string", MaxLen: 64},
 	{Name: "current_focus", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
 	{Name: "demands", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
-	{Name: "agent_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
-	{Name: "human_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
+	{Name: "agent_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 20},
+	{Name: "human_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 20},
 	{Name: "interests_negative", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 30},
 }
 

--- a/pkg/agentcard/registry_test.go
+++ b/pkg/agentcard/registry_test.go
@@ -88,3 +88,16 @@ func TestValidateValue(t *testing.T) {
 		t.Error("system field influence must not be editable")
 	}
 }
+
+func TestValidateValueAllowsOneThousandCharacterRecentStatusItem(t *testing.T) {
+	spec, ok := LookupField("agent_status")
+	if !ok {
+		t.Fatal("agent_status field is missing")
+	}
+	if _, err := ValidateValue(spec, json.RawMessage(`["`+strings.Repeat("状", 1000)+`"]`)); err != nil {
+		t.Fatalf("exact agent_status item limit rejected: %v", err)
+	}
+	if _, err := ValidateValue(spec, json.RawMessage(`["`+strings.Repeat("状", 1001)+`"]`)); err == nil {
+		t.Fatal("agent_status item limit+1 was accepted")
+	}
+}


### PR DESCRIPTION
## Summary
- raise agent_status and human_status item validation from 200 to 1000 characters
- expose the aligned contract through Console V2 onboarding limits
- add exact-limit and limit-plus-one regression coverage

## Verification
- go test ./pkg/agentcard ./api/consolev2
- bash scripts/common/build.sh