### PR TITLE
fix: exclude self-loop messages from unread counts

### DIFF
--- a/rpc/pm/dal/db.go
+++ b/rpc/pm/dal/db.go
@@ -250,7 +250,7 @@ func GetLastFriendDM(db *gorm.DB, agentA, agentB int64) (*PrivateMessage, error)
 func CountUnreadTotal(db *gorm.DB, agentID int64) (int64, error) {
 	var count int64
 	err := db.Model(&PrivateMessage{}).
-		Where("receiver_id = ? AND is_read = false", agentID).
+		Where("receiver_id = ? AND is_read = false AND sender_id <> receiver_id", agentID).
 		Count(&count).Error
 	return count, err
 }
@@ -278,7 +278,7 @@ func CountUnreadByOrigin(db *gorm.DB, agentID int64) (broadcastComment, nonFrien
 		     ELSE 'non_friend'
 		   END AS bucket, COUNT(*) AS n
 		 FROM private_messages pm JOIN conversations c ON pm.conv_id = c.conv_id
-		 WHERE pm.receiver_id = ? AND pm.is_read = false
+		 WHERE pm.receiver_id = ? AND pm.is_read = false AND pm.sender_id <> pm.receiver_id
 		 GROUP BY bucket`, agentID, agentID, agentID,
 	).Scan(&rows).Error
 	for _, r := range rows {

--- a/rpc/pm/dal/unread_test.go
+++ b/rpc/pm/dal/unread_test.go
@@ -1,0 +1,45 @@
+package dal
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestUnreadCountsExcludeSelfLoopMessages(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE conversations (conv_id INTEGER PRIMARY KEY, participant_a INTEGER NOT NULL, participant_b INTEGER NOT NULL, origin_type TEXT NOT NULL)`,
+		`CREATE TABLE private_messages (msg_id INTEGER PRIMARY KEY, conv_id INTEGER NOT NULL, sender_id INTEGER NOT NULL, receiver_id INTEGER NOT NULL, is_read BOOLEAN NOT NULL)`,
+		`CREATE TABLE user_relations (from_uid INTEGER NOT NULL, to_uid INTEGER NOT NULL, rel_type INTEGER NOT NULL)`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Exec(`INSERT INTO conversations (conv_id, participant_a, participant_b, origin_type) VALUES (1, 10, 20, 'broadcast'), (2, 10, 10, 'broadcast')`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO private_messages (msg_id, conv_id, sender_id, receiver_id, is_read) VALUES (1, 1, 20, 10, false), (2, 2, 10, 10, false)`).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	total, err := CountUnreadTotal(db, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Fatalf("expected only the external unread message, got %d", total)
+	}
+	comment, nonFriend, friend, err := CountUnreadByOrigin(db, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comment != 0 || nonFriend != 1 || friend != 0 {
+		t.Fatalf("unexpected unread breakdown: comment=%d non_friend=%d friend=%d", comment, nonFriend, friend)
+	}
+}


### PR DESCRIPTION
Exclude self-addressed private messages from total and per-origin unread counts, with a SQLite regression test.