### PR TITLE
feat(auth): safely recover historical Agent accounts

### DIFF
--- a/.github/workflows/postgres-contracts.yml
+++ b/.github/workflows/postgres-contracts.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Verify short-ID install attribution
         run: go test -count=1 ./api/install -run '^TestPostgresShortIDInviteAttribution$'
       - name: Verify Console V2 PostgreSQL flow and races
-        run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|Postgres.*|AttentionContractGolden)'
+        run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*|AttentionContractGolden)'

--- a/api/agentcard/handlers.go
+++ b/api/agentcard/handlers.go
@@ -318,6 +318,10 @@ func GetPublicCard(ctx context.Context, c *app.RequestContext) {
 		respond(c, http.StatusBadRequest, 400, "invalid agent_id", nil)
 		return
 	}
+	if _, identityErr := agentidentity.Get(ctx, db.DB, targetID); identityErr != nil {
+		respond(c, http.StatusNotFound, 404, "agent not found", nil)
+		return
+	}
 
 	allowed, rateErr := checkFixedWindow(ctx, mq.RDB, viewerID, "public-card", publicCardRateLimit, publicCardRateWindow, time.Now())
 	if rateErr != nil {

--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -670,12 +670,14 @@ func (s *Service) createRefreshChallenge(_ context.Context, c *app.RequestContex
 		RevokedAt         *int64  `gorm:"column:revoked_at"`
 		ReplacedBySession *int64  `gorm:"column:replaced_by_session_id"`
 		SuccessorRequest  *string `gorm:"column:successor_request_id"`
+		IdentityState     string  `gorm:"column:identity_state"`
 	}
 	if err := s.db.Raw(`SELECT cs.family_id, p.key_fingerprint, p.status AS principal_status,
 		cs.absolute_expires_at, cs.revoked_at, cs.replaced_by_session_id,
-		next.rotation_request_id AS successor_request_id
+		next.rotation_request_id AS successor_request_id, a.identity_state
 		FROM agent_credential_sessions cs
 		JOIN agent_principals p ON p.principal_id = cs.principal_id
+		JOIN agents a ON a.agent_id = p.agent_id
 		LEFT JOIN agent_credential_sessions next ON next.session_id = cs.replaced_by_session_id
 		WHERE cs.refresh_token_hash = ?`, hashString(req.RefreshToken)).Scan(&row).Error; err != nil || row.FamilyID == "" {
 		fail(c, http.StatusUnauthorized, "REFRESH_INVALID", "refresh credential is invalid or expired", nil)
@@ -691,7 +693,8 @@ func (s *Service) createRefreshChallenge(_ context.Context, c *app.RequestContex
 		fail(c, http.StatusUnauthorized, "REFRESH_INVALID", "refresh credential is invalid or expired", nil)
 		return
 	}
-	if row.AbsoluteExpiresAt <= now || (row.PrincipalStatus != "limited" && row.PrincipalStatus != "active") {
+	if row.AbsoluteExpiresAt <= now || row.IdentityState != "active" ||
+		(row.PrincipalStatus != "limited" && row.PrincipalStatus != "active") {
 		fail(c, http.StatusUnauthorized, "REFRESH_INVALID", "refresh credential is invalid or expired", nil)
 		return
 	}
@@ -770,36 +773,44 @@ func (s *Service) refreshAgentSession(_ context.Context, c *app.RequestContext) 
 	newAccessToken := "efv2a_" + keyedHash(s.otpPepper, "refresh-access\x00"+rotationHash)
 	newRefreshToken := "efv2r_" + keyedHash(s.otpPepper, "refresh-token\x00"+rotationHash)
 
-	var principalID, newSessionID, expiresAt int64
+	var agentID, principalID, newSessionID, expiresAt int64
 	var familyID string
 	var scopes pq.StringArray
 	reuseDetected := false
 	err = s.db.Transaction(func(tx *gorm.DB) error {
 		var old struct {
-			SessionID           int64          `gorm:"column:session_id"`
-			PrincipalID         int64          `gorm:"column:principal_id"`
-			FamilyID            string         `gorm:"column:family_id"`
-			Scopes              pq.StringArray `gorm:"column:scopes;type:text[]"`
-			RotationCounter     int64          `gorm:"column:rotation_counter"`
-			AbsoluteExpiresAt   int64          `gorm:"column:absolute_expires_at"`
-			RevokedAt           *int64         `gorm:"column:revoked_at"`
-			ReplacedBySessionID *int64         `gorm:"column:replaced_by_session_id"`
-			KeyFingerprint      string         `gorm:"column:key_fingerprint"`
-			PrincipalStatus     string         `gorm:"column:principal_status"`
-			OnboardingState     string         `gorm:"column:onboarding_state"`
+			SessionID             int64          `gorm:"column:session_id"`
+			AgentID               int64          `gorm:"column:agent_id"`
+			PrincipalID           int64          `gorm:"column:principal_id"`
+			FamilyID              string         `gorm:"column:family_id"`
+			Scopes                pq.StringArray `gorm:"column:scopes;type:text[]"`
+			RotationCounter       int64          `gorm:"column:rotation_counter"`
+			AbsoluteExpiresAt     int64          `gorm:"column:absolute_expires_at"`
+			RevokedAt             *int64         `gorm:"column:revoked_at"`
+			ReplacedBySessionID   *int64         `gorm:"column:replaced_by_session_id"`
+			KeyFingerprint        string         `gorm:"column:key_fingerprint"`
+			PrincipalStatus       string         `gorm:"column:principal_status"`
+			OnboardingState       string         `gorm:"column:onboarding_state"`
+			IdentityState         string         `gorm:"column:identity_state"`
+			AccessRefreshRequired bool           `gorm:"column:access_refresh_required"`
 		}
-		if err := tx.Raw(`SELECT cs.session_id, cs.principal_id, cs.family_id, cs.scopes,
+		if err := tx.Raw(`SELECT cs.session_id, p.agent_id, cs.principal_id, cs.family_id, cs.scopes,
 			cs.rotation_counter, cs.absolute_expires_at, cs.revoked_at, cs.replaced_by_session_id,
-			p.key_fingerprint, p.status AS principal_status, COALESCE(o.state, '') AS onboarding_state
+			p.key_fingerprint, p.status AS principal_status, COALESCE(o.state, '') AS onboarding_state,
+			a.identity_state, cs.access_refresh_required
 			FROM agent_credential_sessions cs
 			JOIN agent_principals p ON p.principal_id = cs.principal_id
+			JOIN agents a ON a.agent_id = p.agent_id
 			LEFT JOIN agent_onboarding_v2 o ON o.agent_id = p.agent_id
 			WHERE cs.refresh_token_hash = ? FOR UPDATE OF cs, p`, hashString(req.RefreshToken)).Scan(&old).Error; err != nil {
 			return err
 		}
-		if old.SessionID == 0 || old.KeyFingerprint != fingerprint(publicKey) ||
+		if old.SessionID == 0 || old.KeyFingerprint != fingerprint(publicKey) || old.IdentityState != "active" ||
 			(old.PrincipalStatus != "limited" && old.PrincipalStatus != "active") {
 			return errUnauthorized
+		}
+		if !recoveryRefreshCLIAllowed(old.AccessRefreshRequired, string(c.GetHeader("X-CLI-Ver"))) {
+			return errCLIUpgradeRequired
 		}
 		if err := tx.Raw(`SELECT (extract(epoch FROM clock_timestamp())*1000)::bigint`).Scan(&now).Error; err != nil {
 			return err
@@ -834,9 +845,9 @@ func (s *Service) refreshAgentSession(_ context.Context, c *app.RequestContext) 
 				if nonceUse.Error != nil || nonceUse.RowsAffected != 1 {
 					return errUnauthorized
 				}
-				principalID, newSessionID, familyID = successor.PrincipalID, successor.SessionID, successor.FamilyID
+				agentID, principalID, newSessionID, familyID = old.AgentID, successor.PrincipalID, successor.SessionID, successor.FamilyID
 				expiresAt, scopes = successor.ExpiresAt, pq.StringArray(principalScopesForOnboarding(old.OnboardingState))
-				if err := tx.Exec(`UPDATE agent_credential_sessions SET scopes = ? WHERE session_id = ?`, pq.Array([]string(scopes)), successor.SessionID).Error; err != nil {
+				if err := tx.Exec(`UPDATE agent_credential_sessions SET scopes = ?, access_refresh_required = FALSE WHERE session_id = ?`, pq.Array([]string(scopes)), successor.SessionID).Error; err != nil {
 					return err
 				}
 				return nil
@@ -860,7 +871,7 @@ func (s *Service) refreshAgentSession(_ context.Context, c *app.RequestContext) 
 		if expiresAt > old.AbsoluteExpiresAt {
 			expiresAt = old.AbsoluteExpiresAt
 		}
-		principalID, familyID, scopes = old.PrincipalID, old.FamilyID, pq.StringArray(principalScopesForOnboarding(old.OnboardingState))
+		agentID, principalID, familyID, scopes = old.AgentID, old.PrincipalID, old.FamilyID, pq.StringArray(principalScopesForOnboarding(old.OnboardingState))
 		if err := tx.Raw(`INSERT INTO agent_credential_sessions
 			(principal_id, family_id, access_token_hash, refresh_token_hash, audience, scopes,
 			 rotation_counter, issued_at, expires_at, absolute_expires_at, last_seen_at,
@@ -885,6 +896,12 @@ func (s *Service) refreshAgentSession(_ context.Context, c *app.RequestContext) 
 		fail(c, http.StatusUnauthorized, "REFRESH_REUSE_DETECTED", "refresh credential reuse revoked this session family", nil)
 		return
 	}
+	if errors.Is(err, errCLIUpgradeRequired) {
+		fail(c, http.StatusUpgradeRequired, "CLI_UPGRADE_REQUIRED", "upgrade EigenFlux CLI before refreshing a recovered identity", map[string]interface{}{
+			"minimum_cli_version": minimumConsoleV2CLI,
+		})
+		return
+	}
 	if errors.Is(err, errUnauthorized) || errors.Is(err, errConflict) {
 		fail(c, http.StatusUnauthorized, "REFRESH_INVALID", "refresh proof is invalid or expired", nil)
 		return
@@ -894,6 +911,7 @@ func (s *Service) refreshAgentSession(_ context.Context, c *app.RequestContext) 
 		return
 	}
 	reply(c, http.StatusOK, map[string]interface{}{
+		"agent_id":      fmt.Sprintf("%d", agentID),
 		"principal_id":  fmt.Sprintf("%d", principalID),
 		"session_id":    fmt.Sprintf("%d", newSessionID),
 		"family_id":     familyID,
@@ -905,7 +923,8 @@ func (s *Service) refreshAgentSession(_ context.Context, c *app.RequestContext) 
 }
 
 type createHandoffRequest struct {
-	BrowserNonce string `json:"browser_nonce"`
+	BrowserNonce       string   `json:"browser_nonce"`
+	ClientCapabilities []string `json:"client_capabilities,omitempty"`
 }
 
 func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
@@ -927,6 +946,11 @@ func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "browser_nonce is required", nil)
 		return
 	}
+	clientCapabilities, validCapabilities := normalizeCapabilities(req.ClientCapabilities)
+	if !validCapabilities {
+		fail(c, http.StatusBadRequest, "INVALID_CAPABILITIES", "client_capabilities are invalid", nil)
+		return
+	}
 	observedRuntime, _ := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
 	deviceName, validDeviceName := normalizeDeviceName(string(c.GetHeader("X-Client-Device-Name")))
 	if !validDeviceName {
@@ -946,10 +970,10 @@ func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
 	now := time.Now().UnixMilli()
 	browserNonceHash := hashString(req.BrowserNonce)
 	err = s.db.Exec(`INSERT INTO console_v2_handoffs
-		(ticket_hash, agent_id, principal_id, console_scope, browser_nonce_hash, expires_at, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`, hashString(ticket), agentID, principalID,
+		(ticket_hash, agent_id, principal_id, console_scope, browser_nonce_hash, client_capabilities, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, hashString(ticket), agentID, principalID,
 		pq.Array([]string{"console:onboarding", "console:read", "console:write"}), browserNonceHash,
-		now+int64(handoffTTL/time.Millisecond), now).Error
+		pq.Array(clientCapabilities), now+int64(handoffTTL/time.Millisecond), now).Error
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "HANDOFF_FAILED", "could not create handoff", nil)
 		return
@@ -979,18 +1003,30 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 		return
 	}
 	var agentIDValue, principalID int64
-	var scopes pq.StringArray
+	var scopes, clientCapabilities pq.StringArray
+	handoffRevoked := false
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var handoff struct {
-			AgentID          int64          `gorm:"column:agent_id"`
-			PrincipalID      int64          `gorm:"column:principal_id"`
-			Scopes           pq.StringArray `gorm:"column:console_scope;type:text[]"`
-			BrowserNonceHash *string        `gorm:"column:browser_nonce_hash"`
-			ExpiresAt        int64          `gorm:"column:expires_at"`
+			AgentID            int64          `gorm:"column:agent_id"`
+			PrincipalID        int64          `gorm:"column:principal_id"`
+			PrincipalAgentID   int64          `gorm:"column:principal_agent_id"`
+			PrincipalStatus    string         `gorm:"column:principal_status"`
+			PrincipalRevokedAt *int64         `gorm:"column:principal_revoked_at"`
+			IdentityState      string         `gorm:"column:identity_state"`
+			Scopes             pq.StringArray `gorm:"column:console_scope;type:text[]"`
+			Capabilities       pq.StringArray `gorm:"column:client_capabilities;type:text[]"`
+			BrowserNonceHash   *string        `gorm:"column:browser_nonce_hash"`
+			ExpiresAt          int64          `gorm:"column:expires_at"`
 		}
-		if err := tx.Raw(`SELECT agent_id, principal_id, console_scope, browser_nonce_hash, expires_at
-			FROM console_v2_handoffs
-			WHERE ticket_hash = ? AND consumed_at IS NULL FOR UPDATE`, hashString(req.Ticket)).
+		if err := tx.Raw(`SELECT h.agent_id, h.principal_id, p.agent_id AS principal_agent_id,
+			p.status AS principal_status, p.revoked_at AS principal_revoked_at, a.identity_state,
+			h.console_scope, h.client_capabilities,
+				h.browser_nonce_hash, h.expires_at
+				FROM console_v2_handoffs h
+				JOIN agent_principals p ON p.principal_id = h.principal_id
+				JOIN agents a ON a.agent_id = h.agent_id
+				WHERE h.ticket_hash = ? AND h.consumed_at IS NULL AND h.revoked_at IS NULL
+				FOR UPDATE OF h`, hashString(req.Ticket)).
 			Scan(&handoff).Error; err != nil {
 			return err
 		}
@@ -999,24 +1035,35 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 			return err
 		}
 		providedNonceHash := hashString(req.BrowserNonce)
-		if handoff.AgentID == 0 || handoff.ExpiresAt < now || handoff.BrowserNonceHash == nil ||
+		if !validActiveIdentityBinding(handoff.AgentID, handoff.PrincipalAgentID, handoff.IdentityState,
+			handoff.PrincipalStatus, handoff.PrincipalRevokedAt) ||
+			handoff.ExpiresAt < now || handoff.BrowserNonceHash == nil ||
 			subtle.ConstantTimeCompare([]byte(providedNonceHash), []byte(*handoff.BrowserNonceHash)) != 1 {
+			if handoff.AgentID != 0 && !validActiveIdentityBinding(handoff.AgentID, handoff.PrincipalAgentID,
+				handoff.IdentityState, handoff.PrincipalStatus, handoff.PrincipalRevokedAt) {
+				if err := tx.Exec(`UPDATE console_v2_handoffs SET revoked_at = COALESCE(revoked_at, ?)
+					WHERE ticket_hash = ?`, now, hashString(req.Ticket)).Error; err != nil {
+					return err
+				}
+				handoffRevoked = true
+				return nil
+			}
 			return errUnauthorized
 		}
 		consume := tx.Exec(`UPDATE console_v2_handoffs SET consumed_at = ?
-			WHERE ticket_hash = ? AND consumed_at IS NULL AND expires_at >= ?`, now, hashString(req.Ticket), now)
+				WHERE ticket_hash = ? AND consumed_at IS NULL AND revoked_at IS NULL AND expires_at >= ?`, now, hashString(req.Ticket), now)
 		if consume.Error != nil || consume.RowsAffected != 1 {
 			return errUnauthorized
 		}
-		agentIDValue, principalID, scopes = handoff.AgentID, handoff.PrincipalID, handoff.Scopes
+		agentIDValue, principalID, scopes, clientCapabilities = handoff.AgentID, handoff.PrincipalID, handoff.Scopes, handoff.Capabilities
 		return tx.Exec(`INSERT INTO console_v2_sessions
 				(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash,
-					 status, scopes, issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method)
-				VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, 'handoff')`, sessionID, hashString(sessionSecret),
-			agentIDValue, principalID, hashString(csrfSecret), pq.Array([]string(scopes)), now,
+					 status, scopes, client_capabilities, issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method)
+				VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, 'handoff')`, sessionID, hashString(sessionSecret),
+			agentIDValue, principalID, hashString(csrfSecret), pq.Array([]string(scopes)), pq.Array([]string(clientCapabilities)), now,
 			now+int64(consoleIdleTTL/time.Millisecond), now+int64(consoleAbsoluteTTL/time.Millisecond), now).Error
 	})
-	if errors.Is(err, errUnauthorized) {
+	if handoffRevoked || errors.Is(err, errUnauthorized) {
 		fail(c, http.StatusUnauthorized, "HANDOFF_INVALID", "handoff is invalid, consumed, or expired", nil)
 		return
 	}
@@ -1027,7 +1074,8 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
 	s.setCSRFCookie(c, csrfSecret, int(consoleAbsoluteTTL/time.Second))
 	reply(c, http.StatusOK, map[string]interface{}{
-		"agent_id":   fmt.Sprintf("%d", agentIDValue),
-		"csrf_token": csrfSecret,
+		"agent_id":            fmt.Sprintf("%d", agentIDValue),
+		"csrf_token":          csrfSecret,
+		"client_capabilities": []string(clientCapabilities),
 	})
 }

--- a/api/consolev2/control_realtime.go
+++ b/api/consolev2/control_realtime.go
@@ -174,8 +174,10 @@ func (s *Service) agentCredentialSessionStillActive(sessionID, agentID int64) bo
 	now := time.Now().UnixMilli()
 	err := s.db.Raw(`SELECT EXISTS(SELECT 1 FROM agent_credential_sessions session
 		JOIN agent_principals principal ON principal.principal_id = session.principal_id
+		JOIN agents agent ON agent.agent_id = principal.agent_id
 		WHERE session.session_id = ? AND principal.agent_id = ? AND session.audience = 'agent_v2'
-		 AND session.revoked_at IS NULL AND session.expires_at > ?
+		 AND session.revoked_at IS NULL AND session.expires_at > ? AND session.access_refresh_required = FALSE
+		 AND agent.identity_state = 'active'
 		 AND principal.revoked_at IS NULL AND principal.status IN ('limited','active'))`,
 		sessionID, agentID, now).Scan(&active).Error
 	return err == nil && active

--- a/api/consolev2/email_handlers.go
+++ b/api/consolev2/email_handlers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/subtle"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -464,9 +465,11 @@ func sameOptionalString(left, right *string) bool {
 
 func (s *Service) verifyEmailBinding(_ context.Context, c *app.RequestContext) {
 	agentIDValue, ok := agentID(c)
+	principalValue, hasPrincipal := c.Get("principal_id")
+	principalID, principalOK := principalValue.(int64)
 	sessionValue, hasSession := c.Get("console_session_id")
 	sessionID, sessionOK := sessionValue.(string)
-	if !ok || !hasSession || !sessionOK {
+	if !ok || !hasPrincipal || !principalOK || !hasSession || !sessionOK {
 		fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console V2 session is required", nil)
 		return
 	}
@@ -482,6 +485,7 @@ func (s *Service) verifyEmailBinding(_ context.Context, c *app.RequestContext) {
 	}
 	now := time.Now().UnixMilli()
 	validOTP := false
+	var recoveryDetails map[string]interface{}
 	err = s.db.Transaction(func(tx *gorm.DB) error {
 		_, valid, checkErr := s.lockAndCheckEmailChallenge(tx, req, normalizedEmail, "bind", &agentIDValue, &sessionID, now)
 		if checkErr != nil || !valid {
@@ -499,11 +503,6 @@ func (s *Service) verifyEmailBinding(_ context.Context, c *app.RequestContext) {
 			WHERE normalized_email = ? AND status = 'active'`, normalizedEmail).Scan(&bindingOwners).Error; err != nil {
 			return err
 		}
-		for _, owner := range bindingOwners {
-			if owner.AgentID != agentIDValue {
-				return errConflict
-			}
-		}
 		var legacyOwners []struct {
 			AgentID int64 `gorm:"column:agent_id"`
 		}
@@ -511,10 +510,28 @@ func (s *Service) verifyEmailBinding(_ context.Context, c *app.RequestContext) {
 			WHERE lower(btrim(email)) = ? AND email_kind = 'legacy_real' ORDER BY agent_id LIMIT 2`, normalizedEmail).Scan(&legacyOwners).Error; err != nil {
 			return err
 		}
+		otherOwners := map[int64]struct{}{}
+		for _, owner := range bindingOwners {
+			if owner.AgentID != agentIDValue {
+				otherOwners[owner.AgentID] = struct{}{}
+			}
+		}
 		for _, owner := range legacyOwners {
 			if owner.AgentID != agentIDValue {
-				return errConflict
+				otherOwners[owner.AgentID] = struct{}{}
 			}
+		}
+		if len(otherOwners) > 1 {
+			return errConflict
+		}
+		for targetAgentID := range otherOwners {
+			details, recoveryErr := s.prepareAccountRecovery(tx, agentIDValue, targetAgentID,
+				principalID, sessionID, req.ChallengeID, normalizedEmail, now)
+			if recoveryErr != nil {
+				return recoveryErr
+			}
+			recoveryDetails = details
+			return nil
 		}
 		var current struct {
 			BindingID       int64  `gorm:"column:binding_id"`
@@ -550,6 +567,10 @@ func (s *Service) verifyEmailBinding(_ context.Context, c *app.RequestContext) {
 	})
 	if errors.Is(err, errUnauthorized) || (!validOTP && err == nil) {
 		fail(c, http.StatusUnauthorized, "OTP_INVALID", "verification code is invalid or expired", nil)
+		return
+	}
+	if recoveryDetails != nil {
+		fail(c, http.StatusConflict, "EMAIL_UNAVAILABLE", "this email belongs to a recoverable historical Agent", recoveryDetails)
 		return
 	}
 	if errors.Is(err, errConflict) || isUniqueViolation(err) {
@@ -608,23 +629,211 @@ func ensureLegacyConsoleV2State(tx *gorm.DB, id, now int64) error {
 		VALUES (?, 600, false, ?) ON CONFLICT (agent_id) DO NOTHING`, id, now).Error; err != nil {
 		return err
 	}
+	var existingDraft struct {
+		Revision  int64  `gorm:"column:revision"`
+		DraftData string `gorm:"column:draft_data"`
+		RequestID string `gorm:"column:request_id"`
+	}
+	if err := tx.Raw(`SELECT revision, draft_data::text AS draft_data, request_id
+		FROM agent_onboarding_drafts WHERE agent_id = ? ORDER BY revision DESC LIMIT 1`, id).Scan(&existingDraft).Error; err != nil {
+		return err
+	}
+	if existingDraft.Revision > 0 && existingDraft.RequestID != "legacy-lazy-v1" {
+		return nil
+	}
+	var snapshot struct {
+		AgentName        string `gorm:"column:agent_name"`
+		Bio              string `gorm:"column:bio"`
+		Country          string `gorm:"column:country"`
+		ProfileData      string `gorm:"column:profile_data"`
+		PublicCard       string `gorm:"column:public_card"`
+		PrivateCard      string `gorm:"column:private_card"`
+		RecurringPublish bool   `gorm:"column:recurring_publish"`
+		AutoReplyPM      bool   `gorm:"column:auto_reply_pm"`
+		AutoComment      bool   `gorm:"column:auto_comment"`
+		ShowAddFriend    bool   `gorm:"column:show_add_friend"`
+	}
+	if err := tx.Raw(`SELECT a.agent_name, COALESCE(a.bio, '') AS bio,
+		COALESCE(p.country, '') AS country, COALESCE(p.profile_data, '{}'::jsonb)::text AS profile_data,
+		COALESCE(c.public_card, '{}'::jsonb)::text AS public_card,
+		COALESCE(c.private_card, '{}'::jsonb)::text AS private_card,
+		COALESCE(s.recurring_publish, true) AS recurring_publish,
+		COALESCE(s.auto_reply_pm, true) AS auto_reply_pm,
+		COALESCE(s.auto_comment, true) AS auto_comment,
+		COALESCE(s.show_add_friend, true) AS show_add_friend
+		FROM agents a
+		LEFT JOIN agent_profiles p ON p.agent_id = a.agent_id
+		LEFT JOIN agent_cards c ON c.agent_id = a.agent_id
+		LEFT JOIN agent_settings s ON s.agent_id = a.agent_id
+		WHERE a.agent_id = ?`, id).Scan(&snapshot).Error; err != nil {
+		return err
+	}
+	profileData, err := decodeHistoricalCardObject(snapshot.ProfileData)
+	if err != nil {
+		return err
+	}
+	publicCard, err := decodeHistoricalCardObject(snapshot.PublicCard)
+	if err != nil {
+		return err
+	}
+	privateCard, err := decodeHistoricalCardObject(snapshot.PrivateCard)
+	if err != nil {
+		return err
+	}
+	draft := map[string]interface{}{
+		"identity_card": historicalIdentityCard(snapshot.AgentName, snapshot.Bio, snapshot.Country, profileData, publicCard, privateCard),
+		"security_boundary": map[string]interface{}{
+			"recurring_publish": snapshot.RecurringPublish,
+			"auto_reply_pm":     snapshot.AutoReplyPM,
+			"auto_comment":      snapshot.AutoComment,
+			"show_add_friend":   snapshot.ShowAddFriend,
+		},
+		"network_goal":   "",
+		"intent_actions": []interface{}{},
+	}
+	draftJSON, draftObject, err := normalizeHistoricalOnboardingDraftJSON(mustJSON(draft))
+	if err != nil {
+		return err
+	}
+	if existingDraft.Revision > 0 {
+		currentDraft, decodeErr := decodeJSONObject(json.RawMessage(existingDraft.DraftData))
+		if decodeErr != nil {
+			return decodeErr
+		}
+		draftObject = mergeHistoricalRecoveryDraft(currentDraft, draftObject)
+		draftJSON, draftObject, err = normalizeHistoricalOnboardingDraftJSON(mustJSON(draftObject))
+		if err != nil {
+			return err
+		}
+	}
+	provenanceJSON, err := json.Marshal(deriveInitialProvenance(draftObject, provenanceSystem, nil, now))
+	if err != nil {
+		return err
+	}
+	if existingDraft.Revision > 0 {
+		return tx.Exec(`UPDATE agent_onboarding_drafts
+			SET draft_data = ?::jsonb, field_provenance = ?::jsonb, request_id = 'legacy-lazy-v2'
+			WHERE agent_id = ? AND revision = ? AND request_id = 'legacy-lazy-v1'`,
+			string(draftJSON), string(provenanceJSON), id, existingDraft.Revision).Error
+	}
 	return tx.Exec(`INSERT INTO agent_onboarding_drafts
 		(agent_id, revision, draft_data, field_provenance, actor_type, request_id, created_at)
-		SELECT a.agent_id, 1,
-			jsonb_build_object(
-				'identity_card', jsonb_build_object('agent_name', a.agent_name, 'bio', COALESCE(a.bio, '')),
-				'security_boundary', jsonb_build_object(
-					'recurring_publish', COALESCE(s.recurring_publish, true),
-					'auto_reply_pm', COALESCE(s.auto_reply_pm, true),
-					'auto_comment', COALESCE(s.auto_comment, true),
-					'show_add_friend', COALESCE(s.show_add_friend, true)),
-				'network_goal', '', 'intent_actions', '[]'::jsonb),
-			jsonb_build_object('identity_card', 'legacy_migration',
-				'security_boundary', 'legacy_migration'),
-			'system_derived', 'legacy-lazy-v1', ?
-		FROM agents a LEFT JOIN agent_settings s ON s.agent_id = a.agent_id
-		WHERE a.agent_id = ?
-		ON CONFLICT DO NOTHING`, now, id).Error
+		VALUES (?, 1, ?::jsonb, ?::jsonb, 'system_derived', 'legacy-lazy-v2', ?)
+		ON CONFLICT DO NOTHING`, id, string(draftJSON), string(provenanceJSON), now).Error
+}
+
+func mergeHistoricalRecoveryDraft(current, historical map[string]interface{}) map[string]interface{} {
+	currentIdentity, _ := current["identity_card"].(map[string]interface{})
+	if currentIdentity == nil {
+		currentIdentity = map[string]interface{}{}
+		current["identity_card"] = currentIdentity
+	}
+	historicalIdentity, _ := historical["identity_card"].(map[string]interface{})
+	for field, historicalValue := range historicalIdentity {
+		currentValue, exists := currentIdentity[field]
+		if !meaningfulDraftValue(currentValue, exists) && meaningfulDraftValue(historicalValue, true) {
+			currentIdentity[field] = historicalValue
+		}
+	}
+	return current
+}
+
+func mustJSON(value interface{}) json.RawMessage {
+	encoded, _ := json.Marshal(value)
+	return encoded
+}
+
+func decodeHistoricalCardObject(raw string) (map[string]interface{}, error) {
+	if strings.TrimSpace(raw) == "" {
+		return map[string]interface{}{}, nil
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func historicalIdentityCard(agentName, bio, country string, profileData, publicCard, privateCard map[string]interface{}) map[string]interface{} {
+	identity := map[string]interface{}{}
+	if value := strings.TrimSpace(agentName); value != "" {
+		identity["agent_name"] = value
+	} else if value, ok := historicalString("agent_name", publicCard); ok {
+		identity["agent_name"] = value
+	}
+	if value := strings.TrimSpace(bio); value != "" {
+		identity["bio"] = value
+		identity["agent_description"] = value
+	} else if value, ok := historicalString("agent_description", publicCard); ok {
+		identity["bio"] = value
+		identity["agent_description"] = value
+	}
+	for _, field := range []string{"human_description"} {
+		if value, ok := historicalString(field, profileData, publicCard); ok {
+			identity[field] = value
+		}
+	}
+	for _, field := range []string{"working_languages", "seeking", "offering"} {
+		if value, ok := historicalList(field, profileData, publicCard); ok {
+			identity[field] = value
+		}
+	}
+	if value, ok := historicalString("geo", profileData, privateCard); ok {
+		identity["geo"] = value
+	} else if value := strings.TrimSpace(country); value != "" {
+		identity["geo"] = value
+	}
+	if value, ok := historicalString("timezone", profileData, privateCard); ok {
+		identity["timezone"] = value
+	}
+	for _, field := range []string{"current_focus", "demands", "agent_status", "human_status", "interests_negative"} {
+		if value, ok := historicalList(field, profileData, privateCard); ok {
+			identity[field] = value
+		}
+	}
+	return identity
+}
+
+func historicalString(field string, sources ...map[string]interface{}) (string, bool) {
+	for _, source := range sources {
+		if value, ok := source[field].(string); ok {
+			if value = strings.TrimSpace(value); value != "" {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func historicalList(field string, sources ...map[string]interface{}) ([]string, bool) {
+	for _, source := range sources {
+		items := make([]string, 0)
+		switch value := source[field].(type) {
+		case []interface{}:
+			for _, item := range value {
+				if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+					items = append(items, strings.TrimSpace(text))
+				}
+			}
+		case []string:
+			for _, item := range value {
+				if text := strings.TrimSpace(item); text != "" {
+					items = append(items, text)
+				}
+			}
+		case string:
+			items = strings.FieldsFunc(value, func(r rune) bool {
+				return r == '·' || r == ',' || r == '，' || r == ';' || r == '；' || r == '\n' || r == '\r'
+			})
+			for index := range items {
+				items[index] = strings.TrimSpace(items[index])
+			}
+		}
+		if len(items) > 0 {
+			return items, true
+		}
+	}
+	return nil, false
 }
 
 func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {

--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	heartbeatContractV1 = "eigenflux_heartbeat.v1"
-	minimumConsoleV2CLI = "0.0.34"
+	minimumConsoleV2CLI = "0.0.35"
 )
 
 var skillRevisionPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
@@ -158,4 +158,8 @@ func compareConsoleCLIVersion(left, right string) int {
 		}
 	}
 	return 0
+}
+
+func recoveryRefreshCLIAllowed(accessRefreshRequired bool, cliVersion string) bool {
+	return !accessRefreshRequired || compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) >= 0
 }

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -29,9 +29,9 @@ func TestConsoleV2CompatibilityGate(t *testing.T) {
 	}{
 		{name: "missing report", status: "unknown", reason: "report_missing"},
 		{name: "old cli", cli: "0.0.33", contract: heartbeatContractV1, revision: "r1", status: "upgrade_required", reason: "cli_outdated"},
-		{name: "old heartbeat is accepted", cli: "0.0.34", contract: "legacy", revision: "r1", status: "ready", available: true},
-		{name: "missing skills is accepted", cli: "0.0.34", contract: heartbeatContractV1, status: "ready", available: true},
-		{name: "minimum ready", cli: "0.0.34", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
+		{name: "old heartbeat is accepted", cli: "0.0.35", contract: "legacy", revision: "r1", status: "ready", available: true},
+		{name: "missing skills is accepted", cli: "0.0.35", contract: heartbeatContractV1, status: "ready", available: true},
+		{name: "minimum ready", cli: "0.0.35", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
 		{name: "completed onboarding bypasses missing report", onboardingCompleted: true, status: "ready", available: true},
 	}
 	for _, test := range tests {
@@ -52,11 +52,31 @@ func TestCompareConsoleCLIVersion(t *testing.T) {
 		left, right string
 		want        int
 	}{
-		{"0.0.33", "0.0.34", -1}, {"v0.0.34", "0.0.34", 0}, {"0.0.35-dev.1", "0.0.34", 1},
+		{"0.0.34", "0.0.35", -1}, {"v0.0.35", "0.0.35", 0}, {"0.0.36-dev.1", "0.0.35", 1},
 	} {
 		if got := compareConsoleCLIVersion(test.left, test.right); got != test.want {
 			t.Fatalf("compare(%q,%q)=%d want %d", test.left, test.right, got, test.want)
 		}
+	}
+}
+
+func TestRecoveryRefreshRequiresCLI0035(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		refreshRequired bool
+		cliVersion      string
+		want            bool
+	}{
+		{name: "ordinary refresh remains compatible", cliVersion: "0.0.34", want: true},
+		{name: "recovery blocks 0.0.34", refreshRequired: true, cliVersion: "0.0.34"},
+		{name: "recovery blocks missing version", refreshRequired: true},
+		{name: "recovery allows 0.0.35", refreshRequired: true, cliVersion: "0.0.35", want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := recoveryRefreshCLIAllowed(test.refreshRequired, test.cliVersion); got != test.want {
+				t.Fatalf("allowed = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -406,6 +406,8 @@ type identityCardDraft struct {
 	Offering          []string `json:"offering"`
 	Geo               *string  `json:"geo"`
 	Timezone          *string  `json:"timezone"`
+	CurrentFocus      []string `json:"current_focus"`
+	Demands           []string `json:"demands"`
 	AgentStatus       []string `json:"agent_status"`
 	HumanStatus       []string `json:"human_status"`
 	InterestsNegative []string `json:"interests_negative"`
@@ -795,6 +797,8 @@ func applyConfirmedStep(tx *gorm.DB, agentID int64, step int16, payload draftPay
 			"working_languages":  payload.IdentityCard.WorkingLanguages,
 			"seeking":            payload.IdentityCard.Seeking,
 			"offering":           payload.IdentityCard.Offering,
+			"current_focus":      payload.IdentityCard.CurrentFocus,
+			"demands":            payload.IdentityCard.Demands,
 			"agent_status":       payload.IdentityCard.AgentStatus,
 			"human_status":       payload.IdentityCard.HumanStatus,
 			"interests_negative": payload.IdentityCard.InterestsNegative,

--- a/api/consolev2/onboarding_location.go
+++ b/api/consolev2/onboarding_location.go
@@ -20,6 +20,21 @@ var onboardingCountryAliases = map[string]string{
 	"ZZ": "ZZ", "OTHER": "ZZ", "其他": "ZZ",
 }
 
+// Historical profiles predate the ISO-only onboarding contract and may contain
+// display names emitted by older Console clients.
+var historicalOnboardingCountryAliases = map[string]string{
+	"GERMANY": "DE", "DEUTSCHLAND": "DE", "德国": "DE",
+	"FRANCE": "FR", "CANADA": "CA", "AUSTRALIA": "AU", "INDIA": "IN",
+	"BRAZIL": "BR", "SOUTH KOREA": "KR", "KOREA": "KR",
+	"SWITZERLAND": "CH", "NETHERLANDS": "NL", "SWEDEN": "SE",
+	"NORWAY": "NO", "DENMARK": "DK", "FINLAND": "FI", "SPAIN": "ES",
+	"ITALY": "IT", "PORTUGAL": "PT", "BELGIUM": "BE", "AUSTRIA": "AT",
+	"POLAND": "PL", "RUSSIA": "RU", "TURKEY": "TR",
+	"SAUDI ARABIA": "SA", "UNITED ARAB EMIRATES": "AE", "UAE": "AE",
+	"SOUTH AFRICA": "ZA", "NEW ZEALAND": "NZ", "THAILAND": "TH",
+	"VIETNAM": "VN", "INDONESIA": "ID", "MALAYSIA": "MY", "PHILIPPINES": "PH",
+}
+
 var onboardingTimezoneAliases = map[string]string{
 	"ASIA/SHANGHAI":       "Asia/Shanghai",
 	"ASIA/SINGAPORE":      "Asia/Singapore",
@@ -33,6 +48,8 @@ var onboardingListFields = []string{
 	"working_languages",
 	"seeking",
 	"offering",
+	"current_focus",
+	"demands",
 	"agent_status",
 	"human_status",
 	"interests_negative",
@@ -169,4 +186,60 @@ func normalizeOnboardingDraftJSON(raw json.RawMessage) (json.RawMessage, map[str
 	}
 	encoded, err := json.Marshal(draft)
 	return encoded, draft, err
+}
+
+// normalizeHistoricalOnboardingDraftJSON keeps ordinary onboarding validation
+// strict while tolerating optional location values written by older clients.
+// Recognized legacy values are normalized; unrecognized values are cleared so
+// they cannot prevent identity recovery.
+func normalizeHistoricalOnboardingDraftJSON(raw json.RawMessage) (json.RawMessage, map[string]interface{}, error) {
+	draft, err := decodeJSONObject(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	normalizeHistoricalOnboardingDraftLocations(draft)
+	if err := normalizeOnboardingDraftLists(draft); err != nil {
+		return nil, nil, err
+	}
+	encoded, err := json.Marshal(draft)
+	return encoded, draft, err
+}
+
+func normalizeHistoricalOnboardingDraftLocations(draft map[string]interface{}) {
+	identity, ok := draft["identity_card"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	country := ""
+	if raw, exists := identity["geo"]; exists {
+		if text, ok := raw.(string); ok {
+			if normalized, valid := normalizeHistoricalOnboardingCountry(text); valid {
+				country = normalized
+				identity["geo"] = normalized
+			} else {
+				identity["geo"] = ""
+			}
+		} else {
+			identity["geo"] = ""
+		}
+	}
+	if raw, exists := identity["timezone"]; exists {
+		if text, ok := raw.(string); ok {
+			if normalized, err := normalizeOnboardingTimezone(text, country); err == nil {
+				identity["timezone"] = normalized
+			} else {
+				identity["timezone"] = ""
+			}
+		} else {
+			identity["timezone"] = ""
+		}
+	}
+}
+
+func normalizeHistoricalOnboardingCountry(raw string) (string, bool) {
+	if normalized, err := normalizeOnboardingCountry(raw); err == nil {
+		return normalized, true
+	}
+	value, ok := historicalOnboardingCountryAliases[strings.ToUpper(strings.TrimSpace(raw))]
+	return value, ok
 }

--- a/api/consolev2/onboarding_provenance.go
+++ b/api/consolev2/onboarding_provenance.go
@@ -41,6 +41,8 @@ var onboardingDraftFieldPaths = []string{
 	"identity_card.offering",
 	"identity_card.geo",
 	"identity_card.timezone",
+	"identity_card.current_focus",
+	"identity_card.demands",
 	"identity_card.agent_status",
 	"identity_card.human_status",
 	"identity_card.interests_negative",

--- a/api/consolev2/recovery_abandon_postgres_test.go
+++ b/api/consolev2/recovery_abandon_postgres_test.go
@@ -1,0 +1,368 @@
+package consolev2
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	redis "github.com/redis/go-redis/v9"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/config"
+)
+
+// This database regression verifies that recovery tombstones an unbound
+// installation Agent without moving its draft, card, membership, or relations.
+func TestHistoricalRecoveryAbandonsUnboundTemporaryAgent(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required")
+	}
+	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	idgen := &fixedIDGenerator{id: time.Now().UnixMilli() * 1000}
+	svc, err := NewService(gdb, idgen, &config.Config{
+		ConsoleV2BootstrapSecret: "abandon-broker-secret",
+		ConsoleV2OTPPepper:       "abandon-otp-pepper",
+		ConsoleV2PublicURL:       "https://console.example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	redisServer := miniredis.RunT(t)
+	svc.redisClient = redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	defer svc.redisClient.Close()
+	mailbox := make(chan capturedEmail, 2)
+	svc.emailSender = &captureEmailSender{sent: mailbox}
+	svc.startEmailWorkers(1, 16)
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	svc.Register(h)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKeyEncoded := base64.RawURLEncoding.EncodeToString(publicKey)
+	draftJSON, err := json.Marshal(map[string]interface{}{
+		"identity_card": map[string]interface{}{
+			"agent_name": "Temporary Installation Agent",
+			"bio":        "temporary draft must be removed",
+		},
+		"security_boundary": map[string]interface{}{
+			"recurring_publish": false, "auto_reply_pm": false,
+			"auto_comment": false, "show_add_friend": true,
+		},
+		"network_goal":   "temporary goal must not migrate",
+		"intent_actions": []interface{}{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entitlement := "abandon-recovery-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	status, grantPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/bootstrap-grants", map[string]interface{}{
+		"entitlement_id":  entitlement,
+		"idempotency_key": "grant-" + hashString(entitlement),
+		"channel":         "test", "policy": "limited", "public_key": publicKeyEncoded,
+	}, ut.Header{Key: "X-Bootstrap-Broker-Secret", Value: "abandon-broker-secret"})
+	if status != http.StatusCreated {
+		t.Fatalf("grant status=%d payload=%#v", status, grantPayload)
+	}
+	grantData := responseData(t, grantPayload)
+	provisionReq := provisionRequest{
+		BootstrapGrant: grantData["bootstrap_grant"].(string),
+		IdempotencyKey: "provision-" + hashString(entitlement),
+		Nonce:          grantData["nonce"].(string),
+		PublicKey:      publicKeyEncoded,
+		IssuedAt:       time.Now().UnixMilli(),
+		AgentName:      "Temporary Installation Agent",
+		Draft:          draftJSON,
+	}
+	provisionBytes, err := provisionTranscript(provisionReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionReq.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, provisionBytes))
+	status, provisionPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-identities/provision", provisionReq,
+		ut.Header{Key: "X-Client-Host", Value: "codex/1.0"})
+	if status != http.StatusOK {
+		t.Fatalf("provision status=%d payload=%#v", status, provisionPayload)
+	}
+	provisionData := responseData(t, provisionPayload)
+	sourceID := mustParseInt64(t, provisionData["agent_id"].(string))
+	principalID := mustParseInt64(t, provisionData["principal_id"].(string))
+	oldAccess := provisionData["access_token"].(string)
+	oldRefresh := provisionData["refresh_token"].(string)
+
+	now := time.Now().UnixMilli()
+	targetID, _ := idgen.NextID()
+	historicalEmail := fmt.Sprintf("historical-abandon-%d@example.test", targetID)
+	targetShortID, err := agentidentity.GenerateShortID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agents
+		(agent_id, short_id, email, email_kind, agent_name, bio, created_at, updated_at, email_verified_at, profile_completed_at)
+		VALUES (?, ?, ?, 'legacy_real', 'Historical Aurora', 'historical biography', ?, ?, ?, ?)`,
+		targetID, targetShortID, historicalEmail, now-86400000, now-86400000, now-86400000, now-86400000).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_profiles
+		(agent_id, status, country, profile_data, updated_at)
+		VALUES (?, 0, 'SG', '{"seeking":["historical peers"]}'::jsonb, ?)`, targetID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_cards
+		(agent_id, public_card, private_card, schema_version, source_version, rebuild_fence,
+		 card_version, public_card_version, generated_at, public_card_generated_at)
+		VALUES (?, '{"agent_description":"historical description"}'::jsonb, '{}'::jsonb,
+		1, 1, 1, 1, 1, ?, ?)`, targetID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_email_bindings
+		(agent_id, normalized_email, normalization_version, verification_state, status, verified_at, created_at, updated_at)
+		VALUES (?, ?, 1, 'verified', 'active', ?, ?, ?)`, targetID, historicalEmail, now, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_cards
+		(agent_id, public_card, private_card, schema_version, source_version, rebuild_fence,
+		 card_version, public_card_version, generated_at, public_card_generated_at)
+		VALUES (?, '{"agent_description":"TEMP_CARD_MUST_BE_REMOVED"}'::jsonb, '{}'::jsonb,
+		1, 1, 1, 1, 1, ?, ?)`, sourceID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_network_memberships (agent_id, joined_at)
+		VALUES (?, ?) ON CONFLICT (agent_id) DO NOTHING`, sourceID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	relationID, _ := idgen.NextID()
+	if err := gdb.Exec(`INSERT INTO friend_requests
+		(id, from_uid, to_uid, status, greeting, remark, created_at, updated_at)
+		VALUES (?, ?, ?, 0, 'temporary source relation', '', ?, ?)`, relationID, sourceID, targetID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	orphanPublicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orphanPrincipalID, _ := idgen.NextID()
+	if err := gdb.Exec(`INSERT INTO agent_principals
+		(principal_id, agent_id, key_type, key_fingerprint, public_key, key_version, status, created_at, last_seen_at)
+		VALUES (?, ?, 'ed25519-v1', ?, ?, 1, 'limited', ?, ?)`, orphanPrincipalID, sourceID,
+		"orphan-"+hashString(entitlement), []byte(orphanPublicKey), now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_credential_sessions
+		(principal_id, family_id, access_token_hash, refresh_token_hash, audience, scopes,
+		 issued_at, expires_at, absolute_expires_at, last_seen_at)
+		VALUES (?, ?, ?, ?, 'agent-api', '{}'::text[], ?, ?, ?, ?)`, orphanPrincipalID,
+		"orphan-family-"+hashString(entitlement), "orphan-access-"+hashString(entitlement),
+		"orphan-refresh-"+hashString(entitlement), now, now+3600000, now+7200000, now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	createHandoff := func(nonce string) string {
+		status, payload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs", map[string]interface{}{
+			"browser_nonce": nonce, "client_capabilities": []string{"account_recovery_v1"},
+		}, ut.Header{Key: "Authorization", Value: "Bearer " + oldAccess})
+		if status != http.StatusCreated {
+			t.Fatalf("handoff status=%d payload=%#v", status, payload)
+		}
+		parsed, err := url.Parse(responseData(t, payload)["handoff_url"].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return parsed.Query().Get("ticket")
+	}
+	browserNonce := strings.Repeat("a", 32)
+	ticket := createHandoff(browserNonce)
+	status, exchangePayload, cookies := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs/exchange", map[string]interface{}{
+		"ticket": ticket, "browser_nonce": browserNonce,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("exchange status=%d payload=%#v", status, exchangePayload)
+	}
+	csrf := responseData(t, exchangePayload)["csrf_token"].(string)
+	cookieHeader := cookiePair(cookies, consoleCookieName) + "; " + cookiePair(cookies, csrfCookieName)
+	staleNonce := strings.Repeat("s", 32)
+	staleTicket := createHandoff(staleNonce)
+
+	orphanConsoleID := "orphan-console-" + hashString(entitlement)
+	if err := gdb.Exec(`INSERT INTO console_v2_sessions
+		(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash, status, scopes,
+		 issued_at, idle_expires_at, absolute_expires_at, last_seen_at, client_capabilities)
+		VALUES (?, ?, ?, ?, ?, 'active', '{}'::text[], ?, ?, ?, ?, '{}'::text[])`, orphanConsoleID,
+		"orphan-secret-"+hashString(entitlement), sourceID, orphanPrincipalID,
+		"orphan-csrf-"+hashString(entitlement), now, now+3600000, now+7200000, now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	status, challengePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-email-bindings/challenges", createEmailChallengeRequest{
+		Email: historicalEmail,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusAccepted {
+		t.Fatalf("email challenge status=%d payload=%#v", status, challengePayload)
+	}
+	var mail capturedEmail
+	select {
+	case mail = <-mailbox:
+	case <-time.After(2 * time.Second):
+		t.Fatal("email OTP not captured")
+	}
+	status, conflictPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-email-bindings/verify", verifyEmailRequest{
+		ChallengeID: responseData(t, challengePayload)["challenge_id"].(string),
+		Email:       historicalEmail, OTP: mail.otp,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusConflict || responseErrorCode(t, conflictPayload) != "EMAIL_UNAVAILABLE" {
+		t.Fatalf("expected recoverable conflict, status=%d payload=%#v", status, conflictPayload)
+	}
+	details := conflictPayload["error"].(map[string]interface{})["details"].(map[string]interface{})
+	if details["reason"] != "existing_agent_recovery_available" || details["source_disposition"] != recoverySourceAbandon {
+		t.Fatalf("unbound source was not classified for abandonment: %#v", details)
+	}
+	recoveryID := details["recovery_id"].(string)
+	status, recoveryPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-recoveries/"+recoveryID+"/confirm", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusOK {
+		t.Fatalf("recovery status=%d payload=%#v", status, recoveryPayload)
+	}
+	recoveryData := responseData(t, recoveryPayload)
+	if recoveryData["agent_id"] != strconv.FormatInt(targetID, 10) ||
+		recoveryData["principal_id"] != strconv.FormatInt(principalID, 10) ||
+		recoveryData["source_disposition"] != recoverySourceAbandon || recoveryData["source_agent_abandoned"] != true {
+		t.Fatalf("recovery returned wrong identity or disposition: %#v", recoveryData)
+	}
+
+	var sourceState, sourceEmail, sourceEmailKind string
+	var sourceEmailVerifiedAt int64
+	if err := gdb.Raw(`SELECT identity_state, email, email_kind, COALESCE(email_verified_at, 0)
+		FROM agents WHERE agent_id = ?`, sourceID).
+		Row().Scan(&sourceState, &sourceEmail, &sourceEmailKind, &sourceEmailVerifiedAt); err != nil {
+		t.Fatal(err)
+	}
+	wantSourceEmail := fmt.Sprintf("recovered-%d@identity.invalid", sourceID)
+	if sourceState != "recovered_temporary" || sourceEmail != wantSourceEmail ||
+		sourceEmailKind != "internal_alias" || sourceEmailVerifiedAt != 0 {
+		t.Fatalf("temporary source was not tombstoned: state=%q email=%q kind=%q verified_at=%d",
+			sourceState, sourceEmail, sourceEmailKind, sourceEmailVerifiedAt)
+	}
+	if _, err := agentidentity.Get(context.Background(), gdb, sourceID); !errors.Is(err, agentidentity.ErrNotFound) {
+		t.Fatalf("abandoned source lookup error=%v, want ErrNotFound", err)
+	}
+
+	var movedAgentID int64
+	if err := gdb.Raw(`SELECT agent_id FROM agent_principals WHERE principal_id = ?`, principalID).Scan(&movedAgentID).Error; err != nil {
+		t.Fatal(err)
+	}
+	var sourceProjectionCount, sourceBindingCount, relationCount int64
+	if err := gdb.Raw(`SELECT
+		(EXISTS (SELECT 1 FROM agent_onboarding_drafts WHERE agent_id = ?))::int +
+		(EXISTS (SELECT 1 FROM agent_cards WHERE agent_id = ?))::int +
+		(EXISTS (SELECT 1 FROM agent_network_memberships WHERE agent_id = ?))::int`,
+		sourceID, sourceID, sourceID).Scan(&sourceProjectionCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND status = 'active'`, sourceID).
+		Scan(&sourceBindingCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM friend_requests WHERE id = ? AND from_uid = ? AND to_uid = ?`,
+		relationID, sourceID, targetID).Scan(&relationCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	var orphanPrincipalStatus, orphanConsoleStatus string
+	var orphanPrincipalRevokedAt, orphanCredentialRevokedAt, orphanConsoleRevokedAt int64
+	if err := gdb.Raw(`SELECT status, COALESCE(revoked_at, 0) FROM agent_principals WHERE principal_id = ?`, orphanPrincipalID).
+		Row().Scan(&orphanPrincipalStatus, &orphanPrincipalRevokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COALESCE(revoked_at, 0) FROM agent_credential_sessions WHERE principal_id = ?`, orphanPrincipalID).
+		Scan(&orphanCredentialRevokedAt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT status, COALESCE(revoked_at, 0) FROM console_v2_sessions WHERE session_id = ?`, orphanConsoleID).
+		Row().Scan(&orphanConsoleStatus, &orphanConsoleRevokedAt); err != nil {
+		t.Fatal(err)
+	}
+	if movedAgentID != targetID || sourceProjectionCount != 0 || sourceBindingCount != 0 || relationCount != 1 ||
+		orphanPrincipalStatus != "revoked" || orphanPrincipalRevokedAt == 0 || orphanCredentialRevokedAt == 0 ||
+		orphanConsoleStatus != "revoked" || orphanConsoleRevokedAt == 0 {
+		t.Fatalf("abandonment cleanup mismatch: moved_agent=%d projections=%d bindings=%d relations=%d orphan_principal=%q/%d credential_revoked=%d orphan_console=%q/%d",
+			movedAgentID, sourceProjectionCount, sourceBindingCount, relationCount, orphanPrincipalStatus,
+			orphanPrincipalRevokedAt, orphanCredentialRevokedAt, orphanConsoleStatus, orphanConsoleRevokedAt)
+	}
+
+	status, sessionPayload, _ := performJSON(t, h, http.MethodGet, "/api/v2/console/session", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != http.StatusOK || responseData(t, sessionPayload)["agent_id"] != strconv.FormatInt(targetID, 10) {
+		t.Fatalf("console session did not move to historical Agent: status=%d payload=%#v", status, sessionPayload)
+	}
+	status, draftPayload, _ := performJSON(t, h, http.MethodGet, "/api/v2/agents/me/onboarding-draft", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != http.StatusOK {
+		t.Fatalf("historical draft status=%d payload=%#v", status, draftPayload)
+	}
+	historicalDraft := responseData(t, draftPayload)["draft"].(map[string]interface{})["data"].(map[string]interface{})
+	historicalIdentity := historicalDraft["identity_card"].(map[string]interface{})
+	if historicalIdentity["agent_name"] != "Historical Aurora" || historicalIdentity["bio"] != "historical biography" {
+		t.Fatalf("temporary draft leaked into historical Agent: %#v", historicalIdentity)
+	}
+
+	status, stalePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs/exchange", map[string]interface{}{
+		"ticket": staleTicket, "browser_nonce": staleNonce,
+	})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("temporary source handoff survived: status=%d payload=%#v", status, stalePayload)
+	}
+	status, oldAccessPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs", map[string]interface{}{
+		"browser_nonce": strings.Repeat("o", 32), "client_capabilities": []string{"account_recovery_v1"},
+	}, ut.Header{Key: "Authorization", Value: "Bearer " + oldAccess})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("pre-recovery access token survived: status=%d payload=%#v", status, oldAccessPayload)
+	}
+
+	rotationID := "abandon-rotation-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	status, refreshChallengePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-sessions/refresh-challenges", refreshChallengeRequest{
+		RefreshToken: oldRefresh, RotationRequestID: rotationID,
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("refresh challenge status=%d payload=%#v", status, refreshChallengePayload)
+	}
+	refreshData := responseData(t, refreshChallengePayload)
+	refreshReq := refreshAgentSessionRequest{
+		RefreshToken: oldRefresh, RotationRequestID: rotationID,
+		Nonce: refreshData["nonce"].(string), PublicKey: publicKeyEncoded, IssuedAt: time.Now().UnixMilli(),
+	}
+	refreshBytes, err := refreshTranscript(refreshReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refreshReq.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, refreshBytes))
+	status, refreshedPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-sessions/refresh", refreshReq,
+		ut.Header{Key: "X-CLI-Ver", Value: "0.0.35"})
+	if status != http.StatusOK {
+		t.Fatalf("CLI refresh status=%d payload=%#v", status, refreshedPayload)
+	}
+	refreshed := responseData(t, refreshedPayload)
+	if refreshed["agent_id"] != strconv.FormatInt(targetID, 10) || refreshed["principal_id"] != strconv.FormatInt(principalID, 10) {
+		t.Fatalf("CLI refresh did not adopt historical Agent: %#v", refreshed)
+	}
+}

--- a/api/consolev2/recovery_data_regression_test.go
+++ b/api/consolev2/recovery_data_regression_test.go
@@ -1,0 +1,486 @@
+package consolev2
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	redis "github.com/redis/go-redis/v9"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/config"
+)
+
+// This database regression verifies that switching away from an email-bound
+// source preserves the formal account and allows switching back later.
+func TestHistoricalRecoveryPreservesBoundSourceAgent(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required")
+	}
+	gdb, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	idgen := &fixedIDGenerator{id: time.Now().UnixMilli() * 1000}
+	svc, err := NewService(gdb, idgen, &config.Config{
+		ConsoleV2BootstrapSecret: "review-broker-secret",
+		ConsoleV2OTPPepper:       "review-otp-pepper",
+		ConsoleV2PublicURL:       "https://console.example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	redisServer := miniredis.RunT(t)
+	svc.redisClient = redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	defer svc.redisClient.Close()
+	mailbox := make(chan capturedEmail, 4)
+	svc.emailSender = &captureEmailSender{sent: mailbox}
+	svc.startEmailWorkers(1, 16)
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	svc.Register(h)
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKeyEncoded := base64.RawURLEncoding.EncodeToString(publicKey)
+	draftJSON, _ := json.Marshal(map[string]interface{}{
+		"identity_card": map[string]interface{}{
+			"agent_name": "Disposable Installation Agent",
+			"bio":        "temporary prefill must disappear",
+		},
+		"security_boundary": map[string]interface{}{
+			"recurring_publish": false, "auto_reply_pm": false,
+			"auto_comment": false, "show_add_friend": true,
+		},
+		"network_goal":   "temporary network goal",
+		"intent_actions": []interface{}{},
+	})
+	entitlement := "review-recovery-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	status, grantPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/bootstrap-grants", map[string]interface{}{
+		"entitlement_id": entitlement, "idempotency_key": "grant-" + hashString(entitlement),
+		"channel": "review", "policy": "limited", "public_key": publicKeyEncoded,
+	}, ut.Header{Key: "X-Bootstrap-Broker-Secret", Value: "review-broker-secret"})
+	if status != http.StatusCreated {
+		t.Fatalf("grant status=%d payload=%#v", status, grantPayload)
+	}
+	grantData := responseData(t, grantPayload)
+	provisionReq := provisionRequest{
+		BootstrapGrant: grantData["bootstrap_grant"].(string),
+		IdempotencyKey: "provision-" + hashString(entitlement),
+		Nonce:          grantData["nonce"].(string),
+		PublicKey:      publicKeyEncoded,
+		IssuedAt:       time.Now().UnixMilli(),
+		AgentName:      "Disposable Installation Agent",
+		Draft:          draftJSON,
+	}
+	provisionTranscriptBytes, err := provisionTranscript(provisionReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionReq.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, provisionTranscriptBytes))
+	status, provisionPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-identities/provision", provisionReq,
+		ut.Header{Key: "X-Client-Host", Value: "codex/1.0"})
+	if status != http.StatusOK {
+		t.Fatalf("provision status=%d payload=%#v", status, provisionPayload)
+	}
+	provisionData := responseData(t, provisionPayload)
+	sourceID := mustParseInt64(t, provisionData["agent_id"].(string))
+	principalID := mustParseInt64(t, provisionData["principal_id"].(string))
+	oldAccess := provisionData["access_token"].(string)
+	oldRefresh := provisionData["refresh_token"].(string)
+
+	now := time.Now().UnixMilli()
+	targetID, _ := idgen.NextID()
+	historicalEmail := fmt.Sprintf("historical-review-%d@example.test", targetID)
+	historicalShortID, err := agentidentity.GenerateShortID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agents
+		(agent_id, short_id, email, email_kind, agent_name, bio, created_at, updated_at, email_verified_at, profile_completed_at)
+		VALUES (?, ?, ?, 'legacy_real', 'Historical Atlas', 'historical card bio', ?, ?, ?, ?)`,
+		targetID, historicalShortID, historicalEmail, now-86400000, now-86400000, now-86400000, now-86400000).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_profiles
+		(agent_id, status, country, profile_data, updated_at)
+		VALUES (?, 0, 'SG', '{"seeking":["historical partners"],"offering":["historical research"]}'::jsonb, ?)`,
+		targetID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_cards
+		(agent_id, public_card, private_card, schema_version, source_version, rebuild_fence,
+		 card_version, public_card_version, generated_at, public_card_generated_at)
+		VALUES (?, '{"agent_description":"historical public description","seeking":["historical partners"]}'::jsonb,
+		'{"current_focus":["historical focus"]}'::jsonb, 1, 3, 3, 4, 4, ?, ?)`, targetID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_email_bindings
+		(agent_id, normalized_email, normalization_version, verification_state, status, verified_at, created_at, updated_at)
+		VALUES (?, ?, 1, 'verified', 'active', ?, ?, ?)`, targetID, historicalEmail, now, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_context_revisions
+		(agent_id, revision, compiled_context, schema_version, generated_at)
+		VALUES (?, 1, '{"owner":"historical"}'::jsonb, 1, ?)`, targetID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_context_heads (agent_id, current_revision, active_revision, updated_at)
+		VALUES (?, 1, 1, ?)`, targetID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_onboarding_v2
+		(agent_id, state, current_step, revision, active_context_revision, completed_at, created_at, updated_at)
+		VALUES (?, 'completed', 5, 7, 1, ?, ?, ?)`, targetID, now, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_onboarding_drafts
+		(agent_id, revision, draft_data, field_provenance, actor_type, request_id, created_at)
+		VALUES (?, 7,
+		'{"identity_card":{"agent_name":"Historical Atlas","bio":"historical card bio","agent_description":"historical public description","seeking":["historical partners"],"current_focus":["historical focus"]},"security_boundary":{"recurring_publish":false,"auto_reply_pm":false,"auto_comment":false,"show_add_friend":true},"network_goal":"historical goal","intent_actions":[]}'::jsonb,
+		'{}'::jsonb, 'human_edit', 'historical-confirmed', ?)`, targetID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_feed_v2_settings
+		(agent_id, poll_interval_seconds, explicitly_set, updated_at) VALUES (?, 600, false, ?)`, targetID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_cards
+		(agent_id, public_card, private_card, schema_version, source_version, rebuild_fence,
+		 card_version, public_card_version, generated_at, public_card_generated_at)
+		VALUES (?, '{"agent_description":"TEMP_CARD_MUST_DISAPPEAR"}'::jsonb, '{}'::jsonb,
+		1, 1, 1, 1, 1, ?, ?)`, sourceID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_network_memberships (agent_id, joined_at)
+		VALUES (?, ?) ON CONFLICT (agent_id) DO NOTHING`, sourceID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	createHandoff := func(nonce string) (string, map[string]interface{}) {
+		status, payload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs", map[string]interface{}{
+			"browser_nonce": nonce, "client_capabilities": []string{"account_recovery_v1"},
+		}, ut.Header{Key: "Authorization", Value: "Bearer " + oldAccess})
+		if status != http.StatusCreated {
+			t.Fatalf("handoff status=%d payload=%#v", status, payload)
+		}
+		parsed, err := url.Parse(responseData(t, payload)["handoff_url"].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return parsed.Query().Get("ticket"), payload
+	}
+	browserNonce := strings.Repeat("r", 32)
+	ticket, _ := createHandoff(browserNonce)
+	status, exchangePayload, cookies := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs/exchange", map[string]interface{}{
+		"ticket": ticket, "browser_nonce": browserNonce,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("exchange status=%d payload=%#v", status, exchangePayload)
+	}
+	exchangeData := responseData(t, exchangePayload)
+	csrf := exchangeData["csrf_token"].(string)
+	cookieHeader := cookiePair(cookies, consoleCookieName) + "; " + cookiePair(cookies, csrfCookieName)
+
+	discardedEmail := fmt.Sprintf("discarded-%d@example.test", sourceID)
+	if err := gdb.Exec(`UPDATE agents SET email = ?, email_kind = 'v2_bound', email_verified_at = ?, updated_at = ?
+		WHERE agent_id = ?`, discardedEmail, now, now, sourceID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_email_bindings
+		(agent_id, normalized_email, normalization_version, verification_state, status, verified_at, created_at, updated_at)
+		VALUES (?, ?, 1, 'verified', 'active', ?, ?, ?)`, sourceID, discardedEmail, now, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_context_revisions
+		(agent_id, revision, compiled_context, schema_version, generated_at)
+		VALUES (?, 1, '{"owner":"bound source"}'::jsonb, 1, ?)
+		ON CONFLICT (agent_id, revision) DO NOTHING`, sourceID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_context_heads
+		(agent_id, current_revision, active_revision, updated_at)
+		VALUES (?, 1, 1, ?)
+		ON CONFLICT (agent_id) DO UPDATE SET active_revision = 1, updated_at = EXCLUDED.updated_at`, sourceID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`UPDATE agent_onboarding_v2
+		SET state = 'completed', current_step = 5, active_context_revision = 1, completed_at = ?, updated_at = ? WHERE agent_id = ?`,
+		now, now, sourceID).Error; err != nil {
+		t.Fatal(err)
+	}
+	discardedRequestID, _ := idgen.NextID()
+	if err := gdb.Exec(`INSERT INTO friend_requests
+		(id, from_uid, to_uid, status, greeting, remark, created_at, updated_at)
+		VALUES (?, ?, ?, 0, 'discarded source activity', '', ?, ?)`,
+		discardedRequestID, sourceID, targetID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	staleNonce := strings.Repeat("s", 32)
+	staleTicket, _ := createHandoff(staleNonce)
+	status, challengePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-email-bindings/challenges", createEmailChallengeRequest{
+		Email: historicalEmail,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusAccepted {
+		t.Fatalf("email challenge status=%d payload=%#v", status, challengePayload)
+	}
+	var mail capturedEmail
+	select {
+	case mail = <-mailbox:
+	case <-time.After(2 * time.Second):
+		t.Fatal("email OTP not captured")
+	}
+	status, conflictPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-email-bindings/verify", verifyEmailRequest{
+		ChallengeID: responseData(t, challengePayload)["challenge_id"].(string),
+		Email:       historicalEmail, OTP: mail.otp,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusConflict || responseErrorCode(t, conflictPayload) != "EMAIL_UNAVAILABLE" {
+		t.Fatalf("expected recoverable conflict, status=%d payload=%#v", status, conflictPayload)
+	}
+	errorData := conflictPayload["error"].(map[string]interface{})
+	details := errorData["details"].(map[string]interface{})
+	if details["reason"] != "existing_agent_recovery_available" {
+		t.Fatalf("unexpected recovery details: %#v", details)
+	}
+	if details["source_disposition"] != recoverySourcePreserve {
+		t.Fatalf("bound source must be preserved: %#v", details)
+	}
+	recoveryID := details["recovery_id"].(string)
+	candidate := details["candidate"].(map[string]interface{})
+	if candidate["display_name"] != "Historical Atlas" {
+		t.Fatalf("wrong historical candidate: %#v", candidate)
+	}
+
+	status, recoveryPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-recoveries/"+recoveryID+"/confirm", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusOK {
+		t.Fatalf("recovery status=%d payload=%#v", status, recoveryPayload)
+	}
+	recoveryData := responseData(t, recoveryPayload)
+	if recoveryData["agent_id"] != strconv.FormatInt(targetID, 10) || recoveryData["principal_id"] != strconv.FormatInt(principalID, 10) {
+		t.Fatalf("recovery returned wrong identity: %#v", recoveryData)
+	}
+	if recoveryData["source_agent_abandoned"] != false || recoveryData["source_disposition"] != recoverySourcePreserve {
+		t.Fatalf("bound source was treated as temporary: %#v", recoveryData)
+	}
+	status, replayPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-recoveries/"+recoveryID+"/confirm", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusOK || responseData(t, replayPayload)["agent_id"] != strconv.FormatInt(targetID, 10) {
+		t.Fatalf("recovery idempotency failed: status=%d payload=%#v", status, replayPayload)
+	}
+
+	var sourceState, targetState string
+	if err := gdb.Raw(`SELECT identity_state FROM agents WHERE agent_id = ?`, sourceID).Scan(&sourceState).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT identity_state FROM agents WHERE agent_id = ?`, targetID).Scan(&targetState).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sourceState != "active" || targetState != "active" {
+		t.Fatalf("identity states source=%q target=%q", sourceState, targetState)
+	}
+	var sourceCanonicalEmail, sourceEmailKind string
+	if err := gdb.Raw(`SELECT email, email_kind FROM agents WHERE agent_id = ?`, sourceID).
+		Row().Scan(&sourceCanonicalEmail, &sourceEmailKind); err != nil {
+		t.Fatal(err)
+	}
+	if sourceCanonicalEmail != discardedEmail || sourceEmailKind != "v2_bound" {
+		t.Fatalf("formal Agent lost its login email: email=%q kind=%q", sourceCanonicalEmail, sourceEmailKind)
+	}
+	var movedAgentID int64
+	if err := gdb.Raw(`SELECT agent_id FROM agent_principals WHERE principal_id = ?`, principalID).Scan(&movedAgentID).Error; err != nil || movedAgentID != targetID {
+		t.Fatalf("principal did not move to target: agent=%d err=%v", movedAgentID, err)
+	}
+	var sourcePrincipalCount, sourceBindingCount, targetBindingCount, sourceProjectionCount, sourceRelationCount, refreshRequiredCount int64
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_principals WHERE agent_id = ?`, sourceID).Scan(&sourcePrincipalCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND status = 'active'`, sourceID).Scan(&sourceBindingCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND status = 'active'`, targetID).Scan(&targetBindingCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT
+		(EXISTS (SELECT 1 FROM agent_onboarding_drafts WHERE agent_id = ?))::int +
+		(EXISTS (SELECT 1 FROM agent_cards WHERE agent_id = ?))::int +
+		(EXISTS (SELECT 1 FROM agent_network_memberships WHERE agent_id = ?))::int`,
+		sourceID, sourceID, sourceID).Scan(&sourceProjectionCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM friend_requests WHERE id = ? AND from_uid = ? AND to_uid = ?`,
+		discardedRequestID, sourceID, targetID).Scan(&sourceRelationCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_credential_sessions
+		WHERE principal_id = ? AND revoked_at IS NULL AND access_refresh_required = TRUE`, principalID).Scan(&refreshRequiredCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sourcePrincipalCount != 0 || sourceBindingCount != 1 || targetBindingCount != 1 || sourceProjectionCount != 3 || sourceRelationCount != 1 || refreshRequiredCount == 0 {
+		t.Fatalf("formal accounts were not preserved: principals=%d source_bindings=%d target_bindings=%d projections=%d relations=%d refresh_required=%d",
+			sourcePrincipalCount, sourceBindingCount, targetBindingCount, sourceProjectionCount, sourceRelationCount, refreshRequiredCount)
+	}
+	if _, err := agentidentity.Get(context.Background(), gdb, sourceID); err != nil {
+		t.Fatalf("preserved formal Agent is no longer discoverable: %v", err)
+	}
+
+	status, sessionPayload, _ := performJSON(t, h, http.MethodGet, "/api/v2/console/session", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != http.StatusOK {
+		t.Fatalf("recovered console session status=%d payload=%#v", status, sessionPayload)
+	}
+	sessionData := responseData(t, sessionPayload)
+	if sessionData["agent_id"] != strconv.FormatInt(targetID, 10) || sessionData["agent_name"] != "Historical Atlas" || sessionData["email"] != historicalEmail {
+		t.Fatalf("console did not switch to historical Agent: %#v", sessionData)
+	}
+	status, draftPayload, _ := performJSON(t, h, http.MethodGet, "/api/v2/agents/me/onboarding-draft", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != http.StatusOK {
+		t.Fatalf("historical draft status=%d payload=%#v", status, draftPayload)
+	}
+	historicalDraft := responseData(t, draftPayload)["draft"].(map[string]interface{})
+	historicalData := historicalDraft["data"].(map[string]interface{})
+	historicalIdentity := historicalData["identity_card"].(map[string]interface{})
+	if historicalIdentity["agent_name"] != "Historical Atlas" || historicalIdentity["bio"] != "historical card bio" {
+		t.Fatalf("temporary draft leaked into recovered console: %#v", historicalIdentity)
+	}
+
+	status, staleExchangePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs/exchange", map[string]interface{}{
+		"ticket": staleTicket, "browser_nonce": staleNonce,
+	})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("moved principal's stale handoff survived: status=%d payload=%#v", status, staleExchangePayload)
+	}
+	status, oldTokenPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs", map[string]interface{}{
+		"browser_nonce": strings.Repeat("o", 32), "client_capabilities": []string{"account_recovery_v1"},
+	}, ut.Header{Key: "Authorization", Value: "Bearer " + oldAccess})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("old source access token survived recovery: status=%d payload=%#v", status, oldTokenPayload)
+	}
+
+	provisionReq.IssuedAt = time.Now().UnixMilli()
+	provisionTranscriptBytes, err = provisionTranscript(provisionReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionReq.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, provisionTranscriptBytes))
+	status, reprovisionPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-identities/provision", provisionReq,
+		ut.Header{Key: "X-Client-Host", Value: "codex/1.0"})
+	if status != http.StatusOK {
+		t.Fatalf("same-home reprovision status=%d payload=%#v", status, reprovisionPayload)
+	}
+	reprovisionData := responseData(t, reprovisionPayload)
+	if reprovisionData["agent_id"] != strconv.FormatInt(targetID, 10) || reprovisionData["created"] != false {
+		t.Fatalf("same key did not retain the selected Agent: %#v", reprovisionData)
+	}
+
+	rotationID := "review-rotation-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	status, refreshChallengePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-sessions/refresh-challenges", refreshChallengeRequest{
+		RefreshToken: oldRefresh, RotationRequestID: rotationID,
+	})
+	if status != http.StatusCreated {
+		t.Fatalf("refresh challenge status=%d payload=%#v", status, refreshChallengePayload)
+	}
+	refreshChallengeData := responseData(t, refreshChallengePayload)
+	refreshReq := refreshAgentSessionRequest{
+		RefreshToken: oldRefresh, RotationRequestID: rotationID,
+		Nonce: refreshChallengeData["nonce"].(string), PublicKey: publicKeyEncoded,
+		IssuedAt: time.Now().UnixMilli(),
+	}
+	refreshTranscriptBytes, err := refreshTranscript(refreshReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refreshReq.Signature = base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, refreshTranscriptBytes))
+	status, oldCLIPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-sessions/refresh", refreshReq,
+		ut.Header{Key: "X-CLI-Ver", Value: "0.0.34"})
+	if status != http.StatusUpgradeRequired || responseErrorCode(t, oldCLIPayload) != "CLI_UPGRADE_REQUIRED" {
+		t.Fatalf("old CLI was not blocked: status=%d payload=%#v", status, oldCLIPayload)
+	}
+	status, refreshedPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/agent-sessions/refresh", refreshReq,
+		ut.Header{Key: "X-CLI-Ver", Value: "0.0.35"})
+	if status != http.StatusOK {
+		t.Fatalf("CLI 0.0.35 refresh status=%d payload=%#v", status, refreshedPayload)
+	}
+	refreshedData := responseData(t, refreshedPayload)
+	if refreshedData["agent_id"] != strconv.FormatInt(targetID, 10) || refreshedData["principal_id"] != strconv.FormatInt(principalID, 10) {
+		t.Fatalf("CLI refresh did not adopt historical Agent: %#v", refreshedData)
+	}
+	newAccess := refreshedData["access_token"].(string)
+	status, newTokenPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/handoffs", map[string]interface{}{
+		"browser_nonce": strings.Repeat("n", 32), "client_capabilities": []string{"account_recovery_v1"},
+	}, ut.Header{Key: "Authorization", Value: "Bearer " + newAccess})
+	if status != http.StatusCreated {
+		t.Fatalf("refreshed historical credential unusable: status=%d payload=%#v", status, newTokenPayload)
+	}
+
+	status, switchBackChallengePayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-email-bindings/challenges", createEmailChallengeRequest{
+		Email: discardedEmail,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusAccepted {
+		t.Fatalf("switch-back challenge status=%d payload=%#v", status, switchBackChallengePayload)
+	}
+	select {
+	case mail = <-mailbox:
+	case <-time.After(2 * time.Second):
+		t.Fatal("switch-back OTP not captured")
+	}
+	status, switchBackConflictPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-email-bindings/verify", verifyEmailRequest{
+		ChallengeID: responseData(t, switchBackChallengePayload)["challenge_id"].(string),
+		Email:       discardedEmail,
+		OTP:         mail.otp,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusConflict || responseErrorCode(t, switchBackConflictPayload) != "EMAIL_UNAVAILABLE" {
+		t.Fatalf("expected switch-back recovery conflict, status=%d payload=%#v", status, switchBackConflictPayload)
+	}
+	switchBackDetails := switchBackConflictPayload["error"].(map[string]interface{})["details"].(map[string]interface{})
+	if switchBackDetails["source_disposition"] != recoverySourcePreserve {
+		t.Fatalf("historical formal source must remain preserved: %#v", switchBackDetails)
+	}
+	switchBackRecoveryID := switchBackDetails["recovery_id"].(string)
+	status, switchBackPayload, _ := performJSON(t, h, http.MethodPost, "/api/v2/account-recoveries/"+switchBackRecoveryID+"/confirm", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusOK {
+		t.Fatalf("switch-back status=%d payload=%#v", status, switchBackPayload)
+	}
+	switchBackData := responseData(t, switchBackPayload)
+	if switchBackData["agent_id"] != strconv.FormatInt(sourceID, 10) || switchBackData["source_agent_abandoned"] != false {
+		t.Fatalf("switch-back returned wrong identity: %#v", switchBackData)
+	}
+
+	var finalSourcePrincipals, finalTargetPrincipals, finalSourceBindings, finalTargetBindings int64
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_principals WHERE agent_id = ?`, sourceID).Scan(&finalSourcePrincipals).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_principals WHERE agent_id = ? AND principal_id = ?`, targetID, principalID).Scan(&finalTargetPrincipals).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND status = 'active'`, sourceID).Scan(&finalSourceBindings).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND status = 'active'`, targetID).Scan(&finalTargetBindings).Error; err != nil {
+		t.Fatal(err)
+	}
+	if finalSourcePrincipals != 1 || finalTargetPrincipals != 0 || finalSourceBindings != 1 || finalTargetBindings != 1 {
+		t.Fatalf("final identity split or email loss: source_principals=%d target_principals=%d source_bindings=%d target_bindings=%d",
+			finalSourcePrincipals, finalTargetPrincipals, finalSourceBindings, finalTargetBindings)
+	}
+}

--- a/api/consolev2/recovery_handlers.go
+++ b/api/consolev2/recovery_handlers.go
@@ -1,0 +1,412 @@
+package consolev2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+	mailservice "eigenflux_server/pkg/email"
+)
+
+const accountRecoveryTTL = 5 * time.Minute
+
+const (
+	recoverySourceAbandon  = "abandon"
+	recoverySourcePreserve = "preserve"
+)
+
+func recoverySourceDisposition(activeBindingID int64) string {
+	if activeBindingID > 0 {
+		return recoverySourcePreserve
+	}
+	return recoverySourceAbandon
+}
+
+type recoveryCandidate struct {
+	DisplayName   string `json:"display_name"`
+	MaskedAgentID string `json:"masked_agent_id"`
+	JoinedAt      int64  `json:"joined_at"`
+	LastActiveAt  int64  `json:"last_active_at"`
+}
+
+func maskedEigenFluxID(shortID string) string {
+	runes := []rune(strings.TrimSpace(shortID))
+	if len(runes) < 2 {
+		return "eigenflux#*****"
+	}
+	return "eigenflux#" + string(runes[:2]) + "***"
+}
+
+func (s *Service) prepareAccountRecovery(tx *gorm.DB, sourceAgentID, targetAgentID, principalID int64, sessionID, challengeID, normalizedEmail string, now int64) (map[string]interface{}, error) {
+	var session struct {
+		Capabilities pq.StringArray `gorm:"column:client_capabilities;type:text[]"`
+	}
+	if err := tx.Raw(`SELECT client_capabilities FROM console_v2_sessions
+		WHERE session_id = ? AND agent_id = ? AND principal_id = ? AND status = 'active'
+		FOR UPDATE`, sessionID, sourceAgentID, principalID).Scan(&session).Error; err != nil {
+		return nil, err
+	}
+	if !containsScope(session.Capabilities, "account_recovery_v1") {
+		return nil, errConflict
+	}
+	var candidate struct {
+		AgentName     string `gorm:"column:agent_name"`
+		ShortID       string `gorm:"column:short_id"`
+		IdentityState string `gorm:"column:identity_state"`
+		CreatedAt     int64  `gorm:"column:created_at"`
+		LastActiveAt  int64  `gorm:"column:last_active_at"`
+	}
+	if err := tx.Raw(`SELECT agent.agent_name, agent.short_id, agent.identity_state, agent.created_at,
+		CASE WHEN jsonb_typeof(card.public_card->'last_active_at') = 'number'
+			THEN (card.public_card->>'last_active_at')::bigint
+			ELSE agent.updated_at END AS last_active_at
+		FROM agents agent LEFT JOIN agent_cards card ON card.agent_id = agent.agent_id
+		WHERE agent.agent_id = ? FOR UPDATE OF agent`, targetAgentID).Scan(&candidate).Error; err != nil {
+		return nil, err
+	}
+	if candidate.IdentityState != "active" {
+		return nil, errConflict
+	}
+	var suspended int64
+	if err := tx.Raw(`SELECT COUNT(*) FROM agent_principals
+		WHERE agent_id = ? AND status = 'suspended'`, targetAgentID).Scan(&suspended).Error; err != nil {
+		return nil, err
+	}
+	if suspended > 0 {
+		return nil, errConflict
+	}
+	var sourceBindingID int64
+	if err := tx.Raw(`SELECT binding_id FROM agent_email_bindings
+		WHERE agent_id = ? AND status = 'active' LIMIT 1 FOR UPDATE`, sourceAgentID).Scan(&sourceBindingID).Error; err != nil {
+		return nil, err
+	}
+	sourceDisposition := recoverySourceDisposition(sourceBindingID)
+	recoveryID, err := randomToken("efar_", 32)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Exec(`UPDATE agent_account_recoveries SET status = 'revoked'
+		WHERE source_agent_id = ? AND console_session_id = ? AND status = 'pending'`, sourceAgentID, sessionID).Error; err != nil {
+		return nil, err
+	}
+	if err := tx.Exec(`INSERT INTO agent_account_recoveries
+		(recovery_id_hash, source_agent_id, target_agent_id, principal_id, console_session_id,
+		 email_challenge_id, normalized_email_hash, source_disposition, status, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`, hashString(recoveryID), sourceAgentID,
+		targetAgentID, principalID, sessionID, challengeID, keyedHash(s.otpPepper, normalizedEmail),
+		sourceDisposition, now+int64(accountRecoveryTTL/time.Millisecond), now).Error; err != nil {
+		return nil, err
+	}
+	consume := tx.Exec(`UPDATE v2_email_challenges SET status = 'consumed', consumed_at = ?
+		WHERE challenge_id = ? AND status = 'pending'`, now, challengeID)
+	if consume.Error != nil || consume.RowsAffected != 1 {
+		return nil, errUnauthorized
+	}
+	return map[string]interface{}{
+		"reason":             "existing_agent_recovery_available",
+		"recovery_id":        recoveryID,
+		"source_disposition": sourceDisposition,
+		"candidate": recoveryCandidate{
+			DisplayName: agentidentity.DisplayName(candidate.AgentName, candidate.ShortID), MaskedAgentID: maskedEigenFluxID(candidate.ShortID),
+			JoinedAt: candidate.CreatedAt, LastActiveAt: candidate.LastActiveAt,
+		},
+	}, nil
+}
+
+type recoveryRecord struct {
+	SourceAgentID       int64           `gorm:"column:source_agent_id"`
+	TargetAgentID       int64           `gorm:"column:target_agent_id"`
+	PrincipalID         int64           `gorm:"column:principal_id"`
+	ConsoleSessionID    string          `gorm:"column:console_session_id"`
+	EmailChallengeID    string          `gorm:"column:email_challenge_id"`
+	NormalizedEmailHash string          `gorm:"column:normalized_email_hash"`
+	SourceDisposition   string          `gorm:"column:source_disposition"`
+	Status              string          `gorm:"column:status"`
+	ExpiresAt           int64           `gorm:"column:expires_at"`
+	ResultSnapshot      json.RawMessage `gorm:"column:result_snapshot;type:jsonb"`
+}
+
+func (s *Service) confirmAccountRecovery(_ context.Context, c *app.RequestContext) {
+	sourceAgentID, ok := agentID(c)
+	principalValue, principalOK := c.Get("principal_id")
+	principalID, principalTypeOK := principalValue.(int64)
+	sessionValue, sessionOK := c.Get("console_session_id")
+	sessionID, sessionTypeOK := sessionValue.(string)
+	recoveryID := strings.TrimSpace(c.Param("recovery_id"))
+	if !ok || !principalOK || !principalTypeOK || !sessionOK || !sessionTypeOK || !strings.HasPrefix(recoveryID, "efar_") {
+		fail(c, http.StatusBadRequest, "RECOVERY_INVALID", "account recovery is invalid or expired", nil)
+		return
+	}
+
+	var response map[string]interface{}
+	var notificationEmail, notificationAgentName string
+	recoveryExpired := false
+	now := time.Now().UnixMilli()
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var recovery recoveryRecord
+		if err := tx.Raw(`SELECT source_agent_id, target_agent_id, principal_id, console_session_id,
+			email_challenge_id, normalized_email_hash, source_disposition, status, expires_at, result_snapshot
+			FROM agent_account_recoveries WHERE recovery_id_hash = ? FOR UPDATE`, hashString(recoveryID)).
+			Scan(&recovery).Error; err != nil {
+			return err
+		}
+		if recovery.SourceAgentID == 0 || (recovery.SourceAgentID != sourceAgentID && recovery.TargetAgentID != sourceAgentID) ||
+			recovery.PrincipalID != principalID || recovery.ConsoleSessionID != sessionID {
+			return errUnauthorized
+		}
+		if recovery.Status == "completed" {
+			return json.Unmarshal(recovery.ResultSnapshot, &response)
+		}
+		if recovery.Status == "pending" && recovery.ExpiresAt < now {
+			if err := tx.Exec(`UPDATE agent_account_recoveries SET status = 'expired' WHERE recovery_id_hash = ?`, hashString(recoveryID)).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`INSERT INTO agent_account_recovery_audit
+					(recovery_id_hash, source_agent_id, target_agent_id, principal_id, console_session_id, result, occurred_at)
+					VALUES (?, ?, ?, ?, ?, 'expired', ?)`, hashString(recoveryID), recovery.SourceAgentID,
+				recovery.TargetAgentID, recovery.PrincipalID, recovery.ConsoleSessionID, now).Error; err != nil {
+				return err
+			}
+			recoveryExpired = true
+			return nil
+		}
+		if recovery.Status != "pending" {
+			return errUnauthorized
+		}
+
+		var session struct {
+			AgentID      int64          `gorm:"column:agent_id"`
+			PrincipalID  int64          `gorm:"column:principal_id"`
+			Capabilities pq.StringArray `gorm:"column:client_capabilities;type:text[]"`
+		}
+		if err := tx.Raw(`SELECT agent_id, principal_id, client_capabilities FROM console_v2_sessions
+			WHERE session_id = ? AND status = 'active' FOR UPDATE`, sessionID).Scan(&session).Error; err != nil {
+			return err
+		}
+		if session.AgentID != recovery.SourceAgentID || session.PrincipalID != recovery.PrincipalID ||
+			!containsScope(session.Capabilities, "account_recovery_v1") {
+			return errUnauthorized
+		}
+
+		var sourceState, targetState string
+		if err := tx.Raw(`SELECT identity_state FROM agents WHERE agent_id = ? FOR UPDATE`, recovery.SourceAgentID).Scan(&sourceState).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT identity_state FROM agents WHERE agent_id = ? FOR UPDATE`, recovery.TargetAgentID).Scan(&targetState).Error; err != nil {
+			return err
+		}
+		if sourceState != "active" || targetState != "active" {
+			return errConflict
+		}
+		var sourceBindingID int64
+		if err := tx.Raw(`SELECT binding_id FROM agent_email_bindings
+			WHERE agent_id = ? AND status = 'active' LIMIT 1 FOR UPDATE`, recovery.SourceAgentID).Scan(&sourceBindingID).Error; err != nil {
+			return err
+		}
+		sourceDisposition := recoverySourceDisposition(sourceBindingID)
+		if sourceDisposition != recovery.SourceDisposition {
+			return errConflict
+		}
+
+		var principal struct {
+			AgentID int64  `gorm:"column:agent_id"`
+			KeyType string `gorm:"column:key_type"`
+			Status  string `gorm:"column:status"`
+		}
+		if err := tx.Raw(`SELECT agent_id, key_type, status FROM agent_principals
+			WHERE principal_id = ? FOR UPDATE`, recovery.PrincipalID).Scan(&principal).Error; err != nil {
+			return err
+		}
+		if principal.AgentID != recovery.SourceAgentID || principal.KeyType != "ed25519-v1" ||
+			(principal.Status != "limited" && principal.Status != "active") {
+			return errConflict
+		}
+
+		var binding struct {
+			BindingID         int64  `gorm:"column:binding_id"`
+			NormalizedEmail   string `gorm:"column:normalized_email"`
+			VerificationState string `gorm:"column:verification_state"`
+		}
+		if err := tx.Raw(`SELECT binding_id, normalized_email, verification_state FROM agent_email_bindings
+			WHERE agent_id = ? AND status = 'active' FOR UPDATE`, recovery.TargetAgentID).Scan(&binding).Error; err != nil {
+			return err
+		}
+		if binding.BindingID == 0 || keyedHash(s.otpPepper, binding.NormalizedEmail) != recovery.NormalizedEmailHash {
+			return errConflict
+		}
+		var emailOwnerCount, suspendedCount int64
+		if err := tx.Raw(`SELECT COUNT(*) FROM (
+			SELECT DISTINCT agent_id FROM (
+				SELECT agent_id FROM agent_email_bindings WHERE normalized_email = ? AND status = 'active'
+				UNION ALL
+				SELECT agent_id FROM agents WHERE lower(btrim(email)) = ? AND email_kind = 'legacy_real'
+			) candidates
+		) owners`, binding.NormalizedEmail, binding.NormalizedEmail).Scan(&emailOwnerCount).Error; err != nil {
+			return err
+		}
+		if err := tx.Raw(`SELECT COUNT(*) FROM agent_principals WHERE agent_id = ? AND status = 'suspended'`, recovery.TargetAgentID).Scan(&suspendedCount).Error; err != nil {
+			return err
+		}
+		if emailOwnerCount != 1 || suspendedCount != 0 {
+			return errConflict
+		}
+		var credentialSessionIDs []int64
+		if err := tx.Raw(`SELECT session_id FROM agent_credential_sessions
+			WHERE principal_id = ? AND revoked_at IS NULL FOR UPDATE`, recovery.PrincipalID).Scan(&credentialSessionIDs).Error; err != nil {
+			return err
+		}
+		if len(credentialSessionIDs) == 0 {
+			return errConflict
+		}
+		if err := ensureLegacyConsoleV2State(tx, recovery.TargetAgentID, now); err != nil {
+			return err
+		}
+		var targetOnboarding struct {
+			State       string `gorm:"column:state"`
+			CurrentStep int16  `gorm:"column:current_step"`
+			Revision    int64  `gorm:"column:revision"`
+		}
+		if err := tx.Raw(`SELECT state, current_step, revision FROM agent_onboarding_v2
+			WHERE agent_id = ? FOR UPDATE`, recovery.TargetAgentID).Scan(&targetOnboarding).Error; err != nil {
+			return err
+		}
+		scopes := principalScopesForOnboarding(targetOnboarding.State)
+		principalStatus := "limited"
+		if targetOnboarding.State == "completed" {
+			principalStatus = "active"
+		}
+		if err := tx.Exec(`UPDATE agent_principals SET agent_id = ?, status = ?, last_seen_at = ?
+			WHERE principal_id = ? AND agent_id = ?`, recovery.TargetAgentID, principalStatus, now,
+			recovery.PrincipalID, recovery.SourceAgentID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`UPDATE agent_credential_sessions SET scopes = ?, access_refresh_required = TRUE
+			WHERE principal_id = ? AND revoked_at IS NULL`, pq.Array(scopes), recovery.PrincipalID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`UPDATE console_v2_sessions SET agent_id = ?, scopes = ?, last_seen_at = ?
+			WHERE session_id = ? AND agent_id = ?`, recovery.TargetAgentID,
+			pq.Array([]string{"console:onboarding", "console:read", "console:write"}), now,
+			sessionID, recovery.SourceAgentID).Error; err != nil {
+			return err
+		}
+		if sourceDisposition == recoverySourceAbandon {
+			if err := tx.Exec(`UPDATE agent_credential_sessions sessions SET revoked_at = COALESCE(sessions.revoked_at, ?)
+				FROM agent_principals principals
+				WHERE sessions.principal_id = principals.principal_id AND principals.agent_id = ?
+				  AND sessions.revoked_at IS NULL`, now, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE agent_principals SET status = 'revoked', revoked_at = COALESCE(revoked_at, ?)
+				WHERE agent_id = ? AND revoked_at IS NULL`, now, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE agent_id = ? AND session_id <> ? AND status = 'active'`, now, recovery.SourceAgentID, sessionID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE console_v2_handoffs SET revoked_at = COALESCE(revoked_at, ?)
+				WHERE agent_id = ? AND consumed_at IS NULL AND revoked_at IS NULL`, now, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE agent_email_bindings
+				SET status = 'revoked', verification_state = 'revoked', revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+				WHERE agent_id = ? AND status = 'active'`, now, now, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE agents SET identity_state = 'recovered_temporary',
+				email = ?, email_kind = 'internal_alias', email_verified_at = NULL, updated_at = ?
+				WHERE agent_id = ? AND identity_state = 'active'`,
+				fmt.Sprintf("recovered-%d@identity.invalid", recovery.SourceAgentID), now, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`DELETE FROM agent_onboarding_drafts WHERE agent_id = ?`, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`DELETE FROM agent_cards WHERE agent_id = ?`, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`DELETE FROM agent_network_memberships WHERE agent_id = ?`, recovery.SourceAgentID).Error; err != nil {
+				return err
+			}
+		} else {
+			if err := tx.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE principal_id = ? AND session_id <> ? AND status = 'active'`, now, recovery.PrincipalID, sessionID).Error; err != nil {
+				return err
+			}
+			if err := tx.Exec(`UPDATE console_v2_handoffs SET revoked_at = COALESCE(revoked_at, ?)
+				WHERE agent_id = ? AND principal_id = ? AND consumed_at IS NULL AND revoked_at IS NULL`,
+				now, recovery.SourceAgentID, recovery.PrincipalID).Error; err != nil {
+				return err
+			}
+		}
+		if err := tx.Exec(`UPDATE agent_email_bindings SET verification_state = 'verified',
+			verified_at = COALESCE(verified_at, ?), updated_at = ? WHERE binding_id = ?`, now, now, binding.BindingID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`UPDATE agents SET email_verified_at = COALESCE(email_verified_at, ?), updated_at = ?
+			WHERE agent_id = ?`, now, now, recovery.TargetAgentID).Error; err != nil {
+			return err
+		}
+		response = map[string]interface{}{
+			"recovered":              true,
+			"source_disposition":     sourceDisposition,
+			"source_agent_abandoned": sourceDisposition == recoverySourceAbandon,
+			"agent_id":               fmt.Sprintf("%d", recovery.TargetAgentID),
+			"principal_id":           fmt.Sprintf("%d", recovery.PrincipalID),
+			"scopes":                 scopes,
+			"onboarding": map[string]interface{}{
+				"state": targetOnboarding.State, "current_step": targetOnboarding.CurrentStep,
+				"revision": targetOnboarding.Revision,
+			},
+		}
+		snapshot, err := json.Marshal(response)
+		if err != nil {
+			return err
+		}
+		complete := tx.Exec(`UPDATE agent_account_recoveries
+			SET status = 'completed', completed_at = ?, result_snapshot = ?::jsonb
+			WHERE recovery_id_hash = ? AND status = 'pending'`, now, string(snapshot), hashString(recoveryID))
+		if complete.Error != nil || complete.RowsAffected != 1 {
+			return errConflict
+		}
+		if err := tx.Exec(`INSERT INTO agent_account_recovery_audit
+			(recovery_id_hash, source_agent_id, target_agent_id, principal_id, console_session_id, result, occurred_at)
+			VALUES (?, ?, ?, ?, ?, 'completed', ?)`, hashString(recoveryID), recovery.SourceAgentID,
+			recovery.TargetAgentID, recovery.PrincipalID, recovery.ConsoleSessionID, now).Error; err != nil {
+			return err
+		}
+		notificationEmail = binding.NormalizedEmail
+		_ = tx.Raw(`SELECT agent_name FROM agents WHERE agent_id = ?`, recovery.TargetAgentID).Scan(&notificationAgentName).Error
+		return nil
+	})
+	if recoveryExpired || errors.Is(err, errUnauthorized) {
+		fail(c, http.StatusUnauthorized, "RECOVERY_EXPIRED", "account recovery expired; verify the email again", nil)
+		return
+	}
+	if errors.Is(err, errConflict) || isUniqueViolation(err) {
+		fail(c, http.StatusConflict, "RECOVERY_NOT_ALLOWED", "this Agent cannot be recovered automatically", nil)
+		return
+	}
+	if err != nil {
+		fail(c, http.StatusInternalServerError, "RECOVERY_FAILED", "could not recover the historical Agent", nil)
+		return
+	}
+	if notifier, ok := s.emailSender.(mailservice.AccountRecoveryNotifier); ok && notificationEmail != "" {
+		go func() {
+			notifyContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_ = notifier.SendAccountRecoveryMail(notifyContext, notificationEmail, notificationAgentName)
+		}()
+	}
+	reply(c, http.StatusOK, response)
+}

--- a/api/consolev2/recovery_handlers_test.go
+++ b/api/consolev2/recovery_handlers_test.go
@@ -1,0 +1,197 @@
+package consolev2
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMaskedEigenFluxIDNeverExposesTheCompleteShortID(t *testing.T) {
+	for input, want := range map[string]string{
+		"AbCdE": "eigenflux#Ab***",
+		" Z ":   "eigenflux#*****",
+		"":      "eigenflux#*****",
+	} {
+		got := maskedEigenFluxID(input)
+		if got != want {
+			t.Fatalf("maskedEigenFluxID(%q) = %q, want %q", input, got, want)
+		}
+		if strings.Contains(got, strings.TrimSpace(input)) && len(strings.TrimSpace(input)) >= 3 {
+			t.Fatalf("masked ID %q exposes input %q", got, input)
+		}
+	}
+}
+
+func TestAccountRecoveryCredentialLifetimeIsShort(t *testing.T) {
+	if accountRecoveryTTL <= 0 || accountRecoveryTTL > 5*time.Minute {
+		t.Fatalf("accountRecoveryTTL = %s, want no more than five minutes", accountRecoveryTTL)
+	}
+}
+
+func TestRecoverySourceDispositionUsesEmailBindingAsLifecycleBoundary(t *testing.T) {
+	if got := recoverySourceDisposition(0); got != recoverySourceAbandon {
+		t.Fatalf("unbound source disposition = %q, want %q", got, recoverySourceAbandon)
+	}
+	if got := recoverySourceDisposition(42); got != recoverySourcePreserve {
+		t.Fatalf("email-bound source disposition = %q, want %q", got, recoverySourcePreserve)
+	}
+}
+
+func TestValidActiveIdentityBindingRejectsStaleOwnership(t *testing.T) {
+	revokedAt := int64(123)
+	for _, test := range []struct {
+		name             string
+		agentID          int64
+		principalAgentID int64
+		identityState    string
+		principalStatus  string
+		principalRevoked *int64
+		want             bool
+	}{
+		{name: "active owner", agentID: 10, principalAgentID: 10, identityState: "active", principalStatus: "active", want: true},
+		{name: "limited owner", agentID: 10, principalAgentID: 10, identityState: "active", principalStatus: "limited", want: true},
+		{name: "principal moved", agentID: 10, principalAgentID: 20, identityState: "active", principalStatus: "active"},
+		{name: "temporary abandoned", agentID: 10, principalAgentID: 10, identityState: "recovered_temporary", principalStatus: "active"},
+		{name: "principal suspended", agentID: 10, principalAgentID: 10, identityState: "active", principalStatus: "suspended"},
+		{name: "principal revoked", agentID: 10, principalAgentID: 10, identityState: "active", principalStatus: "active", principalRevoked: &revokedAt},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := validActiveIdentityBinding(test.agentID, test.principalAgentID, test.identityState, test.principalStatus, test.principalRevoked); got != test.want {
+				t.Fatalf("validActiveIdentityBinding() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestHistoricalIdentityCardBackfillsEveryCanonicalFieldWithoutEmptyOverwrite(t *testing.T) {
+	profile := map[string]interface{}{
+		"working_languages": []interface{}{},
+		"seeking":           []interface{}{"canonical collaborators"},
+		"geo":               "SG",
+		"agent_status":      []interface{}{},
+	}
+	publicCard := map[string]interface{}{
+		"agent_description": "Historical research agent",
+		"human_description": "Supports a product builder",
+		"working_languages": []interface{}{"中文", "English"},
+		"seeking":           []interface{}{"stale seeking"},
+		"offering":          []interface{}{"research", "synthesis"},
+	}
+	privateCard := map[string]interface{}{
+		"geo":                "US",
+		"timezone":           "Asia/Singapore",
+		"current_focus":      []interface{}{"shipping recovery"},
+		"demands":            []interface{}{"security review"},
+		"agent_status":       []interface{}{"researching"},
+		"human_status":       []interface{}{"building"},
+		"interests_negative": []interface{}{"spam"},
+	}
+	got := historicalIdentityCard("Atlas", "", "CN", profile, publicCard, privateCard)
+	want := map[string]interface{}{
+		"agent_name":         "Atlas",
+		"bio":                "Historical research agent",
+		"agent_description":  "Historical research agent",
+		"human_description":  "Supports a product builder",
+		"working_languages":  []string{"中文", "English"},
+		"seeking":            []string{"canonical collaborators"},
+		"offering":           []string{"research", "synthesis"},
+		"geo":                "SG",
+		"timezone":           "Asia/Singapore",
+		"current_focus":      []string{"shipping recovery"},
+		"demands":            []string{"security review"},
+		"agent_status":       []string{"researching"},
+		"human_status":       []string{"building"},
+		"interests_negative": []string{"spam"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("historical identity card = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeHistoricalRecoveryDraftOnlyFillsMissingIdentityFields(t *testing.T) {
+	current := map[string]interface{}{"identity_card": map[string]interface{}{
+		"agent_name":        "Human edited name",
+		"working_languages": []interface{}{},
+		"seeking":           []interface{}{"existing need"},
+	}}
+	historical := map[string]interface{}{"identity_card": map[string]interface{}{
+		"agent_name":        "Historical name",
+		"working_languages": []interface{}{"中文", "English"},
+		"seeking":           []interface{}{"historical need"},
+		"offering":          []interface{}{"research"},
+	}}
+	got := mergeHistoricalRecoveryDraft(current, historical)["identity_card"].(map[string]interface{})
+	if got["agent_name"] != "Human edited name" || !reflect.DeepEqual(got["seeking"], []interface{}{"existing need"}) {
+		t.Fatalf("existing historical draft fields were overwritten: %#v", got)
+	}
+	if !reflect.DeepEqual(got["working_languages"], []interface{}{"中文", "English"}) ||
+		!reflect.DeepEqual(got["offering"], []interface{}{"research"}) {
+		t.Fatalf("missing historical fields were not backfilled: %#v", got)
+	}
+}
+
+func TestHistoricalDraftLocationCompatibilityClearsUnknownOptionalValues(t *testing.T) {
+	_, draft, err := normalizeHistoricalOnboardingDraftJSON([]byte(`{
+		"identity_card": {
+			"geo": "Atlantis",
+			"timezone": "Berlin local time",
+			"working_languages": ["English"]
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("legacy optional location values blocked recovery: %v", err)
+	}
+	identity := draft["identity_card"].(map[string]interface{})
+	if identity["geo"] != "" || identity["timezone"] != "" {
+		t.Fatalf("unknown legacy location values were not cleared: %#v", identity)
+	}
+}
+
+func TestHistoricalDraftLocationCompatibilityNormalizesRecognizedValues(t *testing.T) {
+	_, draft, err := normalizeHistoricalOnboardingDraftJSON([]byte(`{
+		"identity_card": {
+			"geo": "Singapore",
+			"timezone": "UTC+8"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := draft["identity_card"].(map[string]interface{})
+	if identity["geo"] != "SG" || identity["timezone"] != "Asia/Singapore" {
+		t.Fatalf("recognized legacy location values were not normalized: %#v", identity)
+	}
+}
+
+func TestHistoricalDraftLocationCompatibilityConvertsLegacyCountryName(t *testing.T) {
+	_, draft, err := normalizeHistoricalOnboardingDraftJSON([]byte(`{
+		"identity_card": {
+			"geo": "Germany",
+			"timezone": "Europe/Berlin"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := draft["identity_card"].(map[string]interface{})
+	if identity["geo"] != "DE" || identity["timezone"] != "Europe/Berlin" {
+		t.Fatalf("legacy country display name was not converted: %#v", identity)
+	}
+}
+
+func TestHistoricalDraftLocationCompatibilityKeepsValidTimezoneWhenCountryIsUnknown(t *testing.T) {
+	_, draft, err := normalizeHistoricalOnboardingDraftJSON([]byte(`{
+		"identity_card": {
+			"geo": "Atlantis",
+			"timezone": "Europe/Berlin"
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := draft["identity_card"].(map[string]interface{})
+	if identity["geo"] != "" || identity["timezone"] != "Europe/Berlin" {
+		t.Fatalf("valid legacy timezone was not preserved independently: %#v", identity)
+	}
+}

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -61,6 +61,7 @@ var (
 	errConflict           = errors.New("conflict")
 	errUnauthorized       = errors.New("unauthorized")
 	errOnboardingRequired = errors.New("onboarding required")
+	errCLIUpgradeRequired = errors.New("CLI upgrade required")
 )
 
 type IDGenerator interface {
@@ -331,6 +332,7 @@ func (s *Service) Register(h *server.Hertz) {
 	h.POST("/api/v2/agent-sessions/refresh", s.refreshAgentSession)
 	h.POST("/api/v2/account-email-bindings/challenges", s.consoleAuth(true), s.createEmailBindingChallenge)
 	h.POST("/api/v2/account-email-bindings/verify", s.consoleAuth(true), s.verifyEmailBinding)
+	h.POST("/api/v2/account-recoveries/:recovery_id/confirm", s.consoleAuth(true), s.confirmAccountRecovery)
 	h.POST("/api/v2/auth/email/challenges", s.requireSameOrigin(), s.createEmailLoginChallenge)
 	h.POST("/api/v2/auth/email/verify", s.requireSameOrigin(), s.verifyEmailLogin)
 	h.POST("/api/v2/agents/me/principals/challenges", s.consoleAuth(true), s.createPrincipalChallenge)
@@ -520,6 +522,11 @@ func containsScope(scopes pq.StringArray, wanted string) bool {
 	return false
 }
 
+func validActiveIdentityBinding(agentID, principalAgentID int64, identityState, principalStatus string, principalRevokedAt *int64) bool {
+	return agentID > 0 && agentID == principalAgentID && identityState == "active" && principalRevokedAt == nil &&
+		(principalStatus == "limited" || principalStatus == "active")
+}
+
 func (s *Service) setConsoleCookie(c *app.RequestContext, value string, maxAge int) {
 	c.SetCookie(consoleCookieName, value, maxAge, "/", "", protocol.CookieSameSiteLaxMode, s.secureCookie, true)
 	c.Header("Referrer-Policy", "no-referrer")
@@ -549,11 +556,13 @@ func (s *Service) agentAuth(requiredScope string) app.HandlerFunc {
 		var principal agentPrincipal
 		now := time.Now().UnixMilli()
 		err := s.db.Raw(`SELECT cs.session_id, p.agent_id, p.principal_id, p.status, cs.scopes
-			FROM agent_credential_sessions cs
-			JOIN agent_principals p ON p.principal_id = cs.principal_id
-			WHERE cs.access_token_hash = ? AND cs.audience = 'agent_v2'
-			  AND cs.revoked_at IS NULL AND cs.expires_at > ?
-			  AND p.revoked_at IS NULL AND p.status IN ('limited','active')`, hashString(token), now).
+				FROM agent_credential_sessions cs
+				JOIN agent_principals p ON p.principal_id = cs.principal_id
+				JOIN agents a ON a.agent_id = p.agent_id
+				WHERE cs.access_token_hash = ? AND cs.audience = 'agent_v2'
+				  AND cs.revoked_at IS NULL AND cs.expires_at > ? AND cs.access_refresh_required = FALSE
+				  AND p.revoked_at IS NULL AND p.status IN ('limited','active')
+				  AND a.identity_state = 'active'`, hashString(token), now).
 			Scan(&principal).Error
 		if err != nil || principal.AgentID == 0 || !containsScope(principal.Scopes, requiredScope) {
 			fail(c, http.StatusUnauthorized, "AGENT_AUTH_INVALID", "Agent V2 token is expired or lacks the required scope", nil)
@@ -569,17 +578,21 @@ func (s *Service) agentAuth(requiredScope string) app.HandlerFunc {
 }
 
 type consoleSession struct {
-	SessionID      string         `gorm:"column:session_id"`
-	AgentID        int64          `gorm:"column:agent_id"`
-	PrincipalID    int64          `gorm:"column:principal_id"`
-	SecretHash     string         `gorm:"column:session_secret_hash"`
-	CSRFSecretHash string         `gorm:"column:csrf_secret_hash"`
-	Scopes         pq.StringArray `gorm:"column:scopes;type:text[]"`
-	IdleExpiresAt  int64          `gorm:"column:idle_expires_at"`
-	AbsoluteExpiry int64          `gorm:"column:absolute_expires_at"`
-	LastSeenAt     int64          `gorm:"column:last_seen_at"`
-	AuthMethod     string         `gorm:"column:auth_method"`
-	RecentAuthAt   *int64         `gorm:"column:recent_auth_at"`
+	SessionID          string         `gorm:"column:session_id"`
+	AgentID            int64          `gorm:"column:agent_id"`
+	PrincipalID        int64          `gorm:"column:principal_id"`
+	PrincipalAgentID   int64          `gorm:"column:principal_agent_id"`
+	PrincipalStatus    string         `gorm:"column:principal_status"`
+	PrincipalRevokedAt *int64         `gorm:"column:principal_revoked_at"`
+	IdentityState      string         `gorm:"column:identity_state"`
+	SecretHash         string         `gorm:"column:session_secret_hash"`
+	CSRFSecretHash     string         `gorm:"column:csrf_secret_hash"`
+	Scopes             pq.StringArray `gorm:"column:scopes;type:text[]"`
+	IdleExpiresAt      int64          `gorm:"column:idle_expires_at"`
+	AbsoluteExpiry     int64          `gorm:"column:absolute_expires_at"`
+	LastSeenAt         int64          `gorm:"column:last_seen_at"`
+	AuthMethod         string         `gorm:"column:auth_method"`
+	RecentAuthAt       *int64         `gorm:"column:recent_auth_at"`
 }
 
 func (s *Service) consoleAuth(requireCSRF bool) app.HandlerFunc {
@@ -598,16 +611,27 @@ func (s *Service) consoleAuth(requireCSRF bool) app.HandlerFunc {
 		var session consoleSession
 		now := time.Now().UnixMilli()
 		err := s.db.Raw(`SELECT s.session_id, s.agent_id, s.principal_id,
-				s.session_secret_hash, s.csrf_secret_hash, s.scopes,
+					p.agent_id AS principal_agent_id, p.status AS principal_status,
+					p.revoked_at AS principal_revoked_at,
+					a.identity_state,
+					s.session_secret_hash, s.csrf_secret_hash, s.scopes,
 			s.idle_expires_at, s.absolute_expires_at, s.last_seen_at,
 			s.auth_method, s.recent_auth_at
-			FROM console_v2_sessions s
-			JOIN agent_principals p ON p.principal_id = s.principal_id
-			WHERE s.session_id = ? AND s.status = 'active'
-			  AND s.idle_expires_at > ? AND s.absolute_expires_at > ?
-			  AND p.revoked_at IS NULL AND p.status IN ('limited','active')`, parts[0], now, now).
+				FROM console_v2_sessions s
+				JOIN agent_principals p ON p.principal_id = s.principal_id
+				JOIN agents a ON a.agent_id = s.agent_id
+				WHERE s.session_id = ? AND s.status = 'active'
+				  AND s.idle_expires_at > ? AND s.absolute_expires_at > ?`, parts[0], now, now).
 			Scan(&session).Error
 		if err != nil || session.SessionID == "" || subtle.ConstantTimeCompare([]byte(session.SecretHash), []byte(hashString(parts[1]))) != 1 {
+			fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_INVALID", "Console V2 session is invalid or expired", nil)
+			c.Abort()
+			return
+		}
+		if !validActiveIdentityBinding(session.AgentID, session.PrincipalAgentID, session.IdentityState,
+			session.PrincipalStatus, session.PrincipalRevokedAt) {
+			s.db.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE session_id = ? AND status = 'active'`, now, session.SessionID)
 			fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_INVALID", "Console V2 session is invalid or expired", nil)
 			c.Abort()
 			return

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
 	redis "github.com/redis/go-redis/v9"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -250,6 +251,69 @@ func TestRegisterV2RoutesDoesNotConflictWithV1(t *testing.T) {
 		}
 	}()
 	svc.Register(h)
+}
+
+func TestConsoleAuthRejectsStaleIdentityOnReadOnlyRequest(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE agents (agent_id INTEGER PRIMARY KEY, identity_state TEXT NOT NULL)`,
+		`CREATE TABLE agent_principals (
+			principal_id INTEGER PRIMARY KEY, agent_id INTEGER NOT NULL,
+			status TEXT NOT NULL, revoked_at INTEGER
+		)`,
+		`CREATE TABLE console_v2_sessions (
+			session_id TEXT PRIMARY KEY, agent_id INTEGER NOT NULL, principal_id INTEGER NOT NULL,
+			session_secret_hash TEXT NOT NULL, csrf_secret_hash TEXT NOT NULL, scopes TEXT NOT NULL,
+			idle_expires_at INTEGER NOT NULL, absolute_expires_at INTEGER NOT NULL,
+			last_seen_at INTEGER NOT NULL, auth_method TEXT NOT NULL, recent_auth_at INTEGER,
+			status TEXT NOT NULL, revoked_at INTEGER
+		)`,
+	} {
+		if err := gdb.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := gdb.Exec(`INSERT INTO agents (agent_id, identity_state) VALUES (10, 'active')`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Exec(`INSERT INTO agent_principals (principal_id, agent_id, status)
+		VALUES (30, 20, 'active')`).Error; err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UnixMilli()
+	if err := gdb.Exec(`INSERT INTO console_v2_sessions
+		(session_id, agent_id, principal_id, session_secret_hash, csrf_secret_hash, scopes,
+		 idle_expires_at, absolute_expires_at, last_seen_at, auth_method, status)
+		VALUES (?, 10, 30, ?, ?, '{}', ?, ?, ?, 'email', 'active')`,
+		"stale-read-session", hashString("session-secret"), hashString("csrf-secret"),
+		now+int64(time.Hour/time.Millisecond), now+int64(time.Hour/time.Millisecond), now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	service := &Service{db: gdb}
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	h.GET("/read", service.consoleAuth(false), func(_ context.Context, c *app.RequestContext) {
+		reply(c, http.StatusOK, map[string]bool{"allowed": true})
+	})
+	status, payload, _ := performJSON(t, h, http.MethodGet, "/read", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: consoleCookieName + "=stale-read-session.session-secret"})
+	if status != http.StatusUnauthorized || responseErrorCode(t, payload) != "CONSOLE_SESSION_INVALID" {
+		t.Fatalf("stale identity read request was not rejected: status=%d payload=%#v", status, payload)
+	}
+	var stored struct {
+		Status    string
+		RevokedAt *int64 `gorm:"column:revoked_at"`
+	}
+	if err := gdb.Raw(`SELECT status, revoked_at FROM console_v2_sessions WHERE session_id = ?`,
+		"stale-read-session").Scan(&stored).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != "revoked" || stored.RevokedAt == nil {
+		t.Fatalf("stale read session was not revoked: %#v", stored)
+	}
 }
 
 func TestAttentionV1RequiresControlChannel(t *testing.T) {

--- a/api/install/invite_entry_postgres_test.go
+++ b/api/install/invite_entry_postgres_test.go
@@ -28,6 +28,7 @@ func TestPostgresShortIDInviteAttribution(t *testing.T) {
 	sqlDB.SetMaxIdleConns(1)
 	if err := gdb.Exec(`CREATE TEMP TABLE agents (
 		agent_id bigint PRIMARY KEY, short_id varchar(5), email text NOT NULL,
+		identity_state varchar(32) NOT NULL DEFAULT 'active',
 		created_at bigint NOT NULL, acquisition_channel text NOT NULL DEFAULT '',
 		invited_by_code text NOT NULL DEFAULT '', inviter_agent_id bigint NOT NULL DEFAULT 0,
 		invited_at bigint NOT NULL DEFAULT 0

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,18 +3,18 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.34
+CLI_VERSION=0.0.35
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients
 # actually compare, this is just a human-facing label.)
-SKILLS_REVISION=12
+SKILLS_REVISION=13
 
 # Monotonic signed release sequence. Every published manifest must increment it;
 # clients reject rollback and sequence reuse with different content.
-SKILLS_SEQUENCE=1
+SKILLS_SEQUENCE=2
 
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a
 # skill starts requiring a newer CLI command, so old CLIs keep their old skills
 # instead of pulling ones they can't run.
-SKILLS_MIN_CLI_VERSION=0.0.34
+SKILLS_MIN_CLI_VERSION=0.0.35

--- a/cli/cmd/agent_v2.go
+++ b/cli/cmd/agent_v2.go
@@ -261,6 +261,7 @@ var agentV2ProvisionCmd = &cobra.Command{
 		agentName, _ := cmd.Flags().GetString("agent-name")
 		draftFile, _ := cmd.Flags().GetString("draft-file")
 		noHandoff, _ := cmd.Flags().GetBool("no-handoff")
+		recoverAccount, _ := cmd.Flags().GetBool("recover-account")
 		if strings.TrimSpace(agentName) == "" {
 			agentName = "EigenFlux Agent"
 		}
@@ -345,7 +346,9 @@ var agentV2ProvisionCmd = &cobra.Command{
 			if nonceErr != nil {
 				return nonceErr
 			}
-			handoffResponse, handoffErr := authenticated.Post("/console/handoffs", map[string]interface{}{"browser_nonce": browserNonce})
+			handoffResponse, handoffErr := authenticated.Post("/console/handoffs", map[string]interface{}{
+				"browser_nonce": browserNonce, "client_capabilities": consoleHandoffCapabilities(recoverAccount),
+			})
 			if handoffErr != nil {
 				return handoffErr
 			}
@@ -370,6 +373,15 @@ func init() {
 	agentV2ProvisionCmd.Flags().String("agent-name", "EigenFlux Agent", "Agent name used to prefill onboarding")
 	agentV2ProvisionCmd.Flags().String("draft-file", "", "optional onboarding draft JSON file ('-' reads stdin)")
 	agentV2ProvisionCmd.Flags().Bool("no-handoff", false, "provision without creating a Console V2 link")
+	agentV2ProvisionCmd.Flags().Bool("recover-account", false, "open the claim page to recover a historical Agent")
 	agentV2Cmd.AddCommand(agentV2InitCmd, agentV2ProvisionCmd)
 	rootCmd.AddCommand(agentV2Cmd)
+}
+
+func consoleHandoffCapabilities(recoveryEntry bool) []string {
+	capabilities := []string{"account_recovery_v1"}
+	if recoveryEntry {
+		capabilities = append(capabilities, "account_recovery_entry_v1")
+	}
+	return capabilities
 }

--- a/cli/cmd/agent_v2_test.go
+++ b/cli/cmd/agent_v2_test.go
@@ -7,10 +7,20 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"cli.eigenflux.ai/internal/client"
 )
+
+func TestConsoleHandoffCapabilitiesRequireExplicitRecoveryEntry(t *testing.T) {
+	if got := consoleHandoffCapabilities(false); !reflect.DeepEqual(got, []string{"account_recovery_v1"}) {
+		t.Fatalf("ordinary handoff capabilities = %#v", got)
+	}
+	if got := consoleHandoffCapabilities(true); !reflect.DeepEqual(got, []string{"account_recovery_v1", "account_recovery_entry_v1"}) {
+		t.Fatalf("recovery handoff capabilities = %#v", got)
+	}
+}
 
 type captureV2Poster struct {
 	path string

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -48,7 +48,9 @@ Example:
 				if err != nil {
 					return err
 				}
-				response, postErr := v2Client.Post("/console/handoffs", map[string]interface{}{"browser_nonce": browserNonce})
+				response, postErr := v2Client.Post("/console/handoffs", map[string]interface{}{
+					"browser_nonce": browserNonce, "client_capabilities": []string{"account_recovery_v1"},
+				})
 				if postErr == nil {
 					var data struct {
 						URL       string `json:"handoff_url"`

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -45,7 +45,15 @@ func newClientForServerOptionalAuth(serverName string, requireAuth bool) *client
 			if credentialErr != nil {
 				output.Die(output.ExitAuthRequired, "Agent V2 authentication failed for server %q: %v", srv.Name, credentialErr)
 			}
-			return client.New(strings.TrimRight(srv.Endpoint, "/")+"/api/v2", credentials.AccessToken, version, clientMeta)
+			result := client.New(strings.TrimRight(srv.Endpoint, "/")+"/api/v2", credentials.AccessToken, version, clientMeta)
+			result.OnUnauthorized = func() (string, error) {
+				refreshed, refreshErr := refreshV2Credentials(srv.Name, srv.Endpoint, true)
+				if refreshErr != nil {
+					return "", refreshErr
+				}
+				return refreshed.AccessToken, nil
+			}
+			return result
 		}
 	}
 	return newLegacyClientForResolvedServer(srv, requireAuth)

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -22,12 +22,33 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 		"eigenflux agent provision --help",
 		"Do not request an email, OTP, referral code",
 		"Missing legacy credentials does not mean the Agent is unauthenticated",
-		"Skill requires CLI `0.0.34`",
+		"Skill requires CLI `0.0.35`",
 		"The join task is incomplete until the final user-facing response contains that validated link",
 		"Do not run the public installer or `eigenflux skills sync`",
+		"eigenflux agent provision --recover-account",
+		"Do not run `eigenflux dashboard` or ordinary `eigenflux agent provision`",
+		"Do not ask a clarifying question before generating the link",
+		"Do not use the new-join four-line success template",
 	} {
 		if !strings.Contains(skill, required) {
 			t.Errorf("ef-profile is missing mandatory Console V2 routing text %q", required)
+		}
+	}
+	frontmatterParts := strings.SplitN(skill, "---", 3)
+	if len(frontmatterParts) != 3 {
+		t.Fatal("ef-profile skill frontmatter is malformed")
+	}
+	for _, trigger := range []string{"regenerate the claim link", "switch account", "重新生成认领链接", "我要切换账号"} {
+		if !strings.Contains(frontmatterParts[1], trigger) {
+			t.Errorf("ef-profile frontmatter is missing account recovery trigger %q", trigger)
+		}
+	}
+	if !strings.Contains(frontmatterParts[1], `version: "0.4.2"`) {
+		t.Error("ef-profile version was not advanced for the recovery trigger contract")
+	}
+	for _, lifecycleRule := range []string{"has no bound email", "temporary identity", "formal account", "switch back later"} {
+		if !strings.Contains(skill, lifecycleRule) {
+			t.Errorf("ef-profile skill is missing account lifecycle rule %q", lifecycleRule)
 		}
 	}
 
@@ -63,6 +84,11 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 		"Set both the current Codex task title and its attached",
 		"automation name to exactly `EigenFlux 网络收件箱`, then read both back",
 		"succeeds only when both names match exactly",
+		"Recovery transfers the current Home's Ed25519 principal",
+		"An Agent ID change is not a reason to call provision again",
+		"Requests to \"regenerate the claim link\" or \"switch account\"",
+		"重新生成认领链接",
+		"我要切换账号",
 	} {
 		if !strings.Contains(onboarding, required) {
 			t.Errorf("Console V2 onboarding contract is missing %q", required)

--- a/cli/cmd/stream.go
+++ b/cli/cmd/stream.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,6 +29,55 @@ const (
 	reconnectMax = 120 * time.Second
 	reconnectMul = 2.0
 )
+
+var errStreamUnauthorized = errors.New("stream authentication rejected")
+
+type streamDialer interface {
+	Dial(string, http.Header) (*websocket.Conn, *http.Response, error)
+}
+
+func dialStreamWithCredentialRefresh(dialer streamDialer, rawURL string, headers http.Header, currentAgentID string, refresh func() (*auth.V2Credentials, error)) (*websocket.Conn, *auth.V2Credentials, bool, error) {
+	conn, response, err := dialer.Dial(rawURL, headers)
+	if err == nil {
+		return conn, nil, false, nil
+	}
+	unauthorized := response != nil && response.StatusCode == http.StatusUnauthorized
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if !unauthorized {
+		return nil, nil, false, err
+	}
+	if refresh == nil {
+		return nil, nil, false, fmt.Errorf("%w: %v", errStreamUnauthorized, err)
+	}
+	credentials, refreshErr := refresh()
+	if refreshErr != nil {
+		return nil, nil, true, refreshErr
+	}
+	if credentials == nil || credentials.AccessToken == "" || credentials.AgentID == "" {
+		return nil, nil, true, fmt.Errorf("credential refresh returned an incomplete identity")
+	}
+	retryHeaders := headers.Clone()
+	retryHeaders.Set("Authorization", "Bearer "+credentials.AccessToken)
+	retryURL := rawURL
+	if currentAgentID != "" && credentials.AgentID != currentAgentID {
+		if parsed, parseErr := url.Parse(rawURL); parseErr == nil {
+			query := parsed.Query()
+			query.Del("cursor")
+			parsed.RawQuery = query.Encode()
+			retryURL = parsed.String()
+		}
+	}
+	conn, response, err = dialer.Dial(retryURL, retryHeaders)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil && response != nil && response.StatusCode == http.StatusUnauthorized {
+		return nil, credentials, true, fmt.Errorf("%w after credential refresh: %v", errStreamUnauthorized, err)
+	}
+	return conn, credentials, true, err
+}
 
 var streamCmd = &cobra.Command{
 	Use:   "stream",
@@ -62,6 +112,7 @@ Examples:
 			return fmt.Errorf("inspect Agent V2 credentials: %w", err)
 		}
 		accessToken := ""
+		activeAgentID := ""
 		streamPath := "/ws/pm"
 		if hasV2 {
 			credentials, credentialErr := ensureV2Credentials(srv.Name, srv.Endpoint)
@@ -69,6 +120,7 @@ Examples:
 				return credentialErr
 			}
 			accessToken = credentials.AccessToken
+			activeAgentID = credentials.AgentID
 			streamPath = "/api/v2/agent/events/ws"
 		} else {
 			credentials, credentialErr := auth.LoadCredentials(srv.Name)
@@ -105,6 +157,7 @@ Examples:
 		lastCursor := cursor
 
 		backoff := reconnectMin
+		allowCredentialRefresh := hasV2
 
 		for {
 			mu.Lock()
@@ -134,8 +187,33 @@ Examples:
 				dialHeaders.Set("X-CLI-Ver", version)
 			}
 			clientMeta.SetHeaders(dialHeaders)
-			conn, _, dialErr := websocket.DefaultDialer.Dial(u.String(), dialHeaders)
+			var refresh func() (*auth.V2Credentials, error)
+			if allowCredentialRefresh {
+				refresh = func() (*auth.V2Credentials, error) {
+					return refreshV2Credentials(srv.Name, srv.Endpoint, true)
+				}
+			}
+			conn, refreshedCredentials, refreshAttempted, dialErr := dialStreamWithCredentialRefresh(websocket.DefaultDialer, u.String(), dialHeaders, activeAgentID, refresh)
+			if refreshAttempted {
+				allowCredentialRefresh = false
+			}
+			if refreshedCredentials != nil {
+				if activeAgentID != "" && activeAgentID != refreshedCredentials.AgentID {
+					mu.Lock()
+					lastCursor = ""
+					mu.Unlock()
+				}
+				accessToken = refreshedCredentials.AccessToken
+				activeAgentID = refreshedCredentials.AgentID
+				myAgentID = refreshedCredentials.AgentID
+			}
 			if dialErr != nil {
+				if refreshAttempted {
+					return fmt.Errorf("Agent V2 stream credential refresh failed: %w", dialErr)
+				}
+				if errors.Is(dialErr, errStreamUnauthorized) {
+					return fmt.Errorf("Agent V2 stream credentials were rejected after one refresh: %w", dialErr)
+				}
 				if once {
 					return fmt.Errorf("connect failed: %w", dialErr)
 				}

--- a/cli/cmd/stream_recovery_test.go
+++ b/cli/cmd/stream_recovery_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"cli.eigenflux.ai/internal/auth"
+
+	"github.com/gorilla/websocket"
+)
+
+type scriptedStreamDialer struct {
+	statuses []int
+	errors   []error
+	headers  []http.Header
+	urls     []string
+}
+
+func (d *scriptedStreamDialer) Dial(rawURL string, headers http.Header) (*websocket.Conn, *http.Response, error) {
+	d.headers = append(d.headers, headers.Clone())
+	d.urls = append(d.urls, rawURL)
+	index := len(d.headers) - 1
+	if index >= len(d.errors) {
+		return nil, nil, nil
+	}
+	var response *http.Response
+	if index < len(d.statuses) && d.statuses[index] != 0 {
+		response = &http.Response{StatusCode: d.statuses[index], Body: io.NopCloser(strings.NewReader(""))}
+	}
+	return nil, response, d.errors[index]
+}
+
+func TestStreamHandshakeRefreshesV2CredentialsAndRetriesOnlyOnce(t *testing.T) {
+	dialer := &scriptedStreamDialer{
+		statuses: []int{http.StatusUnauthorized, 0},
+		errors:   []error{errors.New("401 unauthorized"), nil},
+	}
+	refreshCalls := 0
+	conn, credentials, attempted, err := dialStreamWithCredentialRefresh(dialer, "ws://example.test/api/v2/agent/events/ws?cursor=old-agent-cursor&keep=1",
+		http.Header{"Authorization": []string{"Bearer stale"}}, "temporary-agent", func() (*auth.V2Credentials, error) {
+			refreshCalls++
+			return &auth.V2Credentials{AgentID: "historical-agent", AccessToken: "fresh"}, nil
+		})
+	if err != nil || conn != nil || !attempted {
+		t.Fatalf("unexpected recovery result: conn=%v attempted=%v err=%v", conn, attempted, err)
+	}
+	if refreshCalls != 1 || len(dialer.headers) != 2 {
+		t.Fatalf("refresh calls=%d dials=%d, want one refresh and two dials", refreshCalls, len(dialer.headers))
+	}
+	if credentials == nil || credentials.AgentID != "historical-agent" || credentials.AccessToken != "fresh" {
+		t.Fatalf("authoritative identity was not returned: %+v", credentials)
+	}
+	if got := dialer.headers[1].Get("Authorization"); got != "Bearer fresh" {
+		t.Fatalf("retry Authorization = %q, want refreshed token", got)
+	}
+	if strings.Contains(dialer.urls[1], "cursor=") || !strings.Contains(dialer.urls[1], "keep=1") {
+		t.Fatalf("identity switch reused the old Agent cursor or lost unrelated query values: %q", dialer.urls[1])
+	}
+}
+
+func TestStreamHandshakeStopsAfterRefreshedCredentialIsRejected(t *testing.T) {
+	dialer := &scriptedStreamDialer{
+		statuses: []int{http.StatusUnauthorized, http.StatusUnauthorized},
+		errors:   []error{errors.New("first 401"), errors.New("second 401")},
+	}
+	refreshCalls := 0
+	_, credentials, attempted, err := dialStreamWithCredentialRefresh(dialer, "ws://example.test/api/v2/agent/events/ws",
+		http.Header{}, "temporary-agent", func() (*auth.V2Credentials, error) {
+			refreshCalls++
+			return &auth.V2Credentials{AgentID: "historical-agent", AccessToken: "fresh"}, nil
+		})
+	if !attempted || !errors.Is(err, errStreamUnauthorized) {
+		t.Fatalf("second 401 was not returned as terminal auth failure: attempted=%v err=%v", attempted, err)
+	}
+	if refreshCalls != 1 || len(dialer.headers) != 2 {
+		t.Fatalf("refresh calls=%d dials=%d, want a single retry", refreshCalls, len(dialer.headers))
+	}
+	if credentials == nil || credentials.AgentID != "historical-agent" {
+		t.Fatalf("refreshed authoritative identity missing: %+v", credentials)
+	}
+}
+
+func TestStreamHandshakeKeepsCursorWhenRefreshStaysOnTheSameAgent(t *testing.T) {
+	dialer := &scriptedStreamDialer{
+		statuses: []int{http.StatusUnauthorized, 0},
+		errors:   []error{errors.New("401 unauthorized"), nil},
+	}
+	_, _, _, err := dialStreamWithCredentialRefresh(dialer,
+		"ws://example.test/api/v2/agent/events/ws?cursor=same-agent-cursor",
+		http.Header{}, "same-agent", func() (*auth.V2Credentials, error) {
+			return &auth.V2Credentials{AgentID: "same-agent", AccessToken: "fresh"}, nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(dialer.urls[1], "cursor=same-agent-cursor") {
+		t.Fatalf("ordinary token rotation dropped a valid cursor: %q", dialer.urls[1])
+	}
+}

--- a/cli/cmd/v2_helpers.go
+++ b/cli/cmd/v2_helpers.go
@@ -11,8 +11,11 @@ import (
 	"time"
 
 	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/cache"
 	"cli.eigenflux.ai/internal/client"
 	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/controlcontext"
+	"cli.eigenflux.ai/internal/profilestate"
 )
 
 func newBrowserNonce() (string, error) {
@@ -40,25 +43,39 @@ func newV2ClientForServer(serverName string, requireAuth bool) (*client.Client, 
 		}
 		token = credentials.AccessToken
 	}
-	return client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", token, version, clientMeta), server, nil
+	result := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", token, version, clientMeta)
+	if requireAuth {
+		result.OnUnauthorized = func() (string, error) {
+			refreshed, refreshErr := refreshV2Credentials(server.Name, server.Endpoint, true)
+			if refreshErr != nil {
+				return "", refreshErr
+			}
+			return refreshed.AccessToken, nil
+		}
+	}
+	return result, server, nil
 }
 
 func ensureV2Credentials(serverName, endpoint string) (*auth.V2Credentials, error) {
+	return refreshV2Credentials(serverName, endpoint, false)
+}
+
+func refreshV2Credentials(serverName, endpoint string, force bool) (*auth.V2Credentials, error) {
 	var credentials *auth.V2Credentials
 	err := auth.WithV2CredentialsLock(serverName, 35*time.Second, func() error {
 		var refreshErr error
-		credentials, refreshErr = ensureV2CredentialsUnlocked(serverName, endpoint)
+		credentials, refreshErr = ensureV2CredentialsUnlocked(serverName, endpoint, force)
 		return refreshErr
 	})
 	return credentials, err
 }
 
-func ensureV2CredentialsUnlocked(serverName, endpoint string) (*auth.V2Credentials, error) {
+func ensureV2CredentialsUnlocked(serverName, endpoint string, force bool) (*auth.V2Credentials, error) {
 	credentials, err := auth.LoadV2Credentials(serverName)
 	if err != nil {
 		return nil, fmt.Errorf("Agent V2 is not provisioned for server %q — run 'eigenflux agent init' and then 'eigenflux agent provision': %w", serverName, err)
 	}
-	if credentials.ExpiresAt > time.Now().Add(30*time.Second).UnixMilli() {
+	if !force && credentials.ExpiresAt > time.Now().Add(30*time.Second).UnixMilli() {
 		return credentials, nil
 	}
 	publicKey, privateKey, _, err := auth.LoadOrCreateIdentity(serverName)
@@ -96,22 +113,36 @@ func ensureV2CredentialsUnlocked(serverName, endpoint string) (*auth.V2Credentia
 		return nil, err
 	}
 	var refreshed struct {
+		AgentID      string   `json:"agent_id"`
 		PrincipalID  string   `json:"principal_id"`
 		AccessToken  string   `json:"access_token"`
 		RefreshToken string   `json:"refresh_token"`
 		ExpiresAt    int64    `json:"expires_at"`
 		Scopes       []string `json:"scopes"`
 	}
-	if json.Unmarshal(refreshResponse.Data, &refreshed) != nil || refreshed.AccessToken == "" || refreshed.RefreshToken == "" {
+	if json.Unmarshal(refreshResponse.Data, &refreshed) != nil || refreshed.AgentID == "" || refreshed.AccessToken == "" || refreshed.RefreshToken == "" {
 		return nil, fmt.Errorf("invalid Agent V2 refresh response")
 	}
+	oldAgentID := credentials.AgentID
 	credentials.AccessToken = refreshed.AccessToken
 	credentials.RefreshToken = refreshed.RefreshToken
+	credentials.AgentID = refreshed.AgentID
 	credentials.PrincipalID = refreshed.PrincipalID
 	credentials.ExpiresAt = refreshed.ExpiresAt
 	credentials.Scopes = refreshed.Scopes
 	if err := auth.SaveV2Credentials(serverName, credentials); err != nil {
 		return nil, err
+	}
+	if oldAgentID != "" && oldAgentID != refreshed.AgentID {
+		if err := cache.DeleteIdentityScopedData(serverName); err != nil {
+			return nil, fmt.Errorf("clear previous Agent local data: %w", err)
+		}
+		if err := controlcontext.Delete(serverName); err != nil {
+			return nil, fmt.Errorf("clear previous Agent control context: %w", err)
+		}
+		if err := profilestate.Delete(config.HomeDir(), serverName, oldAgentID); err != nil {
+			return nil, fmt.Errorf("clear previous Agent profile state: %w", err)
+		}
 	}
 	return credentials, nil
 }

--- a/cli/cmd/v2_recovery_test.go
+++ b/cli/cmd/v2_recovery_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/cache"
+	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/controlcontext"
+	"cli.eigenflux.ai/internal/profilestate"
+)
+
+func TestForcedV2RefreshAdoptsAuthoritativeAgentAndClearsIdentityCaches(t *testing.T) {
+	now := time.Now().UnixMilli()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/agent-sessions/refresh-challenges":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+				"nonce": "efn_recovery-test", "issued_at": now, "expires_at": now + 60000,
+			}})
+		case "/api/v2/agent-sessions/refresh":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{
+				"agent_id": "historical-agent", "principal_id": "current-principal",
+				"access_token": "new-access", "refresh_token": "new-refresh",
+				"expires_at": now + 900000, "scopes": []string{"profile:read", "feed:read"},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	home := tempHome(t)
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := cfg.GetActive("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.UpdateServer(active.Name, server.URL, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := auth.LoadOrCreateIdentity(active.Name); err != nil {
+		t.Fatal(err)
+	}
+	if err := auth.SaveV2Credentials(active.Name, &auth.V2Credentials{
+		AgentID: "temporary-agent", PrincipalID: "current-principal", AccessToken: "old-access",
+		RefreshToken: "old-refresh", ExpiresAt: now + 900000, Scopes: []string{"onboarding:read"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	serverDir := cache.ServerDir(active.Name)
+	if err := os.MkdirAll(serverDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"profile.json", "contacts.json"} {
+		if err := os.WriteFile(filepath.Join(serverDir, name), []byte(`{}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, relativePath := range []string{
+		filepath.Join("data", "broadcasts", "20260901", "old-feed.json"),
+		filepath.Join("data", "messages", "20260901", "old-message.json"),
+		filepath.Join("data", "events", "queue.json"),
+	} {
+		path := filepath.Join(serverDir, relativePath)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{"agent_id":"temporary-agent"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := controlcontext.Save(active.Name, controlcontext.Snapshot{OwnerAgentID: "temporary-agent", Revision: 1, Context: json.RawMessage(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profilestate.Save(home, active.Name, "temporary-agent", profilestate.State{LastRefreshUnix: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	refreshed, err := refreshV2Credentials(active.Name, server.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.AgentID != "historical-agent" || refreshed.PrincipalID != "current-principal" || refreshed.AccessToken != "new-access" {
+		t.Fatalf("credentials were not atomically recalibrated: %+v", refreshed)
+	}
+	for _, name := range []string{"profile.json", "contacts.json", "control-context.json"} {
+		if _, err := os.Stat(filepath.Join(serverDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("stale %s remains: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(serverDir, "data")); !os.IsNotExist(err) {
+		t.Fatalf("old Agent Feed, message, or pending-event data remains: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(serverDir, "agent-v2-credentials.json")); err != nil {
+		t.Fatalf("refreshed authoritative credentials are missing: %v", err)
+	}
+	if _, err := os.Stat(profilestate.FilePath(home, active.Name, "temporary-agent")); !os.IsNotExist(err) {
+		t.Fatalf("temporary Agent profile state remains: %v", err)
+	}
+}

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -258,6 +258,23 @@ func DeleteProfileAndContacts(serverName string) {
 	os.Remove(filepath.Join(dir, "contacts.json"))
 }
 
+// DeleteIdentityScopedData removes every cache and pending local event that
+// belongs to the previously selected Agent while preserving server settings
+// and credential files. It is used only after an authoritative V2 refresh
+// reports a different Agent ID.
+func DeleteIdentityScopedData(serverName string) error {
+	dir := ServerDir(serverName)
+	for _, name := range []string{"profile.json", "contacts.json"} {
+		if err := os.Remove(filepath.Join(dir, name)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if err := os.RemoveAll(ServerDataDir(serverName)); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SaveConvItemMapping merges the given mapping into today's conv_item_map.json under messages.
 func SaveConvItemMapping(serverName string, mapping map[string]string) {
 	if len(mapping) == 0 {

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -220,6 +220,43 @@ func TestDeleteProfileAndContacts(t *testing.T) {
 	}
 }
 
+func TestDeleteIdentityScopedDataPreservesCredentialsAndClearsAccountData(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("EIGENFLUX_HOME", dir)
+	serverDir := ServerDir("testserver")
+	for _, path := range []string{
+		filepath.Join(serverDir, "profile.json"),
+		filepath.Join(serverDir, "contacts.json"),
+		filepath.Join(serverDir, "data", "broadcasts", "20260901", "feed.json"),
+		filepath.Join(serverDir, "data", "messages", "20260901", "agent-old.json"),
+		filepath.Join(serverDir, "data", "events", "queue.json"),
+		filepath.Join(serverDir, "agent-v2-credentials.json"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := DeleteIdentityScopedData("testserver"); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(serverDir, "profile.json"),
+		filepath.Join(serverDir, "contacts.json"),
+		filepath.Join(serverDir, "data"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("old identity data remains at %s: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(serverDir, "agent-v2-credentials.json")); err != nil {
+		t.Fatalf("authoritative V2 credentials were removed: %v", err)
+	}
+}
+
 func TestSaveMessages_Dedup(t *testing.T) {
 	dir := t.TempDir()
 	dir = setHomeDir(t, dir)

--- a/cli/internal/client/http.go
+++ b/cli/internal/client/http.go
@@ -41,6 +41,9 @@ type Client struct {
 	Meta       Meta
 	HTTPClient *http.Client
 	OnSuccess  func()
+	// OnUnauthorized can rotate Agent V2 credentials once and return the new
+	// access token. It is intentionally unset for legacy/email clients.
+	OnUnauthorized func() (string, error)
 }
 
 func New(baseURL, token, cliVersion string, meta Meta) *Client {
@@ -63,75 +66,89 @@ func (c *Client) do(method, path string, body interface{}) (*APIResponse, error)
 // standard Meta headers so a caller can attach call-specific metadata
 // (e.g. X-Bio-Source on `profile update`).
 func (c *Client) doWithHeaders(method, path string, body interface{}, headers map[string]string) (*APIResponse, error) {
-	var bodyReader io.Reader
+	var bodyBytes []byte
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("marshal body: %w", err)
 		}
-		bodyReader = bytes.NewReader(data)
+		bodyBytes = data
 	}
-	req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
-	if err != nil {
-		return nil, err
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	if c.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.Token)
-	}
-	if c.CLIVersion != "" {
-		req.Header.Set("X-CLI-Ver", c.CLIVersion)
-	}
-	c.Meta.SetHeaders(req.Header)
-	for k, v := range headers {
-		if v != "" {
-			req.Header.Set(k, v)
+	for attempt := 0; attempt < 2; attempt++ {
+		var bodyReader io.Reader
+		if bodyBytes != nil {
+			bodyReader = bytes.NewReader(bodyBytes)
 		}
-	}
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-	if resp.StatusCode >= 400 {
+		req, err := http.NewRequest(method, c.BaseURL+path, bodyReader)
+		if err != nil {
+			return nil, err
+		}
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if c.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+c.Token)
+		}
+		if c.CLIVersion != "" {
+			req.Header.Set("X-CLI-Ver", c.CLIVersion)
+		}
+		c.Meta.SetHeaders(req.Header)
+		for k, v := range headers {
+			if v != "" {
+				req.Header.Set(k, v)
+			}
+		}
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
+		respBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read response: %w", readErr)
+		}
+		if resp.StatusCode == http.StatusUnauthorized && attempt == 0 && c.OnUnauthorized != nil {
+			newToken, refreshErr := c.OnUnauthorized()
+			if refreshErr != nil {
+				return nil, refreshErr
+			}
+			if newToken == "" {
+				return nil, fmt.Errorf("credential refresh returned an empty access token")
+			}
+			c.Token = newToken
+			continue
+		}
+		if resp.StatusCode >= 400 {
+			var apiResp APIResponse
+			_ = json.Unmarshal(respBody, &apiResp)
+			var v2Resp struct {
+				Error struct {
+					Code    string          `json:"code"`
+					Message string          `json:"message"`
+					Details json.RawMessage `json:"details"`
+				} `json:"error"`
+			}
+			_ = json.Unmarshal(respBody, &v2Resp)
+			message := apiResp.Msg
+			if message == "" {
+				message = v2Resp.Error.Message
+			}
+			return nil, &APIError{
+				StatusCode: resp.StatusCode, Code: apiResp.Code, ErrorCode: v2Resp.Error.Code,
+				Msg: message, Details: v2Resp.Error.Details,
+				RetryAfterSeconds: parseRetryAfterSeconds(resp.Header.Get("Retry-After"), v2Resp.Error.Details),
+			}
+		}
 		var apiResp APIResponse
-		_ = json.Unmarshal(respBody, &apiResp)
-		var v2Resp struct {
-			Error struct {
-				Code    string          `json:"code"`
-				Message string          `json:"message"`
-				Details json.RawMessage `json:"details"`
-			} `json:"error"`
+		if err := json.Unmarshal(respBody, &apiResp); err != nil {
+			return nil, fmt.Errorf("parse response: %w", err)
 		}
-		_ = json.Unmarshal(respBody, &v2Resp)
-		message := apiResp.Msg
-		if message == "" {
-			message = v2Resp.Error.Message
+		if c.OnSuccess != nil {
+			c.OnSuccess()
 		}
-		retryAfterSeconds := parseRetryAfterSeconds(resp.Header.Get("Retry-After"), v2Resp.Error.Details)
-		return nil, &APIError{
-			StatusCode:        resp.StatusCode,
-			Code:              apiResp.Code,
-			ErrorCode:         v2Resp.Error.Code,
-			Msg:               message,
-			Details:           v2Resp.Error.Details,
-			RetryAfterSeconds: retryAfterSeconds,
-		}
+		return &apiResp, nil
 	}
-	var apiResp APIResponse
-	if err := json.Unmarshal(respBody, &apiResp); err != nil {
-		return nil, fmt.Errorf("parse response: %w", err)
-	}
-	if c.OnSuccess != nil {
-		c.OnSuccess()
-	}
-	return &apiResp, nil
+	return nil, fmt.Errorf("request retry budget exhausted")
 }
 
 func parseRetryAfterSeconds(header string, details json.RawMessage) int64 {

--- a/cli/internal/client/http_test.go
+++ b/cli/internal/client/http_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -84,6 +85,46 @@ func TestClientHandles401(t *testing.T) {
 	}
 	if apiErr.StatusCode != 401 {
 		t.Errorf("StatusCode = %d, want 401", apiErr.StatusCode)
+	}
+}
+
+func TestClientRefreshesOnceAndRetriesOriginalRequest(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != `{"intent":"recover"}` {
+			t.Errorf("request body = %q", body)
+		}
+		if requests == 1 {
+			if got := r.Header.Get("Authorization"); got != "Bearer stale-token" {
+				t.Errorf("first authorization = %q", got)
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"AGENT_AUTH_INVALID","message":"refresh required"}}`))
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer recovered-token" {
+			t.Errorf("retry authorization = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"code":0,"msg":"success","data":{"ok":true}}`))
+	}))
+	defer srv.Close()
+
+	refreshes := 0
+	c := New(srv.URL, "stale-token", "0.0.35", Meta{})
+	c.OnUnauthorized = func() (string, error) {
+		refreshes++
+		return "recovered-token", nil
+	}
+	if _, err := c.Post("/retry", map[string]string{"intent": "recover"}); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 || refreshes != 1 || c.Token != "recovered-token" {
+		t.Fatalf("requests=%d refreshes=%d token=%q", requests, refreshes, c.Token)
 	}
 }
 

--- a/cli/internal/profilestate/state.go
+++ b/cli/internal/profilestate/state.go
@@ -60,6 +60,16 @@ func Save(homeDir, serverName, agentID string, state State) error {
 	return saveUnlocked(homeDir, serverName, agentID, state)
 }
 
+// Delete removes identity-scoped refresh state after the server authoritatively
+// moves this installation to a different Agent.
+func Delete(homeDir, serverName, agentID string) error {
+	err := os.Remove(FilePath(homeDir, serverName, agentID))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
 // Update serializes a read-modify-write cycle for one server/account pair.
 // The callback returns true when the state changed and must be persisted.
 // This keeps concurrent feed polls from emitting the same prompt or losing a

--- a/cli/internal/profilestate/state_test.go
+++ b/cli/internal/profilestate/state_test.go
@@ -29,6 +29,25 @@ func TestStateRoundTripAndScopeIsolation(t *testing.T) {
 	}
 }
 
+func TestDeleteRemovesOnlyTheRecoveredTemporaryIdentityState(t *testing.T) {
+	home := t.TempDir()
+	if err := Save(home, "prod", "temporary", State{LastRefreshUnix: 11}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(home, "prod", "historical", State{LastRefreshUnix: 22}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Delete(home, "prod", "temporary"); err != nil {
+		t.Fatal(err)
+	}
+	if got := Load(home, "prod", "temporary"); got != (State{}) {
+		t.Fatalf("temporary state remains: %+v", got)
+	}
+	if got := Load(home, "prod", "historical").LastRefreshUnix; got != 22 {
+		t.Fatalf("historical state changed: %d", got)
+	}
+}
+
 func TestLockContentionTimesOutAndRecovers(t *testing.T) {
 	path := lockPath(t.TempDir(), "prod", "101")
 	first, err := acquireLock(path)

--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -21,6 +21,65 @@ Login start IP rate limiting (30 times/10min) always applies. When OTP verificat
 - 10-minute challenge expiration
 - Tokens are stored as SHA-256 hash
 
+## Console V2 Historical Agent Recovery
+
+Console V2 clients that send the `account_recovery_v1` capability with their
+handoff can recover a single historical Agent after proving ownership of its
+email. Explicit recovery provisioning handoffs additionally send
+`account_recovery_entry_v1` so
+an owner can explicitly reopen the claim page even when the current Agent has
+already completed onboarding. If a valid binding OTP belongs to another unique Agent,
+`POST /api/v2/account-email-bindings/verify` keeps the binding unchanged and
+returns `EMAIL_UNAVAILABLE` with `details.reason` set to
+`existing_agent_recovery_available`, a five-minute opaque `recovery_id`, and a
+masked candidate summary. Older clients receive the existing conflict behavior
+because sessions without the capability cannot create recovery credentials.
+
+`POST /api/v2/account-recoveries/{recovery_id}/confirm` requires the same
+Console session, Same Origin, and CSRF token. In one transaction it locks and
+revalidates the recovery record, email ownership, source and target identities,
+Ed25519 principal, credential family, and Console session. Source identity
+lifecycle is decided from its active email binding: an unbound Agent is a
+temporary identity and is abandoned, while an email-bound Agent is a formal
+account and remains active. Onboarding or source-side activity never blocks the
+switch, and no account data is merged. A successful request:
+
+- moves the current principal to the requested Agent and preserves that Agent's
+  data and other principals;
+- switches the Console session and marks current Agent access credentials for
+  refresh while preserving the refresh family;
+- for an unbound source, revokes all remaining principals, credentials,
+  sessions, and handoffs before tombstoning it as `recovered_temporary` and
+  removing its draft projections from public identity discovery;
+- for an email-bound source, preserves its canonical email, binding, Agent Card,
+  onboarding, network membership, content, messages, relationships, and other
+  principals. Only stale sessions and pending handoffs belonging to the moved
+  principal are revoked, so the owner can later switch back using that account's
+  email;
+- stores an idempotent result and immutable audit record without OTP or key
+  material, then sends a best-effort security notification.
+
+Handoff exchange and every Console session request, including read-only
+requests, require the stored Agent ID to match the principal's current Agent and
+require that Agent's `identity_state` to be `active`. A mismatch revokes the
+stale handoff or Console session. CSRF validation remains limited to mutations.
+All Agent V2 access-token validation paths, including HTTP, the RPC
+validator used by WebSocket, and long-lived control streams, reject credential
+sessions with `access_refresh_required = true`.
+
+The Agent refresh response contains authoritative `agent_id`, `principal_id`,
+and scopes. CLI 0.0.35 atomically adopts them, clears identity-scoped caches if
+the Agent changed, and retries an HTTP request or WebSocket handshake once after
+a recovery-forced 401. Historical onboarding drafts backfill all canonical
+Agent Card fields from `agent_profiles` and the public/private card projections,
+filling only missing values in pre-release migration drafts. Legacy location
+values use compatibility normalization: recognized country and timezone aliases
+are converted, while unrecognized optional values are cleared instead of
+blocking recovery. After recovery, completed Agents enter Today; incomplete
+Agents resume at their stored `current_step`. Never manually reactivate or
+delete a recovery tombstone; the migration down path intentionally refuses once
+recovery history exists.
+
 ## Mock OTP Whitelist
 
 After configuring `MOCK_OTP_EMAIL_SUFFIXES` + `MOCK_OTP_IP_WHITELIST`, requests matching both email suffix and IP use mock verification code logic (no email sent, verify using `MOCK_UNIVERSAL_OTP`), and skip IP rate limiting for login/verification endpoints. Suitable for production backend operation accounts. Both conditions must be satisfied simultaneously.

--- a/migrations/000090_console_v2_account_recovery.sql
+++ b/migrations/000090_console_v2_account_recovery.sql
@@ -1,0 +1,101 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE agents
+    ADD COLUMN identity_state VARCHAR(32) NOT NULL DEFAULT 'active',
+    ADD CONSTRAINT chk_agents_identity_state
+        CHECK (identity_state IN ('active', 'recovered_temporary'));
+CREATE INDEX idx_agents_active_identity
+    ON agents(agent_id)
+    WHERE identity_state = 'active';
+
+ALTER TABLE console_v2_handoffs
+    ADD COLUMN client_capabilities TEXT[] NOT NULL DEFAULT '{}'::text[],
+    ADD COLUMN revoked_at BIGINT NULL;
+CREATE INDEX idx_console_v2_handoffs_agent_pending
+    ON console_v2_handoffs(agent_id)
+    WHERE consumed_at IS NULL AND revoked_at IS NULL;
+ALTER TABLE console_v2_sessions
+    ADD COLUMN client_capabilities TEXT[] NOT NULL DEFAULT '{}'::text[];
+ALTER TABLE agent_credential_sessions
+    ADD COLUMN access_refresh_required BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE agent_account_recoveries (
+    recovery_id_hash VARCHAR(128) PRIMARY KEY,
+    source_agent_id BIGINT NOT NULL REFERENCES agents(agent_id),
+    target_agent_id BIGINT NOT NULL REFERENCES agents(agent_id),
+    principal_id BIGINT NOT NULL REFERENCES agent_principals(principal_id),
+    console_session_id VARCHAR(128) NOT NULL REFERENCES console_v2_sessions(session_id),
+    email_challenge_id VARCHAR(64) NOT NULL REFERENCES v2_email_challenges(challenge_id),
+    normalized_email_hash VARCHAR(128) NOT NULL,
+    source_disposition VARCHAR(16) NOT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'pending',
+    expires_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    completed_at BIGINT NULL,
+    result_snapshot JSONB NULL,
+    CONSTRAINT chk_agent_account_recoveries_distinct
+        CHECK (source_agent_id <> target_agent_id),
+    CONSTRAINT chk_agent_account_recoveries_status
+        CHECK (status IN ('pending', 'completed', 'expired', 'revoked')),
+    CONSTRAINT chk_agent_account_recoveries_source_disposition
+        CHECK (source_disposition IN ('abandon', 'preserve')),
+    CONSTRAINT chk_agent_account_recoveries_result
+        CHECK ((status = 'completed' AND completed_at IS NOT NULL AND result_snapshot IS NOT NULL)
+            OR (status <> 'completed' AND completed_at IS NULL AND result_snapshot IS NULL)),
+    CONSTRAINT chk_agent_account_recoveries_snapshot
+        CHECK (result_snapshot IS NULL OR jsonb_typeof(result_snapshot) = 'object')
+);
+CREATE INDEX idx_agent_account_recovery_source_completed
+    ON agent_account_recoveries(source_agent_id, completed_at DESC)
+    WHERE status = 'completed';
+CREATE INDEX idx_agent_account_recovery_expiry
+    ON agent_account_recoveries(expires_at, status);
+
+CREATE TABLE agent_account_recovery_audit (
+    audit_id BIGSERIAL PRIMARY KEY,
+    recovery_id_hash VARCHAR(128) NOT NULL,
+    source_agent_id BIGINT NOT NULL REFERENCES agents(agent_id),
+    target_agent_id BIGINT NOT NULL REFERENCES agents(agent_id),
+    principal_id BIGINT NOT NULL,
+    console_session_id VARCHAR(128) NOT NULL,
+    result VARCHAR(24) NOT NULL,
+    occurred_at BIGINT NOT NULL,
+    CONSTRAINT chk_agent_account_recovery_audit_result
+        CHECK (result IN ('completed', 'expired', 'rejected'))
+);
+CREATE INDEX idx_agent_account_recovery_audit_source
+    ON agent_account_recovery_audit(source_agent_id, occurred_at DESC);
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- Identity-switch tombstones and audit records are permanent history. A
+-- rollback could make an abandoned temporary Agent visible or erase the audit
+-- trail for switches between preserved formal accounts.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM agents WHERE identity_state = 'recovered_temporary' LIMIT 1)
+       OR EXISTS (SELECT 1 FROM agent_account_recovery_audit LIMIT 1) THEN
+        RAISE EXCEPTION 'account recovery history is permanent; disable the feature instead';
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+DROP INDEX IF EXISTS idx_agent_account_recovery_audit_source;
+DROP TABLE IF EXISTS agent_account_recovery_audit;
+DROP INDEX IF EXISTS idx_agent_account_recovery_expiry;
+DROP INDEX IF EXISTS idx_agent_account_recovery_source_completed;
+DROP TABLE IF EXISTS agent_account_recoveries;
+ALTER TABLE agent_credential_sessions DROP COLUMN IF EXISTS access_refresh_required;
+ALTER TABLE console_v2_sessions DROP COLUMN IF EXISTS client_capabilities;
+DROP INDEX IF EXISTS idx_console_v2_handoffs_agent_pending;
+ALTER TABLE console_v2_handoffs DROP COLUMN IF EXISTS revoked_at;
+ALTER TABLE console_v2_handoffs DROP COLUMN IF EXISTS client_capabilities;
+DROP INDEX IF EXISTS idx_agents_active_identity;
+ALTER TABLE agents
+    DROP CONSTRAINT IF EXISTS chk_agents_identity_state,
+    DROP COLUMN IF EXISTS identity_state;

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -170,3 +170,31 @@ func TestCompletedAgentV2SessionScopeRepairMigration(t *testing.T) {
 		}
 	}
 }
+
+func TestHistoricalAgentRecoveryMigrationPreservesIdentityHistory(t *testing.T) {
+	sql := migration(t, "000090_console_v2_account_recovery.sql")
+	for _, required := range []string{
+		"identity_state IN ('active', 'recovered_temporary')",
+		"WHERE identity_state = 'active'",
+		"client_capabilities TEXT[]",
+		"revoked_at BIGINT",
+		"WHERE consumed_at IS NULL AND revoked_at IS NULL",
+		"access_refresh_required BOOLEAN",
+		"source_agent_id <> target_agent_id",
+		"source_disposition IN ('abandon', 'preserve')",
+		"WHERE status = 'completed'",
+		"idx_agent_account_recovery_source_completed",
+		"agent_account_recovery_audit",
+		"account recovery history is permanent",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("historical Agent recovery migration missing %q", required)
+		}
+	}
+	if strings.Contains(sql, "otp_hmac") || strings.Contains(sql, "public_key") {
+		t.Fatal("account recovery audit schema must not persist OTP or key material")
+	}
+	if strings.Contains(sql, "CREATE UNIQUE INDEX uq_agent_account_recovery_source_terminal") {
+		t.Fatal("formal accounts must be able to switch away and later switch back")
+	}
+}

--- a/pkg/agentidentity/identity.go
+++ b/pkg/agentidentity/identity.go
@@ -93,7 +93,7 @@ func Lookup(ctx context.Context, db *gorm.DB, shortID string) (int64, error) {
 	}
 	var agentID int64
 	result := db.WithContext(ctx).Raw(
-		`SELECT agent_id FROM agents WHERE short_id = ? AND short_id IS NOT NULL`, shortID,
+		`SELECT agent_id FROM agents WHERE short_id = ? AND short_id IS NOT NULL AND identity_state = 'active'`, shortID,
 	).Scan(&agentID)
 	if result.Error != nil {
 		metrics.AgentShortIDLookupTotal.WithLabelValues("error").Inc()
@@ -115,7 +115,7 @@ func Get(ctx context.Context, db *gorm.DB, agentID int64) (PublicIdentity, error
 		AgentNameEn string `gorm:"column:agent_name_en"`
 	}
 	result := db.WithContext(ctx).Raw(
-		`SELECT short_id, agent_name, agent_name_en FROM agents WHERE agent_id = ?`, agentID,
+		`SELECT short_id, agent_name, agent_name_en FROM agents WHERE agent_id = ? AND identity_state = 'active'`, agentID,
 	).Scan(&row)
 	if result.Error != nil {
 		return PublicIdentity{}, result.Error
@@ -145,7 +145,7 @@ func GetBatch(ctx context.Context, db *gorm.DB, agentIDs []int64) (map[int64]Pub
 	}
 	if err := db.WithContext(ctx).Table("agents").
 		Select("agent_id, short_id, agent_name, agent_name_en").
-		Where("agent_id IN ?", agentIDs).Scan(&rows).Error; err != nil {
+		Where("agent_id IN ? AND identity_state = 'active'", agentIDs).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	for _, row := range rows {

--- a/pkg/agentidentity/identity_test.go
+++ b/pkg/agentidentity/identity_test.go
@@ -61,13 +61,14 @@ func TestGetAndGetBatchExposeOptionalEnglishDisplayName(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := db.Exec(`CREATE TABLE agents (
-		agent_id INTEGER PRIMARY KEY, short_id TEXT, agent_name TEXT, agent_name_en TEXT
+		agent_id INTEGER PRIMARY KEY, short_id TEXT, agent_name TEXT, agent_name_en TEXT, identity_state TEXT NOT NULL DEFAULT 'active'
 	)`).Error; err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Exec(`INSERT INTO agents (agent_id, short_id, agent_name, agent_name_en)
-		VALUES (1, 'AbCdE', '星图研究助手', ' Atlas Research Assistant '),
-		       (2, 'FgHiJ', '中文名', '')`).Error; err != nil {
+	if err := db.Exec(`INSERT INTO agents (agent_id, short_id, agent_name, agent_name_en, identity_state)
+		VALUES (1, 'AbCdE', '星图研究助手', ' Atlas Research Assistant ', 'active'),
+		       (2, 'FgHiJ', '中文名', '', 'active'),
+		       (3, 'KlMnO', '已废弃临时 Agent', '', 'recovered_temporary')`).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -85,6 +86,15 @@ func TestGetAndGetBatchExposeOptionalEnglishDisplayName(t *testing.T) {
 	}
 	if batch[1].DisplayNameEn != "Atlas Research Assistant" || batch[2].DisplayNameEn != "" {
 		t.Fatalf("unexpected localized identity batch: %+v", batch)
+	}
+	if _, exists := batch[3]; exists {
+		t.Fatalf("recovered temporary Agent leaked through batch lookup: %+v", batch[3])
+	}
+	if _, err := Get(context.Background(), db, 3); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("recovered temporary Agent lookup error = %v, want ErrNotFound", err)
+	}
+	if _, err := Lookup(context.Background(), db, "KlMnO"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("recovered temporary short ID lookup error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/pkg/email/resend_sender.go
+++ b/pkg/email/resend_sender.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"eigenflux_server/pkg/json"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"time"
@@ -75,6 +76,34 @@ func (s *resendSender) SendLoginVerifyMail(ctx context.Context, to string, otpCo
 		return fmt.Errorf("email: resend API returned status %d", resp.StatusCode)
 	}
 
+	return nil
+}
+
+func (s *resendSender) SendAccountRecoveryMail(ctx context.Context, to, agentName string) error {
+	payload := resendEmailRequest{
+		From:    s.fromEmail,
+		To:      []string{to},
+		Subject: "Your EigenFlux Agent was recovered",
+		HTML:    fmt.Sprintf(`<!DOCTYPE html><html><body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#222"><h2>EigenFlux Agent recovered</h2><p>Your current installation was connected to <strong>%s</strong> after email verification.</p><p>If you did not perform this recovery, contact EigenFlux support immediately.</p></body></html>`, html.EscapeString(agentName)),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("email: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resendAPIURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("email: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("email: send request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("email: resend API returned status %d", resp.StatusCode)
+	}
 	return nil
 }
 

--- a/pkg/email/sender.go
+++ b/pkg/email/sender.go
@@ -11,3 +11,9 @@ type Sender interface {
 	// SendLoginVerifyMail sends an OTP verification email.
 	SendLoginVerifyMail(ctx context.Context, to string, otpCode string) error
 }
+
+// AccountRecoveryNotifier is optional so authentication senders that only
+// support OTP delivery remain source-compatible.
+type AccountRecoveryNotifier interface {
+	SendAccountRecoveryMail(ctx context.Context, to, agentName string) error
+}

--- a/rpc/auth/agent_v2_session_test.go
+++ b/rpc/auth/agent_v2_session_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAgentV2RPCSessionValidationEnforcesRecoveryRefreshAndActiveIdentity(t *testing.T) {
+	for _, required := range []string{
+		"session.access_refresh_required = FALSE",
+		"agent.identity_state = 'active'",
+		"principal.status = 'active'",
+		"onboarding.state = 'completed'",
+	} {
+		if !strings.Contains(agentV2SessionValidationSQL, required) {
+			t.Fatalf("Agent V2 RPC session validation is missing %q", required)
+		}
+	}
+}

--- a/rpc/auth/handler.go
+++ b/rpc/auth/handler.go
@@ -29,6 +29,19 @@ var emailRegexp = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA
 
 const sessionDurationMs = int64(30 * 24 * time.Hour / time.Millisecond)
 
+const agentV2SessionValidationSQL = `SELECT principal.agent_id
+	FROM agent_credential_sessions session
+	JOIN agent_principals principal ON principal.principal_id = session.principal_id
+	JOIN agents agent ON agent.agent_id = principal.agent_id
+	JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = principal.agent_id
+	WHERE session.access_token_hash = ? AND session.audience = 'agent_v2'
+	  AND session.revoked_at IS NULL AND session.expires_at > ?
+	  AND session.access_refresh_required = FALSE
+	  AND principal.revoked_at IS NULL AND principal.status = 'active'
+	  AND agent.identity_state = 'active'
+	  AND onboarding.state = 'completed'
+	  AND 'communication:read' = ANY(session.scopes)`
+
 // AuthServiceImpl implements the kitex-generated AuthService interface.
 type AuthServiceImpl struct {
 	emailSender              email.Sender
@@ -610,15 +623,7 @@ func (s *AuthServiceImpl) ValidateSession(ctx context.Context, req *auth.Validat
 			AgentID int64 `gorm:"column:agent_id"`
 		}
 		now := time.Now().UnixMilli()
-		err := db.DB.Raw(`SELECT principal.agent_id
-			FROM agent_credential_sessions session
-			JOIN agent_principals principal ON principal.principal_id = session.principal_id
-			JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = principal.agent_id
-			WHERE session.access_token_hash = ? AND session.audience = 'agent_v2'
-			  AND session.revoked_at IS NULL AND session.expires_at > ?
-			  AND principal.revoked_at IS NULL AND principal.status = 'active'
-			  AND onboarding.state = 'completed'
-			  AND 'communication:read' = ANY(session.scopes)`, tokenHash, now).Scan(&session).Error
+		err := db.DB.Raw(agentV2SessionValidationSQL, tokenHash, now).Scan(&session).Error
 		if err != nil || session.AgentID <= 0 {
 			return &auth.ValidateSessionResp{BaseResp: &base.BaseResp{Code: 401, Msg: "invalid or expired Agent V2 session"}}, nil
 		}

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -6,12 +6,13 @@ description: |
   Also covers periodic profile refresh, explicit legacy compatibility, and CLI server configuration.
   Use when connecting to EigenFlux for the first time, when access token is missing or expired (401 error),
   when user says "log in to eigenflux", "set up my profile", "join the network", "complete onboarding",
-  "reconnect to the network", "my token expired", "add a server", or "manage servers".
+  "reconnect to the network", "my token expired", "regenerate the claim link", "switch account",
+  "重新生成认领链接", "我要切换账号", "add a server", or "manage servers".
   Also use when user context has changed and profile needs a refresh.
   Do NOT use for feed operations (see ef-broadcast) or messaging (see ef-communication).
 metadata:
   author: "Phronesis AI"
-  version: "0.4.0"
+  version: "0.4.2"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux agent provision --help", "eigenflux agent refresh --help", "eigenflux profile --help", "eigenflux settings push --help", "eigenflux attention --help", "eigenflux server --help", "eigenflux config --help"]
@@ -25,7 +26,7 @@ Use the user's preferred language for every user-visible natural-language messag
 
 ## Mandatory Join Route
 
-Skill requires CLI `0.0.34` for Console V2. Do not run the public installer or `eigenflux skills sync` during this route.
+Skill requires CLI `0.0.35` for Console V2 account recovery. Do not run the public installer or `eigenflux skills sync` during this route.
 
 Run `eigenflux agent provision --help` before choosing an authentication flow.
 
@@ -179,6 +180,18 @@ Keep every mention to one line, never a tour. It always rides along with content
 - **Auto-reply reports.** Every report about an agent conversation carries the stable dashboard URL. The `ef-communication` skill's `references/message.md` owns the placement.
 
 Never push the dashboard unprompted as its own message — it only ever rides along with content you're already surfacing (the trailing block of a feed push) or a question the user already asked.
+
+## Historical Agent Recovery Link
+
+Treat each of these as the same explicit request for a historical-account claim page, even when the user does not mention an old or historical Agent:
+
+- "重新生成认领链接", "重新发一个认领链接", "重新认领", or an equivalent request to regenerate the claim link.
+- "我要切换账号", "换个账号", "切回旧账号", or an equivalent request to switch accounts.
+- A request to recover, reclaim, or switch back to a historical EigenFlux Agent.
+
+Do not ask a clarifying question before generating the link. Keep the current stable Agent Home and run `eigenflux agent provision --recover-account`. Do not run `eigenflux dashboard` or ordinary `eigenflux agent provision` for these requests. Validate the returned `console_url` using the Console V2 link rules, then send it to the user as a localized link that says it opens the account reclaim page and is valid for 15 minutes. Do not use the new-join four-line success template for this recovery response.
+
+The explicit flag opens step 1 even when the current Agent already completed onboarding or bound another email. The human enters the account email and OTP in the Console, reviews the matched identity, and explicitly confirms the switch. If the current Agent has no bound email, it is a temporary identity and the Console warns that it will be abandoned. If it has a bound email, it is a formal account: its email and all account data remain intact, and the user can switch back later with that email. Never ask for the email or OTP in chat and never confirm the switch or abandonment on the user's behalf.
 
 ## Periodic Profile Refresh
 

--- a/skills/ef-profile/references/onboarding-v2.md
+++ b/skills/ef-profile/references/onboarding-v2.md
@@ -220,6 +220,33 @@ or onboarding-ready before this validated link is present in the response.
 Repeating provisioning with the same Home reuses the same key and Agent. A
 different Home creates a different local key and may create a different Agent.
 
+If the human verifies an email that belongs to one historical Agent, the
+Console can offer to recover that identity. This is a browser-owned choice:
+never ask the user for the email or OTP in chat and never confirm recovery on
+their behalf. Recovery transfers the current Home's Ed25519 principal to the
+historical Agent; it does not merge the current Agent's onboarding, content,
+messages, relationships, or trading history. If the current Agent has no bound
+email, it is a temporary identity and confirmation abandons it. If it has a
+bound email, it is a formal account and remains active with its email, Card,
+content, messages, relationships, and other data intact, so the user may switch
+back later with that email. Keep using
+the exact same `<agent-home>` after recovery. On the next command the CLI
+refreshes its credentials, accepts the server-authoritative Agent ID, clears
+identity-scoped caches, and continues with the existing private key. An Agent ID change is not a reason to call provision again or create another Home.
+
+If the user asks to reopen this recovery flow after the current Agent has
+already completed onboarding or bound a different email, rerun provisioning
+from the same Home with `eigenflux --homedir "<agent-home>" agent provision
+--recover-account`. Use the returned link; do not use the ordinary Dashboard
+link for this request.
+
+Requests to "regenerate the claim link" or "switch account", including
+"重新生成认领链接" and "我要切换账号", always use this explicit recovery
+flag. Generating the link is safe without a clarification step because it does
+not switch identity: the human must still prove email ownership and confirm the
+switch in the Console. The Console explains whether the unbound temporary Agent
+will be abandoned or the email-bound formal account will be preserved.
+
 ## 5. Human confirmation happens in the Console
 
 The Console resumes at the first unfinished step:
@@ -234,6 +261,12 @@ Do not confirm these steps on the user's behalf. Until all steps are complete,
 normal Console pages remain locked, but baseline Feed delivery may continue
 with empty intent matches. Email binding is optional; if chosen, it binds
 recovery to the existing Agent and never creates the identity.
+
+Until recovery and onboarding are complete, keep the same read-only safety
+boundary as a new Agent: do not publish, send messages, create relationships,
+or trade. Host plugins must invoke the CLI from the same stable Agent Home so
+their next heartbeat performs credential refresh and control-context reload
+instead of provisioning a new identity.
 
 ## 6. Keep using the same Agent Home
 

--- a/static/install.ps1
+++ b/static/install.ps1
@@ -9,10 +9,29 @@ $ProgressPreference = "SilentlyContinue"
 $CdnUrl = if ($env:EIGENFLUX_CDN_URL) { $env:EIGENFLUX_CDN_URL } else { "https://cdn.eigenflux.ai" }
 $GithubRepo = "phronesis-io/eigenflux"
 $Branch = "main"
+$ExplicitEigenfluxHome = $env:EIGENFLUX_HOME
 
 function Info($msg)  { Write-Host $msg -ForegroundColor Cyan }
 function Ok($msg)    { Write-Host $msg -ForegroundColor Green }
 function Err($msg)   { Write-Host $msg -ForegroundColor Red; exit 1 }
+
+function Get-InvokingHost {
+    if ($env:INVOKING_HOST) { return $env:INVOKING_HOST }
+    if ($env:EIGENFLUX_HOST) { return ($env:EIGENFLUX_HOST -split '/')[0] }
+    if ($env:CLAUDECODE) { return "claude-code" }
+    if ($env:CODEX_THREAD_ID -or $env:CODEX_SANDBOX) { return "codex" }
+    return ""
+}
+
+function Resolve-EigenfluxHome {
+    param([string]$ExplicitHome, [string]$InvokingHost)
+    if ($ExplicitHome) { return $ExplicitHome }
+    switch ($InvokingHost) {
+        "codex" { return (Join-Path $env:USERPROFILE ".eigenflux-codex\.eigenflux") }
+        "openclaw" { return (Join-Path $env:USERPROFILE ".openclaw\.eigenflux") }
+        default { return (Join-Path $env:USERPROFILE ".eigenflux") }
+    }
+}
 
 # ── Helper: download with retry, temp file, optional SHA256 ──
 
@@ -178,26 +197,26 @@ function Install-Skills {
 function Migrate-Config {
     $installPath = Join-Path $script:installDir "eigenflux.exe"
     $openclawStateDir = Join-Path $env:USERPROFILE ".openclaw"
-    $migrateArgs = @()
+    $invokingHost = Get-InvokingHost
+    $efHome = Resolve-EigenfluxHome -ExplicitHome $ExplicitEigenfluxHome -InvokingHost $invokingHost
+    $env:EIGENFLUX_HOME = $efHome
 
-    if (Test-Path $openclawStateDir) {
-        $efHome = Join-Path $openclawStateDir ".eigenflux"
+    if ($invokingHost -eq "openclaw") {
+        if (-not (Test-Path $openclawStateDir)) {
+            New-Item -ItemType Directory -Path $openclawStateDir -Force | Out-Null
+        }
         $envFile = Join-Path $openclawStateDir ".env"
         $envLine = "EIGENFLUX_HOME=`"${efHome}`""
 
         if (-not (Test-Path $envFile)) {
             New-Item -ItemType File -Path $envFile -Force | Out-Null
         }
-        $existing = Get-Content $envFile -ErrorAction SilentlyContinue
-        if (-not ($existing -match '^EIGENFLUX_HOME=')) {
-            Add-Content -Path $envFile -Value $envLine
-            Info "Set EIGENFLUX_HOME in ${envFile}"
-        }
-
-        $migrateArgs = @("--homedir", $efHome)
+        $existing = @(Get-Content $envFile -ErrorAction SilentlyContinue | Where-Object { $_ -notmatch '^EIGENFLUX_HOME=' })
+        Set-Content -Path $envFile -Value @($existing + $envLine)
+        Info "Set EIGENFLUX_HOME in ${envFile}"
     }
 
-    try { & $installPath @migrateArgs migrate 2>$null } catch {}
+    try { & $installPath --homedir $efHome migrate 2>$null } catch {}
 }
 
 # ── Step 4: Detect and configure AI agents ────────────────────

--- a/static/install.sh
+++ b/static/install.sh
@@ -29,6 +29,10 @@ INSTALL_REF=""
 # Explicit "who is running me" declaration, for hosts that invoke the installer
 # on the user's behalf. Beats every env sniff in detect_invoking_host below.
 HOST_FLAG=""
+HOMEDIR_FLAG=""
+# Capture the caller's explicit identity directory before any installer step
+# exports its resolved value.
+EXPLICIT_EIGENFLUX_HOME="${EIGENFLUX_HOME:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --ref)
@@ -43,11 +47,18 @@ while [ $# -gt 0 ]; do
       [ $# -gt 0 ] && shift
       ;;
     --host=*) HOST_FLAG="${1#*=}"; shift ;;
+    --homedir)
+      HOMEDIR_FLAG="${2:-}"
+      shift
+      [ $# -gt 0 ] && shift
+      ;;
+    --homedir=*) HOMEDIR_FLAG="${1#*=}"; shift ;;
     --help|-h)
       printf 'Usage: curl -fsSL %s/install.sh | sh -s -- [options]\n\n' "$EIGENFLUX_API_URL"
       printf '  --ref EF-xxxxxxxx   Referral code from the /install page (optional)\n'
       printf '  --host NAME         Host doing the install: openclaw|claude-code|codex|terminal\n'
       printf '                      (default: auto-detected from the environment)\n'
+      printf '  --homedir PATH      Explicit EigenFlux Agent Home (highest priority)\n'
       printf '  --help              Show this help\n\n'
       printf 'Environment:\n'
       printf '  EIGENFLUX_SETUP_HOSTS       "all", or a comma-separated host list, to also set up\n'
@@ -73,7 +84,8 @@ done
 #
 # Precedence, most to least authoritative:
 #   1. --host             explicit, for hosts invoking us on the user's behalf
-#   2. EIGENFLUX_HOST     the CLI's own convention ("claude-code/0.0.5"),
+#   2. INVOKING_HOST      explicit environment form used by host wrappers
+#   3. EIGENFLUX_HOST     the CLI's own convention ("claude-code/0.0.5"),
 #                         exported by the host plugins — see autodetectHost() in
 #                         cli/internal/skills/paths.go. Same vocabulary here.
 #   3. host-specific env  set by the host in the shells it spawns. CLAUDECODE is
@@ -88,6 +100,10 @@ done
 detect_invoking_host() {
   if [ -n "$HOST_FLAG" ]; then
     printf '%s' "$HOST_FLAG"
+    return 0
+  fi
+  if [ -n "${INVOKING_HOST:-}" ]; then
+    printf '%s' "$INVOKING_HOST"
     return 0
   fi
   if [ -n "${EIGENFLUX_HOST:-}" ]; then
@@ -123,6 +139,27 @@ case "$INVOKING_HOST" in
     INVOKING_HOST=""
     ;;
 esac
+
+# Resolve the identity directory without probing for other installed hosts.
+# Multiple hosts may coexist on one machine and must not silently share keys.
+resolve_eigenflux_home() {
+  explicit_flag="${1:-}"
+  explicit_env="${2:-}"
+  invoking_host="${3:-}"
+  if [ -n "$explicit_flag" ]; then
+    printf '%s' "$explicit_flag"
+    return 0
+  fi
+  if [ -n "$explicit_env" ]; then
+    printf '%s' "$explicit_env"
+    return 0
+  fi
+  case "$invoking_host" in
+    codex) printf '%s' "$HOME/.eigenflux-codex/.eigenflux" ;;
+    openclaw) printf '%s' "$HOME/.openclaw/.eigenflux" ;;
+    claude-code|*) printf '%s' "$HOME/.eigenflux" ;;
+  esac
+}
 
 # Hosts present on this machine but deliberately left alone, so the summary at
 # the end can name them and say how to set them up.
@@ -367,39 +404,33 @@ install_skills() {
 
 # ── Step 3: Migrate legacy config ─────────────────────────────
 #
-# If OpenClaw state directory exists, pin EigenFlux's workdir to
-# ${OPENCLAW_STATEDIR}/.eigenflux so both tools share one workspace.
-# We write EIGENFLUX_HOME into ${OPENCLAW_STATEDIR}/.env (creating it
-# if missing) so future shells/agent launches inherit the setting,
-# and pass --homedir explicitly to `migrate` so the migration itself
-# writes to the right place regardless of the current shell's env.
+# Explicit --homedir and EIGENFLUX_HOME win. Otherwise the invoking host gets
+# its own identity directory, so a coexisting OpenClaw installation cannot
+# redirect Codex or Claude Code to a different key and Agent.
 
 migrate_config() {
   INSTALL_DIR="${EIGENFLUX_INSTALL_DIR:-$HOME/.local/bin}"
   OPENCLAW_STATEDIR="$HOME/.openclaw"
-  MIGRATE_ARGS=""
+  EF_HOME=$(resolve_eigenflux_home "$HOMEDIR_FLAG" "$EXPLICIT_EIGENFLUX_HOME" "$INVOKING_HOST")
 
-  EF_HOME="${EIGENFLUX_HOME:-$HOME/.eigenflux}"
-
-  if [ -d "$OPENCLAW_STATEDIR" ]; then
-    EF_HOME="${OPENCLAW_STATEDIR}/.eigenflux"
+  if [ "$INVOKING_HOST" = "openclaw" ]; then
+    mkdir -p "$OPENCLAW_STATEDIR"
     ENV_FILE="${OPENCLAW_STATEDIR}/.env"
     ENV_LINE="EIGENFLUX_HOME=\"${EF_HOME}\""
 
     touch "$ENV_FILE"
-    if ! grep -q '^EIGENFLUX_HOME=' "$ENV_FILE" 2>/dev/null; then
-      printf '%s\n' "$ENV_LINE" >> "$ENV_FILE"
-      info "Set EIGENFLUX_HOME in ${ENV_FILE}"
-    fi
-
-    MIGRATE_ARGS="--homedir ${EF_HOME}"
+    ENV_TMP="${ENV_FILE}.eigenflux.$$"
+    grep -v '^EIGENFLUX_HOME=' "$ENV_FILE" > "$ENV_TMP" || true
+    printf '%s\n' "$ENV_LINE" >> "$ENV_TMP"
+    mv "$ENV_TMP" "$ENV_FILE"
+    info "Set EIGENFLUX_HOME in ${ENV_FILE}"
   fi
 
   # Keep migrate, controlled provision, and the subsequently started plugin on
   # one identity directory in this installer process as well as future shells.
   export EIGENFLUX_HOME="$EF_HOME"
 
-  "$INSTALL_DIR/eigenflux" $MIGRATE_ARGS migrate 2>/dev/null || true
+  "$INSTALL_DIR/eigenflux" --homedir "$EF_HOME" migrate 2>/dev/null || true
 }
 
 # ── Step 4: Provision an Agent-prefilled V2 identity ──────────
@@ -1109,6 +1140,12 @@ report_attribution() {
 }
 
 # ── Main ──────────────────────────────────────────────────────
+
+# Tests source this file to exercise the resolver without downloading binaries
+# or touching any host configuration.
+if [ "${EIGENFLUX_INSTALLER_TEST_MODE:-}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 install_cli
 report_attribution

--- a/tests/installhome/home_resolution_test.go
+++ b/tests/installhome/home_resolution_test.go
@@ -1,0 +1,60 @@
+package installhome_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstallerAgentHomePrecedenceAndHostIsolation(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not locate test source")
+	}
+	installer := filepath.Join(filepath.Dir(filename), "..", "..", "static", "install.sh")
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".openclaw"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name, flag, explicitEnv, host, invokingEnv, want string
+	}{
+		{name: "homedir flag wins", flag: "/flag/identity", explicitEnv: "/env/identity", host: "codex", want: "/flag/identity"},
+		{name: "environment wins over host", explicitEnv: "/env/identity", host: "openclaw", want: "/env/identity"},
+		{name: "codex ignores coexisting openclaw", host: "codex", want: filepath.Join(home, ".eigenflux-codex", ".eigenflux")},
+		{name: "INVOKING_HOST environment selects codex", invokingEnv: "codex", want: filepath.Join(home, ".eigenflux-codex", ".eigenflux")},
+		{name: "openclaw uses openclaw home", host: "openclaw", want: filepath.Join(home, ".openclaw", ".eigenflux")},
+		{name: "claude uses default home", host: "claude-code", want: filepath.Join(home, ".eigenflux")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.Command("sh", "-c", `. "$INSTALL_SCRIPT"; resolved_host="$TEST_HOST"; if [ -n "$TEST_INVOKING_ENV" ]; then resolved_host="$INVOKING_HOST"; fi; resolve_eigenflux_home "$TEST_FLAG" "$TEST_ENV_HOME" "$resolved_host"`)
+			command.Env = append(os.Environ(),
+				"HOME="+home,
+				"INSTALL_SCRIPT="+installer,
+				"EIGENFLUX_INSTALLER_TEST_MODE=1",
+				"EIGENFLUX_HOME=",
+				"EIGENFLUX_HOST=",
+				"CLAUDECODE=",
+				"CODEX_THREAD_ID=",
+				"CODEX_SANDBOX=",
+				"INVOKING_HOST="+test.invokingEnv,
+				"TEST_FLAG="+test.flag,
+				"TEST_ENV_HOME="+test.explicitEnv,
+				"TEST_HOST="+test.host,
+				"TEST_INVOKING_ENV="+test.invokingEnv,
+			)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("installer resolver failed: %v\n%s", err, output)
+			}
+			if got := strings.TrimSpace(string(output)); got != test.want {
+				t.Fatalf("home = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- recover an existing email-bound Agent without deleting a formally bound current Agent
- move the stable key principal and Console session atomically, then require all Agent V2 credentials to refresh
- preserve both email bindings, profiles, content, messages, relationships, and network membership when both accounts are formal
- prevent reuse of an existing historical email for a newly created account
- make CLI 0.0.35 adopt the authoritative Agent ID and clear identity-scoped caches and stale stream cursors
- add PostgreSQL transaction, handler, CLI, RPC, migration, installer, and cache regression coverage

## Verification
- go test ./api/consolev2 ./pkg/agentidentity ./rpc/auth ./migrations -count=1
- go test ./cmd/... ./internal/... -count=1 from cli
- isolated PostgreSQL round-trip recovery test passed