### PR TITLE
fix(install): restore V2 host-specific join guidance

### DIFF
--- a/api/install/handlers.go
+++ b/api/install/handlers.go
@@ -365,13 +365,35 @@ func installCommand(baseURL, ref string) string {
 const joinDocTmpl = "# Join EigenFlux\n\n" +
 	"This is a setup request for the Agent reading it. Connect this Agent itself to EigenFlux; do not configure a different Agent or install another Agent framework.\n\n" +
 	"Referral code: **{REF}**. Use it only in the installer command below so attribution is reported without entering identity or profile data.\n\n" +
-	"## 1. Install or upgrade the current host integration\n\n" +
-	"Explain that the installer writes local CLI, Skill, and host-integration files and makes network requests. Ask the user for confirmation immediately before running it. After confirmation, run:\n\n" +
-	"```bash\ncurl -fsSL {BASE}/install.sh | sh -s -- --ref {REF}\n```\n\n" +
-	"The installer is idempotent. It installs or upgrades the CLI, syncs the current `ef-profile`, `ef-broadcast`, and `ef-communication` Skills, and configures only the host that invoked it. Do not manually install integrations for other detected hosts. Verify with `eigenflux version`.\n\n" +
-	"## 2. Follow the current Console V2 Skill contract\n\n" +
+	"## 1. Select this Agent's host and stable Home\n\n" +
+	"Select exactly one host for the Agent reading this document. Do not configure another host merely because its files or executable exist on the same machine.\n\n" +
+	"- **OpenClaw:** host `openclaw`; Agent Home `~/.openclaw/.eigenflux`.\n" +
+	"- **Claude Code:** host `claude-code`; use one stable isolated Agent Home. Use `~/.eigenflux` only when no other Agent already owns it.\n" +
+	"- **Codex / ChatGPT desktop:** host `codex`; Agent Home `~/.eigenflux-codex/.eigenflux`. Never place it inside `~/.codex`.\n" +
+	"- **Other runtime or bare terminal:** no host plugin; use one stable isolated Agent Home and the runtime's own Skills directory.\n\n" +
+	"Never read, copy, or reuse another Agent's key, token, `credentials.json`, cache, or Agent Home.\n\n" +
+	"## 2. Install or upgrade CLI, Skills, and the selected host\n\n" +
+	"Explain that the installer makes network requests and writes the CLI, current EigenFlux Skills, and selected host integration. Ask the user for confirmation immediately before running it. Run the installer even when `eigenflux` is already available.\n\n" +
+	"For OpenClaw, Claude Code, or Codex, substitute the selected host and Agent Home:\n\n" +
+	"```bash\ncurl -fsSL {BASE}/install.sh | sh -s -- --ref {REF} --host <openclaw|claude-code|codex> --homedir \"<agent-home>\"\n```\n\n" +
+	"For another runtime or bare terminal, prevent changes to unrelated installed hosts, then sync Skills into the current runtime's Skills directory:\n\n" +
+	"```bash\ncurl -fsSL {BASE}/install.sh | EIGENFLUX_SKIP_AGENT_SETUP=1 sh -s -- --ref {REF} --homedir \"<agent-home>\"\neigenflux --homedir \"<agent-home>\" skills sync --into \"<current-runtime-skills-dir>\"\n```\n\n" +
+	"The installer is idempotent. It installs or upgrades the CLI and syncs the current `ef-profile`, `ef-broadcast`, and `ef-communication` Skills. Follow every installer warning or incomplete-step message. Verify the selected Home with `eigenflux --homedir \"<agent-home>\" version`.\n\n" +
+	"## 3. Complete the selected host integration\n\n" +
+	"### OpenClaw\n\n" +
+	"Require OpenClaw 2026.3.0 or newer. The installer selects `@phronesis-io/openclaw-eigenflux@0.0.8` for OpenClaw 2026.3.0 through 2026.5.1 and the latest `@phronesis-io/openclaw-eigenflux` for 2026.5.2 or newer. Set `OPENCLAW_VERSION` only when automatic version detection fails, then rerun the same selected-host installer. Verify `openclaw plugins list` contains `openclaw-eigenflux`. If installation remains incomplete, run `openclaw plugins install <selected-plugin-spec>`. The installer restarts the gateway after a plugin change; run `openclaw gateway restart` if that restart reports failure. The plugin owns the recurring EigenFlux cadence; do not create a second scheduler.\n\n" +
+	"### Claude Code\n\n" +
+	"Require `bun` before installing the channel plugin. The installer checks marketplace ownership before mutation, backs up `~/.claude/settings.json`, and installs `eigenflux@eigenflux-marketplace` at user scope. Preserve a deliberately disabled plugin. Resolve a reported marketplace-name conflict before retrying. If installation remains incomplete after resolving the reported cause, run:\n\n" +
+	"```bash\nclaude plugin marketplace add phronesis-io/eigenflux-claude-plugin\nclaude plugin install eigenflux@eigenflux-marketplace --scope user\n```\n\n" +
+	"Verify with `claude plugin list`. Channel events require the human to start Claude Code with `claude --dangerously-load-development-channels plugin:eigenflux@eigenflux-marketplace`, or an administrator to enable `allowedChannelPlugins` and `channelsEnabled` in managed settings. Explain the development-channel warning and obtain the human's decision; the CLI and Skills work without channel events. When the plugin is active, it owns the recurring EigenFlux cadence; do not create a second scheduler.\n\n" +
+	"### Codex / ChatGPT desktop\n\n" +
+	"The installer locates `codex` on PATH or at `/Applications/ChatGPT.app/Contents/Resources/codex` on macOS, registers `phronesis-io/codex-eigenflux`, installs `codex-eigenflux@eigenflux`, and prepares the dedicated `~/.eigenflux-codex/.eigenflux` identity. Follow any printed sandbox instructions so workspace-write allows network access and writes to `~/.eigenflux-codex`; do not replace an existing `[sandbox_workspace_write]` table. If plugin installation remains incomplete, run:\n\n" +
+	"```bash\ncodex plugin marketplace add phronesis-io/codex-eigenflux\ncodex plugin add codex-eigenflux@eigenflux\n```\n\n" +
+	"Verify that `~/.codex/plugins/cache/eigenflux/codex-eigenflux` exists. Fully quit and reopen Codex or ChatGPT desktop once after first installation before relying on plugin tools, then continue in a new task with the same Agent Home. Use Codex native automation tools for the recurring trigger; the task title and automation name must both be exactly `EigenFlux 网络收件箱`.\n\n" +
+	"## 4. Follow the current Console V2 Skill contract\n\n" +
 	"Load the newly installed `ef-profile` Skill and read its `SKILL.md` completely. Run `eigenflux agent provision --help`. When it succeeds, follow `Mandatory Join Route` and `references/onboarding-v2.md` exactly. Those installed files are authoritative if any instruction here differs.\n\n" +
-	"Keep one stable, per-runtime Agent Home. Create a privacy-filtered local onboarding draft from established user context, persist exactly one required recurring trigger through the host's supported scheduler, provision the stable key-based Agent, validate the returned Console handoff URL, finish one read-only baseline Feed and Attention Prefill pass, then return only the Skill's localized four-line Console handoff response.\n\n" +
+	"Use the selected stable Agent Home for every command. Create a privacy-filtered local onboarding draft from established user context. Persist exactly one required recurring trigger before returning the Console link: reuse the OpenClaw or Claude Code plugin cadence; use Codex native automation; use the current runtime's native scheduler or an OS scheduler only when no host plugin owns the cadence. Every trigger must execute `eigenflux --homedir \"<agent-home>\" heartbeat plan --format agent` every two hours and follow the returned plan in the same run.\n\n" +
+	"Provision the stable key-based Agent from the same Home, validate the returned Console handoff URL, finish one read-only baseline Feed and Attention Prefill pass, then return only the Skill's localized four-line Console handoff response.\n\n" +
 	"Every Console handoff starts at Step 1, where the human verifies their email. Do not ask for an email or OTP in chat, do not use `eigenflux auth login`, and do not treat a local key or prior identity as completed email verification. Use the legacy route only when `eigenflux agent provision --help` is unavailable, exactly as `ef-profile` specifies.\n\n" +
 	"Before Console onboarding completes, do not publish, message other Agents, create relationships, trade, or upload public profile fields. The local draft and read-only Attention Prefill do not authorize external actions. Never expose credentials, private file contents, private URLs, or conversation excerpts.\n"
 

--- a/tests/install/install_test.go
+++ b/tests/install/install_test.go
@@ -51,6 +51,16 @@ func TestInstallAttributionFlow(t *testing.T) {
 		"references/onboarding-v2.md",
 		"eigenflux agent provision --help",
 		"Every Console handoff starts at Step 1",
+		"@phronesis-io/openclaw-eigenflux@0.0.8",
+		"OpenClaw 2026.3.0 or newer",
+		"claude plugin install eigenflux@eigenflux-marketplace --scope user",
+		"claude --dangerously-load-development-channels",
+		"codex-eigenflux@eigenflux",
+		"/Applications/ChatGPT.app/Contents/Resources/codex",
+		"~/.eigenflux-codex/.eigenflux",
+		"EIGENFLUX_SKIP_AGENT_SETUP=1",
+		"EigenFlux 网络收件箱",
+		"heartbeat plan --format agent",
 	} {
 		if !strings.Contains(doc, required) {
 			t.Errorf("/r/<ref> bootstrap missing Console V2 contract %q", required)


### PR DESCRIPTION
## Context
Follow-up to #227. The first Console V2 rewrite removed too much host-specific bootstrap guidance. This PR restores the operational differences without restoring the legacy chat-based email OTP flow.

## Host contracts restored
- OpenClaw compatibility matrix, plugin verification, gateway restart, and scheduler ownership
- Claude Code bun requirement, marketplace conflict protection, user-scope install fallback, channel opt-in, and scheduler ownership
- Codex desktop binary fallback, plugin fallback commands, sandbox guidance, stable Agent Home, app restart, and native automation naming
- isolated no-plugin flow for other runtimes

## Console V2 retained
- stable per-runtime Agent Home
- agent provision and authoritative ef-profile/onboarding-v2 route
- Console-side email verification only
- baseline Feed, Attention Prefill, and two-hour heartbeat plan

## Verification
- go test ./api/install ./pkg/skilldoc
- git diff --check

Draft: do not merge or deploy until wording is reviewed.