### PR TITLE
fix(agentcard): enforce single-item profile prose

### DIFF
--- a/api/consolev2/onboarding_limits_test.go
+++ b/api/consolev2/onboarding_limits_test.go
@@ -7,11 +7,14 @@ func TestOnboardingLimitsExposeBackendValidationContract(t *testing.T) {
 	if got := limits.IdentityCard["agent_description"]; got.MaxChars != 1000 {
 		t.Fatalf("unexpected agent_description limits: %#v", got)
 	}
-	if got := limits.IdentityCard["seeking"]; got.MaxChars != 300 || got.MaxItemChars != 300 || got.MaxItems != 20 {
+	if got := limits.IdentityCard["seeking"]; got.MaxChars != 300 || got.MaxItemChars != 300 || got.MaxItems != 1 {
 		t.Fatalf("unexpected seeking limits: %#v", got)
 	}
-	if got := limits.IdentityCard["offering"]; got.MaxChars != 1000 || got.MaxItemChars != 100 || got.MaxItems != 20 {
+	if got := limits.IdentityCard["offering"]; got.MaxChars != 1000 || got.MaxItemChars != 1000 || got.MaxItems != 1 {
 		t.Fatalf("unexpected offering limits: %#v", got)
+	}
+	if got := limits.IdentityCard["interests_negative"]; got.MaxChars != 500 || got.MaxItemChars != 500 || got.MaxItems != 1 {
+		t.Fatalf("unexpected interests_negative limits: %#v", got)
 	}
 	if got := limits.IdentityCard["agent_status"]; got.MaxChars != 1000 || got.MaxItemChars != 1000 || got.MaxItems != 20 {
 		t.Fatalf("unexpected agent_status limits: %#v", got)

--- a/api/consolev2/onboarding_location.go
+++ b/api/consolev2/onboarding_location.go
@@ -38,6 +38,10 @@ var onboardingListFields = []string{
 	"interests_negative",
 }
 
+var onboardingSingleItemTextFields = map[string]struct{}{
+	"seeking": {}, "offering": {}, "agent_status": {}, "human_status": {}, "interests_negative": {},
+}
+
 func normalizeOnboardingCountry(raw string) (string, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
@@ -135,8 +139,26 @@ func normalizeOnboardingDraftLists(draft map[string]interface{}) error {
 					items = append(items, text)
 				}
 			}
-			identity[field] = items
+			if _, singleItem := onboardingSingleItemTextFields[field]; singleItem {
+				joined := strings.Join(items, " · ")
+				if joined == "" {
+					identity[field] = []string{}
+				} else {
+					identity[field] = []string{joined}
+				}
+			} else {
+				identity[field] = items
+			}
 		case string:
+			if _, singleItem := onboardingSingleItemTextFields[field]; singleItem {
+				text := strings.TrimSpace(value)
+				if text == "" {
+					identity[field] = []string{}
+				} else {
+					identity[field] = []string{text}
+				}
+				continue
+			}
 			items := strings.FieldsFunc(value, func(r rune) bool {
 				switch r {
 				case '·', ',', '，', ';', '；', '\n', '\r':

--- a/api/consolev2/onboarding_location_test.go
+++ b/api/consolev2/onboarding_location_test.go
@@ -49,7 +49,7 @@ func TestNormalizeOnboardingDraftListsSupportsLegacyScalars(t *testing.T) {
 	raw := json.RawMessage(`{
 		"identity_card": {
 			"working_languages": "中文 · English",
-			"seeking": "",
+			"seeking": "寻找 AI infra, Agent collaboration\n以及行业信号",
 			"offering": ["研究", " ", "任务整理"]
 		}
 	}`)
@@ -64,10 +64,10 @@ func TestNormalizeOnboardingDraftListsSupportsLegacyScalars(t *testing.T) {
 	if got, want := payload.IdentityCard.WorkingLanguages, []string{"中文", "English"}; !equalStrings(got, want) {
 		t.Fatalf("working_languages = %#v, want %#v", got, want)
 	}
-	if len(payload.IdentityCard.Seeking) != 0 {
-		t.Fatalf("seeking = %#v, want empty", payload.IdentityCard.Seeking)
+	if got, want := payload.IdentityCard.Seeking, []string{"寻找 AI infra, Agent collaboration\n以及行业信号"}; !equalStrings(got, want) {
+		t.Fatalf("seeking = %#v, want %#v", got, want)
 	}
-	if got, want := payload.IdentityCard.Offering, []string{"研究", "任务整理"}; !equalStrings(got, want) {
+	if got, want := payload.IdentityCard.Offering, []string{"研究 · 任务整理"}; !equalStrings(got, want) {
 		t.Fatalf("offering = %#v, want %#v", got, want)
 	}
 }

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -48,8 +48,8 @@ var EditableFields = []FieldSpec{
 	{Name: "agent_description", Public: true, Storage: StorageAgents, Kind: "string", MaxLen: 4000},
 	{Name: "human_description", Public: true, Storage: StorageProfileData, Kind: "string", MaxLen: 2000},
 	{Name: "working_languages", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 32, MaxItems: 10},
-	{Name: "seeking", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 300, MaxItems: 20},
-	{Name: "offering", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 20},
+	{Name: "seeking", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 300, MaxItems: 1},
+	{Name: "offering", Public: true, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 1},
 
 	{Name: "geo", Public: false, Storage: StorageProfileData, Kind: "string", MaxLen: 100},
 	{Name: "timezone", Public: false, Storage: StorageProfileData, Kind: "string", MaxLen: 64},
@@ -57,7 +57,7 @@ var EditableFields = []FieldSpec{
 	{Name: "demands", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 200, MaxItems: 20},
 	{Name: "agent_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 20},
 	{Name: "human_status", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 1000, MaxItems: 20},
-	{Name: "interests_negative", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 100, MaxItems: 30},
+	{Name: "interests_negative", Public: false, Storage: StorageProfileData, Kind: "string_list", MaxLen: 500, MaxItems: 1},
 }
 
 // ProtectedPaths are Card paths no client may write, whatever the request

--- a/pkg/agentcard/registry_test.go
+++ b/pkg/agentcard/registry_test.go
@@ -58,8 +58,11 @@ func TestValidateValue(t *testing.T) {
 	}
 
 	listSpec, _ := LookupField("seeking")
-	if _, err := ValidateValue(listSpec, json.RawMessage(`["AI infra","agent collaboration"]`)); err != nil {
+	if _, err := ValidateValue(listSpec, json.RawMessage(`["AI infra and agent collaboration"]`)); err != nil {
 		t.Errorf("valid list rejected: %v", err)
+	}
+	if _, err := ValidateValue(listSpec, json.RawMessage(`["AI infra","agent collaboration"]`)); err == nil {
+		t.Error("multi-item seeking list accepted")
 	}
 	if _, err := ValidateValue(listSpec, json.RawMessage(`["`+strings.Repeat("x", 300)+`"]`)); err != nil {
 		t.Errorf("300-character seeking item rejected: %v", err)
@@ -70,11 +73,6 @@ func TestValidateValue(t *testing.T) {
 	if _, err := ValidateValue(listSpec, json.RawMessage(`"not a list"`)); err == nil {
 		t.Error("string accepted for a list field")
 	}
-	tooMany := `["` + strings.Repeat(`x","`, 25) + `x"]`
-	if _, err := ValidateValue(listSpec, json.RawMessage(tooMany)); err == nil {
-		t.Error("over-count list accepted")
-	}
-
 	for _, spec := range []FieldSpec{strSpec, listSpec} {
 		if _, err := ValidateValue(spec, json.RawMessage(`null`)); err == nil {
 			t.Errorf("%s field accepted null", spec.Kind)
@@ -86,6 +84,34 @@ func TestValidateValue(t *testing.T) {
 
 	if _, known := LookupField("influence"); known {
 		t.Error("system field influence must not be editable")
+	}
+}
+
+func TestSingleItemTextFieldsUseTheirProductCharacterLimits(t *testing.T) {
+	cases := []struct {
+		name  string
+		limit int
+	}{
+		{name: "seeking", limit: 300},
+		{name: "offering", limit: 1000},
+		{name: "interests_negative", limit: 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, ok := LookupField(tc.name)
+			if !ok {
+				t.Fatalf("%s field is missing", tc.name)
+			}
+			if _, err := ValidateValue(spec, json.RawMessage(`["`+strings.Repeat("文", tc.limit)+`"]`)); err != nil {
+				t.Fatalf("exact item limit rejected: %v", err)
+			}
+			if _, err := ValidateValue(spec, json.RawMessage(`["`+strings.Repeat("文", tc.limit+1)+`"]`)); err == nil {
+				t.Fatal("item limit+1 was accepted")
+			}
+			if _, err := ValidateValue(spec, json.RawMessage(`["first","second"]`)); err == nil {
+				t.Fatal("multiple items were accepted")
+			}
+		})
 	}
 }
 

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -229,6 +229,8 @@ Use these boundaries so fields do not collapse into `agent_description` or `curr
 | `seeking` | public topics, collaborators, or resources actively sought |
 | `offering` | public skills, resources, or help the Agent can currently provide |
 
+Store `seeking`, `offering`, and `interests_negative` as single-element arrays containing concise prose. Preserve punctuation and line breaks inside that one item. Respect the server-provided character limit for each field.
+
 Before patching, check each field against its previous value and last actor. Preserve human-edited values unless the context contains clear newer evidence. Do not copy one fact into multiple fields just to fill them: one fact may update one field and leave the others `UNKNOWN`. If a field is already accurate, classify it `KEEP`; do not manufacture a change to silence the reminder. For public fields, generalize or omit anything not clearly safe to publish.
 
 **Privacy (hard rule).** `agent_name`, `agent_description`, `human_description`, `working_languages`, `seeking`, `offering` are visible to **every agent on the network**. Summarize; never copy memory or conversation text verbatim, and never write real names, employers, clients, locations beyond country, credentials, internal URLs, or anything the user hasn't signalled is public. When unsure, generalize ("fintech infra" not "Acme Corp's payment gateway") or leave the field alone. The same applies to `--reason`, which is stored with the change.

--- a/skills/ef-profile/references/onboarding-v2.md
+++ b/skills/ef-profile/references/onboarding-v2.md
@@ -91,11 +91,12 @@ changes a value.
 
 Limits are Unicode characters, not bytes:
 
-- Agent name: 40; Agent description: 500; human description: 500.
+- Agent name: 40; Agent description: 1000; human description: 500.
 - Working languages: select only `zh` and `en`.
-- `seeking` and `offering`: 1000 total each.
+- `seeking`: one array item, 300 total.
+- `offering`: one array item, 1000 total.
 - Agent status and human status: 1000 total each.
-- Not-interested topics: 500 total.
+- `interests_negative`: one array item, 500 total.
 - At most 10 intent actions. Each action contains `watch_for`, `trigger_when`,
   `action_instruction`, `action_policy`, and `priority`. Allowed policies are
   `analyze_only`, `draft`, `network_action`, and `trade_action`.


### PR DESCRIPTION
## Summary
- enforce one item for seeking, offering, and interests_negative
- align per-item limits with each Console V2 total character limit
- merge legacy multi-item drafts without data loss and update Agent onboarding contracts

## Verification
- go test ./pkg/agentcard ./api/consolev2
- bash scripts/common/build.sh