### PR TITLE
fix(console): enforce CLI gate after onboarding

### DIFF
--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -78,7 +78,6 @@ func (s *Service) loadConsoleV2Compatibility(agentIDValue int64) (map[string]int
 		state.HeartbeatContract,
 		state.SkillRevision,
 		state.ReportedAt,
-		state.OnboardingState == "completed",
 	), state.OnboardingState, nil
 }
 
@@ -110,17 +109,15 @@ func (s *Service) LegacyConsoleCompatibilityHandler() app.HandlerFunc {
 	}
 }
 
-func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string, reportedAt int64, onboardingCompleted bool) map[string]interface{} {
+func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string, reportedAt int64) map[string]interface{} {
 	status := "ready"
 	reason := ""
 	available := true
-	if !onboardingCompleted {
-		switch {
-		case strings.TrimSpace(cliVersion) == "":
-			status, reason, available = "unknown", "report_missing", false
-		case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
-			status, reason, available = "upgrade_required", "cli_outdated", false
-		}
+	switch {
+	case strings.TrimSpace(cliVersion) == "":
+		status, reason, available = "unknown", "report_missing", false
+	case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
+		status, reason, available = "upgrade_required", "cli_outdated", false
 	}
 	return map[string]interface{}{
 		"available":                           available,

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -24,7 +24,6 @@ func TestLoadConsoleV2CompatibilityQueryTypesAgentIDAsBigInt(t *testing.T) {
 func TestConsoleV2CompatibilityGate(t *testing.T) {
 	tests := []struct {
 		name, cli, contract, revision, status, reason string
-		onboardingCompleted                           bool
 		available                                     bool
 	}{
 		{name: "missing report", status: "unknown", reason: "report_missing"},
@@ -32,11 +31,10 @@ func TestConsoleV2CompatibilityGate(t *testing.T) {
 		{name: "old heartbeat is accepted", cli: "0.0.35", contract: "legacy", revision: "r1", status: "ready", available: true},
 		{name: "missing skills is accepted", cli: "0.0.35", contract: heartbeatContractV1, status: "ready", available: true},
 		{name: "minimum ready", cli: "0.0.35", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
-		{name: "completed onboarding bypasses missing report", onboardingCompleted: true, status: "ready", available: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := consoleV2Compatibility(test.cli, test.contract, test.revision, 123, test.onboardingCompleted)
+			got := consoleV2Compatibility(test.cli, test.contract, test.revision, 123)
 			if got["available"] != test.available || got["status"] != test.status || got["reason"] != test.reason {
 				t.Fatalf("compatibility = %#v", got)
 			}
@@ -80,7 +78,7 @@ func TestRecoveryRefreshRequiresCLI0035(t *testing.T) {
 	}
 }
 
-func TestLegacyConsoleCompatibilityHandlerBypassesCompletedOnboarding(t *testing.T) {
+func TestLegacyConsoleCompatibilityHandlerGatesCompletedOnboarding(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +92,7 @@ func TestLegacyConsoleCompatibilityHandlerBypassesCompletedOnboarding(t *testing
 		`CREATE TABLE agent_onboarding_v2 (agent_id INTEGER PRIMARY KEY, state TEXT)`,
 		`INSERT INTO agent_settings
 			(agent_id, cli_version, heartbeat_contract_version, skill_revision, heartbeat_reported_at)
-			VALUES (42, '', '', '', 0)`,
+			VALUES (42, '0.0.34', '', '', 0)`,
 		`INSERT INTO agent_onboarding_v2 (agent_id, state) VALUES (42, 'completed')`,
 	} {
 		if err := db.Exec(statement).Error; err != nil {
@@ -122,7 +120,8 @@ func TestLegacyConsoleCompatibilityHandlerBypassesCompletedOnboarding(t *testing
 	if err := json.Unmarshal(request.Response.Body(), &envelope); err != nil {
 		t.Fatal(err)
 	}
-	if envelope.Code != 0 || envelope.Data.Onboarding.State != "completed" || envelope.Data.Compatibility["available"] != true {
+	if envelope.Code != 0 || envelope.Data.Onboarding.State != "completed" ||
+		envelope.Data.Compatibility["available"] != false || envelope.Data.Compatibility["reason"] != "cli_outdated" {
 		t.Fatalf("unexpected compatibility envelope: %#v", envelope)
 	}
 }

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -187,7 +187,7 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		"device_name":             identity.DeviceName,
 		"identity_state":          identityState,
 		"connection":              map[string]interface{}{"state": identityState},
-		"compatibility":           consoleV2Compatibility(identity.CLIVersion, identity.HeartbeatContract, identity.SkillRevision, identity.HeartbeatReportedAt, state.State == "completed"),
+		"compatibility":           consoleV2Compatibility(identity.CLIVersion, identity.HeartbeatContract, identity.SkillRevision, identity.HeartbeatReportedAt),
 		"onboarding":              state,
 	})
 }

--- a/docs/console-v2-agent-upgrade.md
+++ b/docs/console-v2-agent-upgrade.md
@@ -4,7 +4,7 @@ Upgrade the current Agent in place. Preserve its existing identity, credentials,
 
 ## Required outcome
 
-- EigenFlux CLI is `0.0.34` or newer.
+- EigenFlux CLI is `0.0.35` or newer, regardless of onboarding state.
 - All official `ef-*` Skills come from one current, verified manifest.
 - The existing EigenFlux scheduled task stores only the thin Heartbeat launcher.
 - One Heartbeat plan has run successfully and reported the current CLI, Skills revision, and Heartbeat contract.


### PR DESCRIPTION
## Summary
- enforce minimum CLI 0.0.35 regardless of onboarding completion
- treat missing CLI reports as unavailable
- add regression coverage for completed onboarding with outdated CLI

## Verification
- GOCACHE=/private/tmp/eigenflux-cli-gate-go-cache go test ./api/consolev2 -count=1
- GOCACHE=/private/tmp/eigenflux-cli-gate-go-cache bash scripts/common/build.sh