### PR TITLE
fix(console): restore completed onboarding bypass

### DIFF
--- a/api/consolev2/heartbeat_compatibility_handlers.go
+++ b/api/consolev2/heartbeat_compatibility_handlers.go
@@ -78,6 +78,7 @@ func (s *Service) loadConsoleV2Compatibility(agentIDValue int64) (map[string]int
 		state.HeartbeatContract,
 		state.SkillRevision,
 		state.ReportedAt,
+		state.OnboardingState == "completed",
 	), state.OnboardingState, nil
 }
 
@@ -109,15 +110,17 @@ func (s *Service) LegacyConsoleCompatibilityHandler() app.HandlerFunc {
 	}
 }
 
-func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string, reportedAt int64) map[string]interface{} {
+func consoleV2Compatibility(cliVersion, heartbeatContract, skillRevision string, reportedAt int64, onboardingCompleted bool) map[string]interface{} {
 	status := "ready"
 	reason := ""
 	available := true
-	switch {
-	case strings.TrimSpace(cliVersion) == "":
-		status, reason, available = "unknown", "report_missing", false
-	case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
-		status, reason, available = "upgrade_required", "cli_outdated", false
+	if !onboardingCompleted {
+		switch {
+		case strings.TrimSpace(cliVersion) == "":
+			status, reason, available = "unknown", "report_missing", false
+		case compareConsoleCLIVersion(cliVersion, minimumConsoleV2CLI) < 0:
+			status, reason, available = "upgrade_required", "cli_outdated", false
+		}
 	}
 	return map[string]interface{}{
 		"available":                           available,

--- a/api/consolev2/heartbeat_compatibility_test.go
+++ b/api/consolev2/heartbeat_compatibility_test.go
@@ -24,6 +24,7 @@ func TestLoadConsoleV2CompatibilityQueryTypesAgentIDAsBigInt(t *testing.T) {
 func TestConsoleV2CompatibilityGate(t *testing.T) {
 	tests := []struct {
 		name, cli, contract, revision, status, reason string
+		onboardingCompleted                           bool
 		available                                     bool
 	}{
 		{name: "missing report", status: "unknown", reason: "report_missing"},
@@ -31,10 +32,11 @@ func TestConsoleV2CompatibilityGate(t *testing.T) {
 		{name: "old heartbeat is accepted", cli: "0.0.35", contract: "legacy", revision: "r1", status: "ready", available: true},
 		{name: "missing skills is accepted", cli: "0.0.35", contract: heartbeatContractV1, status: "ready", available: true},
 		{name: "minimum ready", cli: "0.0.35", contract: heartbeatContractV1, revision: "r1", status: "ready", available: true},
+		{name: "completed onboarding bypasses missing report", onboardingCompleted: true, status: "ready", available: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := consoleV2Compatibility(test.cli, test.contract, test.revision, 123)
+			got := consoleV2Compatibility(test.cli, test.contract, test.revision, 123, test.onboardingCompleted)
 			if got["available"] != test.available || got["status"] != test.status || got["reason"] != test.reason {
 				t.Fatalf("compatibility = %#v", got)
 			}
@@ -78,7 +80,7 @@ func TestRecoveryRefreshRequiresCLI0035(t *testing.T) {
 	}
 }
 
-func TestLegacyConsoleCompatibilityHandlerGatesCompletedOnboarding(t *testing.T) {
+func TestLegacyConsoleCompatibilityHandlerBypassesCompletedOnboarding(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		t.Fatal(err)
@@ -120,8 +122,7 @@ func TestLegacyConsoleCompatibilityHandlerGatesCompletedOnboarding(t *testing.T)
 	if err := json.Unmarshal(request.Response.Body(), &envelope); err != nil {
 		t.Fatal(err)
 	}
-	if envelope.Code != 0 || envelope.Data.Onboarding.State != "completed" ||
-		envelope.Data.Compatibility["available"] != false || envelope.Data.Compatibility["reason"] != "cli_outdated" {
+	if envelope.Code != 0 || envelope.Data.Onboarding.State != "completed" || envelope.Data.Compatibility["available"] != true {
 		t.Fatalf("unexpected compatibility envelope: %#v", envelope)
 	}
 }

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -187,7 +187,7 @@ func (s *Service) getConsoleSession(_ context.Context, c *app.RequestContext) {
 		"device_name":             identity.DeviceName,
 		"identity_state":          identityState,
 		"connection":              map[string]interface{}{"state": identityState},
-		"compatibility":           consoleV2Compatibility(identity.CLIVersion, identity.HeartbeatContract, identity.SkillRevision, identity.HeartbeatReportedAt),
+		"compatibility":           consoleV2Compatibility(identity.CLIVersion, identity.HeartbeatContract, identity.SkillRevision, identity.HeartbeatReportedAt, state.State == "completed"),
 		"onboarding":              state,
 	})
 }

--- a/docs/console-v2-agent-upgrade.md
+++ b/docs/console-v2-agent-upgrade.md
@@ -4,7 +4,7 @@ Upgrade the current Agent in place. Preserve its existing identity, credentials,
 
 ## Required outcome
 
-- EigenFlux CLI is `0.0.35` or newer, regardless of onboarding state.
+- EigenFlux CLI is `0.0.35` or newer while onboarding is incomplete. Agents that already completed onboarding remain available.
 - All official `ef-*` Skills come from one current, verified manifest.
 - The existing EigenFlux scheduled task stores only the thin Heartbeat launcher.
 - One Heartbeat plan has run successfully and reported the current CLI, Skills revision, and Heartbeat contract.


### PR DESCRIPTION
## Summary
- restore compatibility bypass for agents that already completed onboarding
- keep the 0.0.35 CLI minimum for incomplete onboarding
- restore regression coverage for completed onboarding with missing or outdated CLI reports

## Verification
- GOCACHE=/private/tmp/eigenflux-onboarding-bypass-go-cache go test ./api/consolev2 -count=1
- GOCACHE=/private/tmp/eigenflux-onboarding-bypass-go-cache bash scripts/common/build.sh