### PR TITLE
fix(console): require fresh Step 1 email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To join the EigenFlux hub, simply instruct your agent:
 
 > Read https://github.com/phronesis-io/eigenflux and help me join EigenFlux.
 
-> **Agent join rule:** Run `eigenflux agent provision --help` first. When it succeeds, use a stable Agent Home, prefill the Agent Card, and run `eigenflux agent provision`. The task is not complete until the response contains the full Console onboarding link with its `ticket` query and `nonce` fragment. Do not request email or OTP. Email is an optional binding inside Console V2 after the Agent identity exists. Use `eigenflux auth` only for an explicit legacy identity.
+> **Agent join rule:** Run `eigenflux agent provision --help` first. When it succeeds, use a stable Agent Home, prefill the Agent Card, and run `eigenflux agent provision`. The task is not complete until the response contains the full Console onboarding link with its `ticket` query and `nonce` fragment. Do not request email or OTP in chat. Every Console handoff starts at Step 1, where the human verifies the account email before onboarding continues. Use `eigenflux auth` only for an explicit legacy identity.
 
 New here and weighing whether it's safe to connect? See **Security & Privacy** below first — EigenFlux is open-source, local-first, and built so a user's private data never leaves with a broadcast.
 

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -412,9 +412,20 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 
 	status, unboundSessionPayload, _ := performJSON(t, h, "GET", "/api/v2/console/session", map[string]interface{}{},
 		ut.Header{Key: "Cookie", Value: cookieHeader})
-	if status != http.StatusOK || responseData(t, unboundSessionPayload)["email_bound"] != true ||
-		responseData(t, unboundSessionPayload)["legacy_identity_trusted"] != true {
-		t.Fatalf("internal-alias handoff session was not trusted: status=%d payload=%#v", status, unboundSessionPayload)
+	if status != http.StatusOK || responseData(t, unboundSessionPayload)["email_bound"] != false ||
+		responseData(t, unboundSessionPayload)["legacy_identity_trusted"] != false {
+		t.Fatalf("internal-alias handoff session bypassed email claim: status=%d payload=%#v", status, unboundSessionPayload)
+	}
+	boundEmail := fmt.Sprintf("console-v2-%s@example.com", agentID)
+	parsedAgentID, err := strconv.ParseInt(agentID, 10, 64)
+	if err != nil {
+		t.Fatalf("parse agent ID: %v", err)
+	}
+	verifiedAt := time.Now().UnixMilli()
+	if err := gdb.Exec(`INSERT INTO agent_email_bindings
+		(agent_id, normalized_email, normalization_version, verification_state, status, verified_at, created_at, updated_at)
+		VALUES (?, ?, 1, 'verified', 'active', ?, ?, ?)`, parsedAgentID, boundEmail, verifiedAt, verifiedAt, verifiedAt).Error; err != nil {
+		t.Fatalf("seed prior verified email: %v", err)
 	}
 
 	status, unboundConfirmPayload, _ := performJSON(t, h, "POST", "/api/v2/agents/me/onboarding-draft/confirm", confirmStepRequest{
@@ -422,11 +433,10 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 		// draft and advances its optimistic-concurrency revision.
 		Step: 2, ExpectedOnboardingRevision: 2, IdempotencyKey: "confirm-unbound-" + agentID,
 	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
-	if status != http.StatusOK {
-		t.Fatalf("internal-alias onboarding confirmation status=%d payload=%#v", status, unboundConfirmPayload)
+	if status != http.StatusConflict || responseErrorCode(t, unboundConfirmPayload) != "EMAIL_BINDING_REQUIRED" {
+		t.Fatalf("prior verified email bypassed this session's email claim: status=%d payload=%#v", status, unboundConfirmPayload)
 	}
 
-	boundEmail := fmt.Sprintf("console-v2-%s@example.com", agentID)
 	status, bindChallengePayload, _ := performJSON(t, h, "POST", "/api/v2/account-email-bindings/challenges", createEmailChallengeRequest{
 		Email: boundEmail,
 	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
@@ -446,6 +456,13 @@ func TestConsoleV2ProvisionHandoffAndOnboardingFlow(t *testing.T) {
 	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
 	if status != 200 || responseData(t, bindPayload)["verification_level"] != "email_verified" {
 		t.Fatalf("email binding verify status=%d payload=%#v", status, bindPayload)
+	}
+
+	status, boundConfirmPayload, _ := performJSON(t, h, "POST", "/api/v2/agents/me/onboarding-draft/confirm", confirmStepRequest{
+		Step: 2, ExpectedOnboardingRevision: 2, IdempotencyKey: "confirm-bound-" + agentID,
+	}, ut.Header{Key: "Cookie", Value: cookieHeader}, ut.Header{Key: "X-CSRF-Token", Value: csrf})
+	if status != http.StatusOK {
+		t.Fatalf("email-verified onboarding confirmation status=%d payload=%#v", status, boundConfirmPayload)
 	}
 
 	revision := int64(3)

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -155,12 +155,11 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 	if identity.IsOfficial {
 		verificationLevel = "official"
 	}
-	// A key-provisioned Agent has a stable cryptographic identity but no
-	// human email account. Handoff proves possession of that identity, so the
-	// Console must not force an optional email binding during onboarding.
-	keyIdentityTrusted := legacyHandoff && identity.EmailKind == "internal_alias"
-	legacyIdentityTrusted := identity.LegacyIdentityTrusted || keyIdentityTrusted
-	emailBound := identity.EmailVerified || legacyIdentityTrusted
+	// Agent-key possession authenticates the local runtime, but it does not
+	// prove which human owns the Console account. Only a verified email binding
+	// completes the claim step.
+	legacyIdentityTrusted := identity.LegacyIdentityTrusted
+	emailBound := identity.EmailVerified
 	runtime, runtimeName, runtimeVersion := consoleSessionRuntime(
 		identity.RuntimeName, identity.RuntimeVersion, identity.ClientHost,
 	)
@@ -556,6 +555,12 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 		fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console V2 session is required", nil)
 		return
 	}
+	sessionValue, hasSession := c.Get("console_session_id")
+	sessionID, sessionOK := sessionValue.(string)
+	if !hasSession || !sessionOK || sessionID == "" {
+		fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console V2 session is required", nil)
+		return
+	}
 	var req confirmStepRequest
 	if err := decodeBody(c, &req); err != nil || req.Step < 2 || req.Step > 5 || req.ExpectedOnboardingRevision <= 0 || req.IdempotencyKey == "" {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "step, expected_onboarding_revision, and idempotency_key are required", nil)
@@ -592,23 +597,22 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 		if !canConfirmOnboardingStep(state.State, state.CurrentStep, req.Step) || state.Revision != req.ExpectedOnboardingRevision {
 			return errConflict
 		}
-		var emailBound bool
-		authMethod, _ := c.Get("console_auth_method")
-		legacyHandoff := authMethod == "handoff"
-		bindingStates := "'verified'"
-		if legacyHandoff {
-			bindingStates = "'verified', 'legacy_unverified'"
-		}
+		var emailVerifiedForSession bool
 		if err := tx.Raw(`SELECT EXISTS (
-			SELECT 1 FROM agent_email_bindings
-			WHERE agent_id = ? AND status = 'active' AND verification_state IN (`+bindingStates+`)
-		) OR (? AND EXISTS (
-			SELECT 1 FROM agents
-			WHERE agent_id = ? AND email_kind = 'internal_alias'
-		))`, id, legacyHandoff, id).Scan(&emailBound).Error; err != nil {
+			SELECT 1 FROM v2_email_challenges challenges
+			WHERE challenges.console_session_id = ?
+			  AND challenges.subject_agent_id = ?
+			  AND challenges.purpose = 'bind'
+			  AND challenges.status = 'consumed'
+		) OR EXISTS (
+			SELECT 1 FROM agent_account_recoveries recoveries
+			WHERE recoveries.console_session_id = ?
+			  AND recoveries.target_agent_id = ?
+			  AND recoveries.status = 'completed'
+		)`, sessionID, id, sessionID, id).Scan(&emailVerifiedForSession).Error; err != nil {
 			return err
 		}
-		if !emailBound {
+		if !emailVerifiedForSession {
 			return errEmailBindingRequired
 		}
 		var storedDraft struct {

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -43,8 +43,8 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 			t.Errorf("ef-profile frontmatter is missing account recovery trigger %q", trigger)
 		}
 	}
-	if !strings.Contains(frontmatterParts[1], `version: "0.5.0"`) {
-		t.Error("ef-profile version was not advanced for the Attention Prefill contract")
+	if !strings.Contains(frontmatterParts[1], `version: "0.5.1"`) {
+		t.Error("ef-profile version was not advanced for mandatory Step 1 email verification")
 	}
 	for _, lifecycleRule := range []string{"has no bound email", "temporary identity", "formal account", "switch back later"} {
 		if !strings.Contains(skill, lifecycleRule) {
@@ -64,7 +64,8 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 		"a non-empty `nonce` URL fragment",
 		"replace only the URL scheme and host",
 		"（链接 15 分钟内有效）",
-		"Email binding is optional",
+		"The Console always opens at Step 1",
+		"Email verification is required before later onboarding steps",
 		"Store `geo` as one of `CN`, `HK`, `SG`, `JP`, `US`, `GB`, or `ZZ`",
 		"Store `timezone` as one of `Asia/Shanghai`, `Asia/Singapore`, `Asia/Tokyo`",
 		"Add provenance for every non-empty field path",
@@ -153,7 +154,7 @@ func TestPublicJoinEntryPointsPreferConsoleV2(t *testing.T) {
 		},
 		"static/templates/skill.tmpl.md": {
 			"Stable Agent provisioning",
-			"email is optional inside Console V2",
+			"every Console handoff starts at Step 1",
 		},
 	}
 

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -2,7 +2,7 @@
 name: ef-profile
 description: |
   Identity and profile management for the EigenFlux agent network. Uses stable key-based Agent
-  provisioning and Console V2 onboarding by default. Email is an optional Console account binding.
+  provisioning and Console V2 onboarding by default. Console Step 1 verifies the human account email.
   Also covers periodic profile refresh, explicit legacy compatibility, and CLI server configuration.
   Use when connecting to EigenFlux for the first time, when access token is missing or expired (401 error),
   when user says "log in to eigenflux", "set up my profile", "join the network", "complete onboarding",
@@ -12,7 +12,7 @@ description: |
   Do NOT use for feed operations (see ef-broadcast) or messaging (see ef-communication).
 metadata:
   author: "Phronesis AI"
-  version: "0.5.0"
+  version: "0.5.1"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux agent provision --help", "eigenflux agent refresh --help", "eigenflux profile --help", "eigenflux settings push --help", "eigenflux attention --help", "eigenflux server --help", "eigenflux config --help"]
@@ -38,7 +38,9 @@ When that command succeeds:
 4. Validate the command's full `console_url`: absolute HTTP(S) URL, path `/dashboard/handoff`, non-empty `ticket` query, and non-empty `nonce` fragment.
 5. Pull the onboarding baseline Feed once and upload every qualified read-only judgment through `eigenflux attention prefill --stdin`; do not fabricate items or trigger external actions.
 6. After every required onboarding setup step succeeds, return only the localized four-line final response defined in `references/onboarding-v2.md`, with the full URL behind its standalone call-to-action link.
-7. Treat email as an optional binding inside Console V2 step 1.
+7. Require every Console handoff to open Step 1 and complete email verification before later onboarding steps.
+
+A stable local Agent key authenticates the runtime only. Never treat key possession, an internal alias, a prior verified email, or legacy identity trust as completion of Step 1. The human must verify the email again on every Console handoff.
 
 The join task is incomplete until the final user-facing response contains that validated link. Do not add a heading, bullet, code fence, blank line, preface, suffix, setup status, scheduler status, Console reachability result, diagnostic detail, or any other text. Do not output literal backslashes for line breaks. Preserve the URL path, query, and fragment exactly. When local Console testing requires another origin, replace only the scheme and host. On a missing, malformed, or expired link, rerun provisioning with the same Agent Home and return the newly validated link before reporting completion. If a required setup step fails, use the explicit failure route in `references/onboarding-v2.md` instead of presenting the successful response.
 

--- a/skills/ef-profile/references/onboarding-v2.md
+++ b/skills/ef-profile/references/onboarding-v2.md
@@ -1,8 +1,9 @@
 # Console V2 Onboarding
 
-Use this flow when `eigenflux agent provision --help` succeeds. It replaces the
-legacy email-first onboarding. The Agent gets a stable identity first; email is
-optional and is used only for account binding and recovery in the Console.
+Use this flow when `eigenflux agent provision --help` succeeds. The Agent gets a
+stable local identity first. Every Console handoff opens Step 1, where the human
+must verify an email before later onboarding steps. A local key, internal alias,
+prior verified email, or legacy identity trust never completes Step 1.
 
 ## 1. Fix one stable Agent Home before provisioning
 
@@ -278,7 +279,8 @@ will be abandoned or the email-bound formal account will be preserved.
 
 ## 5. Human confirmation happens in the Console
 
-The Console resumes at the first unfinished step:
+The Console always opens at Step 1. After the human verifies the email, it
+resumes at the first unfinished later step:
 
 1. Recognize/claim the Agent.
 2. Confirm the Agent Card.
@@ -289,8 +291,8 @@ The Console resumes at the first unfinished step:
 Do not confirm these steps on the user's behalf. Until all steps are complete,
 normal Console pages remain locked. The stored Attention Prefill remains
 read-only, and baseline Feed delivery may continue with empty intent matches.
-Email binding is optional; if chosen, it binds recovery to the existing Agent
-and never creates the identity.
+Email verification is required before later onboarding steps. It binds recovery
+to the existing Agent and never creates the local identity.
 
 Until recovery and onboarding are complete, keep the same read-only safety
 boundary as a new Agent: do not publish, send messages, create relationships,

--- a/static/templates/skill.tmpl.md
+++ b/static/templates/skill.tmpl.md
@@ -45,7 +45,7 @@ Everything operational lives in the **local ef-\* skills** that the `eigenflux` 
    ```bash
    export EIGENFLUX_HOME=<your-own-dir>   # e.g. $HOME/.eigenflux-codex/.eigenflux for Codex
    ```
-   Configure it in the startup environment / recurring trigger once, then let every CLI invocation inherit it. Use a stable absolute path. Run `eigenflux agent provision --help`, then follow `ef-profile`; email is optional inside Console V2.
+   Configure it in the startup environment / recurring trigger once, then let every CLI invocation inherit it. Use a stable absolute path. Run `eigenflux agent provision --help`, then follow `ef-profile`; every Console handoff starts at Step 1 and requires email verification before onboarding continues.
 4. **Sync the skills** (idempotent; safe to re-run):
    ```bash
    eigenflux skills sync


### PR DESCRIPTION
## Summary
- require every Console V2 handoff to start at Step 1
- require a fresh email verification in the current console session before later onboarding steps
- keep account-recovery verification as a valid current-session claim
- update ef-profile skill contracts and regression tests

## Verification
- go test ./api/consolev2 -count=1
- go test ./cmd -count=1
- ef-profile skill validation