### PR TITLE
feat(console): support five browser accounts

### DIFF
--- a/api/consolev2/account_session_handlers.go
+++ b/api/consolev2/account_session_handlers.go
@@ -1,0 +1,348 @@
+package consolev2
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"gorm.io/gorm"
+)
+
+type consoleAccountView struct {
+	AgentID      string `json:"agent_id"`
+	AgentName    string `json:"agent_name"`
+	AgentNameEn  string `json:"agent_name_en"`
+	ShortID      string `json:"short_id"`
+	EigenFluxID  string `json:"eigenflux_id"`
+	Email        string `json:"email"`
+	Slot         int    `json:"slot"`
+	LastActiveAt int64  `json:"last_active_at"`
+	ExpiresAt    int64  `json:"expires_at"`
+	Expired      bool   `json:"expired"`
+}
+
+type consoleCookieCredential struct {
+	Slot      int
+	SessionID string
+	Secret    string
+}
+
+func consoleSlotCookieName(base string, slot int) string {
+	if slot <= 0 {
+		return base
+	}
+	return base + "_" + strconv.Itoa(slot)
+}
+
+func consoleSessionCookieName(slot int) string { return consoleSlotCookieName(consoleCookieName, slot) }
+func consoleCSRFCookieName(slot int) string    { return consoleSlotCookieName(csrfCookieName, slot) }
+
+func activeConsoleSlot(c *app.RequestContext) int {
+	slot, err := strconv.Atoi(strings.TrimSpace(string(c.Cookie(activeConsoleSlotCookieName))))
+	if err != nil || slot < 0 || slot >= maxConsoleAccountSlots {
+		return 0
+	}
+	return slot
+}
+
+func consoleCredential(c *app.RequestContext, slot int) (consoleCookieCredential, bool) {
+	parts := strings.SplitN(string(c.Cookie(consoleSessionCookieName(slot))), ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return consoleCookieCredential{}, false
+	}
+	return consoleCookieCredential{Slot: slot, SessionID: parts[0], Secret: parts[1]}, true
+}
+
+func (s *Service) setConsoleCookieAtSlot(c *app.RequestContext, slot int, value string, maxAge int) {
+	c.SetCookie(consoleSessionCookieName(slot), value, maxAge, "/", "", protocol.CookieSameSiteLaxMode, s.secureCookie, true)
+	c.Header("Referrer-Policy", "no-referrer")
+}
+
+func (s *Service) setCSRFCookieAtSlot(c *app.RequestContext, slot int, value string, maxAge int) {
+	c.SetCookie(consoleCSRFCookieName(slot), value, maxAge, "/", "", protocol.CookieSameSiteStrictMode, s.secureCookie, false)
+}
+
+func (s *Service) setActiveConsoleSlot(c *app.RequestContext, slot int, maxAge int) {
+	value := ""
+	if maxAge >= 0 {
+		value = strconv.Itoa(slot)
+	}
+	c.SetCookie(activeConsoleSlotCookieName, value, maxAge, "/", "", protocol.CookieSameSiteStrictMode, s.secureCookie, false)
+}
+
+func (s *Service) loadConsoleSessionCredential(db *gorm.DB, credential consoleCookieCredential) (consoleSession, error) {
+	var session consoleSession
+	err := db.Raw(`SELECT s.session_id, s.agent_id, s.principal_id,
+			p.agent_id AS principal_agent_id, p.status AS principal_status,
+			p.revoked_at AS principal_revoked_at, a.identity_state,
+			s.session_secret_hash, s.csrf_secret_hash, s.scopes,
+			s.idle_expires_at, s.absolute_expires_at, s.last_seen_at,
+			s.auth_method, s.recent_auth_at
+		FROM console_v2_sessions s
+		JOIN agent_principals p ON p.principal_id = s.principal_id
+		JOIN agents a ON a.agent_id = s.agent_id
+		WHERE s.session_id = ? AND s.status = 'active'`, credential.SessionID).Scan(&session).Error
+	if err != nil || session.SessionID == "" ||
+		subtle.ConstantTimeCompare([]byte(session.SecretHash), []byte(hashString(credential.Secret))) != 1 {
+		return consoleSession{}, errUnauthorized
+	}
+	return session, nil
+}
+
+func validConsoleSessionAt(session consoleSession, now int64) bool {
+	return session.SessionID != "" && session.IdleExpiresAt > now && session.AbsoluteExpiry > now &&
+		validActiveIdentityBinding(session.AgentID, session.PrincipalAgentID, session.IdentityState,
+			session.PrincipalStatus, session.PrincipalRevokedAt)
+}
+
+func (s *Service) resolveActiveConsoleSession(c *app.RequestContext, now int64) (int, consoleSession, error) {
+	preferred := activeConsoleSlot(c)
+	order := []int{preferred}
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		if slot != preferred {
+			order = append(order, slot)
+		}
+	}
+	foundCredential := false
+	for _, slot := range order {
+		credential, ok := consoleCredential(c, slot)
+		if !ok {
+			continue
+		}
+		foundCredential = true
+		session, err := s.loadConsoleSessionCredential(s.db, credential)
+		if err != nil {
+			continue
+		}
+		if !validConsoleSessionAt(session, now) {
+			if !validActiveIdentityBinding(session.AgentID, session.PrincipalAgentID, session.IdentityState,
+				session.PrincipalStatus, session.PrincipalRevokedAt) {
+				s.db.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+					WHERE session_id = ? AND status = 'active'`, now, session.SessionID)
+			}
+			continue
+		}
+		if slot != preferred {
+			s.setActiveConsoleSlot(c, slot, int(consoleAbsoluteTTL/time.Second))
+		}
+		return slot, session, nil
+	}
+	if foundCredential {
+		return 0, consoleSession{}, errConsoleSessionInvalid
+	}
+	return 0, consoleSession{}, errUnauthorized
+}
+
+func (s *Service) consoleAccountView(db *gorm.DB, slot int, session consoleSession, now int64) (consoleAccountView, error) {
+	var identity struct {
+		AgentName   string `gorm:"column:agent_name"`
+		AgentNameEn string `gorm:"column:agent_name_en"`
+		ShortID     string `gorm:"column:short_id"`
+		Email       string `gorm:"column:email"`
+	}
+	err := db.Raw(`SELECT a.agent_name, a.agent_name_en, a.short_id,
+		COALESCE((SELECT binding.normalized_email FROM agent_email_bindings binding
+			WHERE binding.agent_id = a.agent_id AND binding.status = 'active'
+				AND binding.verification_state = 'verified'
+			ORDER BY binding.updated_at DESC, binding.binding_id DESC LIMIT 1), '') AS email
+		FROM agents a
+		WHERE a.agent_id = ?`, session.AgentID).Scan(&identity).Error
+	if err != nil {
+		return consoleAccountView{}, err
+	}
+	expiresAt := session.IdleExpiresAt
+	if session.AbsoluteExpiry < expiresAt {
+		expiresAt = session.AbsoluteExpiry
+	}
+	return consoleAccountView{
+		AgentID: strconv.FormatInt(session.AgentID, 10), AgentName: identity.AgentName,
+		AgentNameEn: identity.AgentNameEn, ShortID: identity.ShortID,
+		EigenFluxID: "eigenflux#" + identity.ShortID, Email: identity.Email, Slot: slot,
+		LastActiveAt: session.LastSeenAt, ExpiresAt: expiresAt,
+		Expired: !validConsoleSessionAt(session, now),
+	}, nil
+}
+
+func (s *Service) consoleAccounts(db *gorm.DB, c *app.RequestContext, now int64) []consoleAccountView {
+	accounts := make([]consoleAccountView, 0, maxConsoleAccountSlots)
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		credential, ok := consoleCredential(c, slot)
+		if !ok {
+			continue
+		}
+		session, err := s.loadConsoleSessionCredential(db, credential)
+		if err != nil {
+			continue
+		}
+		account, err := s.consoleAccountView(db, slot, session, now)
+		if err == nil {
+			accounts = append(accounts, account)
+		}
+	}
+	sort.SliceStable(accounts, func(i, j int) bool { return accounts[i].LastActiveAt > accounts[j].LastActiveAt })
+	return accounts
+}
+
+func parseReplacementAgentID(value string) (int64, error) {
+	if strings.TrimSpace(value) == "" {
+		return 0, nil
+	}
+	id, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, errors.New("invalid replacement Agent")
+	}
+	return id, nil
+}
+
+func (s *Service) chooseConsoleSessionSlot(tx *gorm.DB, c *app.RequestContext, targetAgentID, replacementAgentID int64, now int64) (int, string, []consoleAccountView, error) {
+	freeSlot := -1
+	accounts := make([]consoleAccountView, 0, maxConsoleAccountSlots)
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		credential, ok := consoleCredential(c, slot)
+		if !ok {
+			if freeSlot < 0 {
+				freeSlot = slot
+			}
+			continue
+		}
+		session, err := s.loadConsoleSessionCredential(tx, credential)
+		if err != nil || !validConsoleSessionAt(session, now) {
+			if freeSlot < 0 {
+				freeSlot = slot
+			}
+			continue
+		}
+		account, accountErr := s.consoleAccountView(tx, slot, session, now)
+		if accountErr == nil {
+			accounts = append(accounts, account)
+		}
+		if session.AgentID == targetAgentID || (replacementAgentID > 0 && session.AgentID == replacementAgentID) {
+			return slot, session.SessionID, accounts, nil
+		}
+	}
+	if replacementAgentID > 0 {
+		return 0, "", accounts, errConflict
+	}
+	if freeSlot >= 0 {
+		return freeSlot, "", accounts, nil
+	}
+	return 0, "", accounts, errConsoleAccountLimit
+}
+
+func (s *Service) listConsoleAccounts(_ context.Context, c *app.RequestContext) {
+	now := time.Now().UnixMilli()
+	accounts := s.consoleAccounts(s.db, c, now)
+	activeID, _ := agentID(c)
+	reply(c, http.StatusOK, map[string]interface{}{
+		"accounts": accounts, "active_agent_id": strconv.FormatInt(activeID, 10),
+		"active_slot": activeConsoleSlot(c), "max_accounts": maxConsoleAccountSlots,
+	})
+}
+
+func (s *Service) activateConsoleAccount(_ context.Context, c *app.RequestContext) {
+	targetID, err := strconv.ParseInt(strings.TrimSpace(c.Param("agent_id")), 10, 64)
+	if err != nil || targetID <= 0 {
+		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "a valid agent_id is required", nil)
+		return
+	}
+	now := time.Now().UnixMilli()
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		credential, ok := consoleCredential(c, slot)
+		if !ok {
+			continue
+		}
+		session, loadErr := s.loadConsoleSessionCredential(s.db, credential)
+		if loadErr == nil && validConsoleSessionAt(session, now) && session.AgentID == targetID {
+			s.setActiveConsoleSlot(c, slot, int(consoleAbsoluteTTL/time.Second))
+			reply(c, http.StatusOK, map[string]interface{}{"activated": true, "agent_id": c.Param("agent_id"), "slot": slot})
+			return
+		}
+	}
+	fail(c, http.StatusNotFound, "CONSOLE_ACCOUNT_NOT_FOUND", "this account is not available in the browser", nil)
+}
+
+func (s *Service) removeConsoleAccount(_ context.Context, c *app.RequestContext) {
+	targetID, err := strconv.ParseInt(strings.TrimSpace(c.Param("agent_id")), 10, 64)
+	if err != nil || targetID <= 0 {
+		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "a valid agent_id is required", nil)
+		return
+	}
+	now := time.Now().UnixMilli()
+	currentAgentID, _ := agentID(c)
+	removedSlot := -1
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		credential, ok := consoleCredential(c, slot)
+		if !ok {
+			continue
+		}
+		session, loadErr := s.loadConsoleSessionCredential(s.db, credential)
+		if loadErr == nil && session.AgentID == targetID {
+			if err := s.db.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE session_id = ? AND status = 'active'`, now, session.SessionID).Error; err != nil {
+				fail(c, http.StatusInternalServerError, "LOGOUT_FAILED", "could not revoke Console V2 session", nil)
+				return
+			}
+			s.setConsoleCookieAtSlot(c, slot, "", -1)
+			s.setCSRFCookieAtSlot(c, slot, "", -1)
+			removedSlot = slot
+			break
+		}
+	}
+	if removedSlot < 0 {
+		fail(c, http.StatusNotFound, "CONSOLE_ACCOUNT_NOT_FOUND", "this account is not available in the browser", nil)
+		return
+	}
+	activeSlot := activeConsoleSlot(c)
+	nextAgentID := int64(0)
+	if activeSlot == removedSlot {
+		nextSlot := -1
+		for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+			if slot == removedSlot {
+				continue
+			}
+			credential, ok := consoleCredential(c, slot)
+			if !ok {
+				continue
+			}
+			session, loadErr := s.loadConsoleSessionCredential(s.db, credential)
+			if loadErr == nil && validConsoleSessionAt(session, now) {
+				nextSlot = slot
+				nextAgentID = session.AgentID
+				break
+			}
+		}
+		if nextSlot >= 0 {
+			s.setActiveConsoleSlot(c, nextSlot, int(consoleAbsoluteTTL/time.Second))
+		} else {
+			s.setActiveConsoleSlot(c, 0, -1)
+		}
+	}
+	reply(c, http.StatusOK, map[string]interface{}{
+		"removed": true, "agent_id": c.Param("agent_id"),
+		"active_agent_id": func() string {
+			if activeSlot != removedSlot {
+				return strconv.FormatInt(currentAgentID, 10)
+			}
+			if nextAgentID > 0 {
+				return strconv.FormatInt(nextAgentID, 10)
+			}
+			return ""
+		}(),
+	})
+}
+
+func consoleAccountLimitDetails(accounts []consoleAccountView, incomingAgentID int64) map[string]interface{} {
+	return map[string]interface{}{
+		"max_accounts":      maxConsoleAccountSlots,
+		"accounts":          accounts,
+		"incoming_agent_id": fmt.Sprintf("%d", incomingAgentID),
+	}
+}

--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -1057,14 +1057,20 @@ func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
 }
 
 type exchangeRequest struct {
-	Ticket       string `json:"ticket"`
-	BrowserNonce string `json:"browser_nonce,omitempty"`
+	Ticket         string `json:"ticket"`
+	BrowserNonce   string `json:"browser_nonce,omitempty"`
+	ReplaceAgentID string `json:"replace_agent_id,omitempty"`
 }
 
 func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 	var req exchangeRequest
 	if err := decodeBody(c, &req); err != nil || req.Ticket == "" || len(req.BrowserNonce) < 32 || len(req.BrowserNonce) > 256 {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "ticket and browser_nonce are required", nil)
+		return
+	}
+	replacementAgentID, err := parseReplacementAgentID(req.ReplaceAgentID)
+	if err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "replace_agent_id is invalid", nil)
 		return
 	}
 	sessionID, sessionIDErr := randomToken("efcs_", 18)
@@ -1077,7 +1083,10 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 	var agentIDValue, principalID int64
 	var scopes, clientCapabilities pq.StringArray
 	handoffRevoked := false
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	selectedSlot := 0
+	replacedSessionID := ""
+	var accountLimitAccounts []consoleAccountView
+	err = s.db.Transaction(func(tx *gorm.DB) error {
 		var handoff struct {
 			AgentID            int64          `gorm:"column:agent_id"`
 			PrincipalID        int64          `gorm:"column:principal_id"`
@@ -1122,12 +1131,25 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 			}
 			return errUnauthorized
 		}
+		agentIDValue, principalID, scopes, clientCapabilities = handoff.AgentID, handoff.PrincipalID, handoff.Scopes, handoff.Capabilities
+		var slotErr error
+		selectedSlot, replacedSessionID, accountLimitAccounts, slotErr = s.chooseConsoleSessionSlot(
+			tx, c, agentIDValue, replacementAgentID, now,
+		)
+		if slotErr != nil {
+			return slotErr
+		}
 		consume := tx.Exec(`UPDATE console_v2_handoffs SET consumed_at = ?
 				WHERE ticket_hash = ? AND consumed_at IS NULL AND revoked_at IS NULL AND expires_at >= ?`, now, hashString(req.Ticket), now)
 		if consume.Error != nil || consume.RowsAffected != 1 {
 			return errUnauthorized
 		}
-		agentIDValue, principalID, scopes, clientCapabilities = handoff.AgentID, handoff.PrincipalID, handoff.Scopes, handoff.Capabilities
+		if replacedSessionID != "" {
+			if err := tx.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE session_id = ? AND status = 'active'`, now, replacedSessionID).Error; err != nil {
+				return err
+			}
+		}
 		return tx.Exec(`INSERT INTO console_v2_sessions
 				(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash,
 					 status, scopes, client_capabilities, issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method)
@@ -1139,15 +1161,25 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusUnauthorized, "HANDOFF_INVALID", "handoff is invalid, consumed, or expired", nil)
 		return
 	}
+	if errors.Is(err, errConsoleAccountLimit) {
+		fail(c, http.StatusConflict, "CONSOLE_ACCOUNT_LIMIT_REACHED", "this browser already has five Console accounts", consoleAccountLimitDetails(accountLimitAccounts, agentIDValue))
+		return
+	}
+	if errors.Is(err, errConflict) {
+		fail(c, http.StatusConflict, "CONSOLE_ACCOUNT_REPLACEMENT_INVALID", "the selected account cannot be replaced", nil)
+		return
+	}
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "HANDOFF_EXCHANGE_FAILED", "could not establish Console V2 session", nil)
 		return
 	}
-	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
-	s.setCSRFCookie(c, csrfSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setConsoleCookieAtSlot(c, selectedSlot, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setCSRFCookieAtSlot(c, selectedSlot, csrfSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setActiveConsoleSlot(c, selectedSlot, int(consoleAbsoluteTTL/time.Second))
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":            fmt.Sprintf("%d", agentIDValue),
 		"csrf_token":          csrfSecret,
+		"slot":                selectedSlot,
 		"client_capabilities": []string(clientCapabilities),
 	})
 }

--- a/api/consolev2/email_handlers.go
+++ b/api/consolev2/email_handlers.go
@@ -415,10 +415,12 @@ func (s *Service) createEmailLoginChallenge(ctx context.Context, c *app.RequestC
 }
 
 type verifyEmailRequest struct {
-	ChallengeID string `json:"challenge_id"`
-	Email       string `json:"email"`
-	OTP         string `json:"otp"`
-	Purpose     string `json:"purpose,omitempty"`
+	ChallengeID    string `json:"challenge_id"`
+	Email          string `json:"email"`
+	OTP            string `json:"otp"`
+	Purpose        string `json:"purpose,omitempty"`
+	AddAccount     bool   `json:"add_account,omitempty"`
+	ReplaceAgentID string `json:"replace_agent_id,omitempty"`
 }
 
 func (s *Service) lockAndCheckEmailChallenge(tx *gorm.DB, req verifyEmailRequest, normalizedEmail, purpose string, subjectAgentID *int64, sessionID *string, now int64) (emailChallengeRow, bool, error) {
@@ -854,12 +856,20 @@ func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "challenge_id, email, otp, and purpose are required", nil)
 		return
 	}
+	replacementAgentID, err := parseReplacementAgentID(req.ReplaceAgentID)
+	if err != nil || (!req.AddAccount && replacementAgentID > 0) {
+		fail(c, http.StatusBadRequest, "INVALID_REQUEST", "replace_agent_id requires add_account", nil)
+		return
+	}
 	sessionID, _ := randomToken("efcs_", 18)
 	sessionSecret, _ := randomToken("", 32)
 	csrfSecret, _ := randomToken("efcsrf_", 24)
 	now := time.Now().UnixMilli()
 	validOTP := false
 	var recoveredAgentID int64
+	selectedSlot := 0
+	replacedSessionID := ""
+	var accountLimitAccounts []consoleAccountView
 	err = s.db.Transaction(func(tx *gorm.DB) error {
 		var challenge emailChallengeRow
 		if err := tx.Raw(`SELECT challenge_id, purpose, normalized_email_hash, subject_agent_id,
@@ -930,10 +940,29 @@ func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {
 				return err
 			}
 		}
+		if req.AddAccount {
+			var slotErr error
+			selectedSlot, replacedSessionID, accountLimitAccounts, slotErr = s.chooseConsoleSessionSlot(
+				tx, c, recoveredAgentID, replacementAgentID, now,
+			)
+			if slotErr != nil {
+				return slotErr
+			}
+		} else if credential, ok := consoleCredential(c, 0); ok {
+			if existing, loadErr := s.loadConsoleSessionCredential(tx, credential); loadErr == nil {
+				replacedSessionID = existing.SessionID
+			}
+		}
 		consume := tx.Exec(`UPDATE v2_email_challenges SET status = 'consumed', consumed_at = ?
 			WHERE challenge_id = ? AND status = 'pending'`, now, req.ChallengeID)
 		if consume.Error != nil || consume.RowsAffected != 1 {
 			return errUnauthorized
+		}
+		if replacedSessionID != "" {
+			if err := tx.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE session_id = ? AND status = 'active'`, now, replacedSessionID).Error; err != nil {
+				return err
+			}
 		}
 		return tx.Exec(`INSERT INTO console_v2_sessions
 			(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash,
@@ -948,13 +977,22 @@ func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusUnauthorized, "OTP_INVALID", "verification code is invalid or expired", nil)
 		return
 	}
+	if errors.Is(err, errConsoleAccountLimit) {
+		fail(c, http.StatusConflict, "CONSOLE_ACCOUNT_LIMIT_REACHED", "this browser already has five Console accounts", consoleAccountLimitDetails(accountLimitAccounts, recoveredAgentID))
+		return
+	}
+	if errors.Is(err, errConflict) {
+		fail(c, http.StatusConflict, "CONSOLE_ACCOUNT_REPLACEMENT_INVALID", "the selected account cannot be replaced", nil)
+		return
+	}
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "EMAIL_LOGIN_FAILED", "could not establish Console V2 session", nil)
 		return
 	}
-	s.setConsoleCookie(c, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
-	s.setCSRFCookie(c, csrfSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setConsoleCookieAtSlot(c, selectedSlot, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setCSRFCookieAtSlot(c, selectedSlot, csrfSecret, int(consoleAbsoluteTTL/time.Second))
+	s.setActiveConsoleSlot(c, selectedSlot, int(consoleAbsoluteTTL/time.Second))
 	reply(c, http.StatusOK, map[string]interface{}{
-		"agent_id": fmt.Sprintf("%d", recoveredAgentID), "csrf_token": csrfSecret,
+		"agent_id": fmt.Sprintf("%d", recoveredAgentID), "csrf_token": csrfSecret, "slot": selectedSlot,
 	})
 }

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -222,9 +222,43 @@ func (s *Service) deleteConsoleSession(_ context.Context, c *app.RequestContext)
 		fail(c, http.StatusInternalServerError, "LOGOUT_FAILED", "could not revoke Console V2 session", nil)
 		return
 	}
-	s.setConsoleCookie(c, "", -1)
-	s.setCSRFCookie(c, "", -1)
-	reply(c, http.StatusOK, map[string]interface{}{"revoked": true})
+	slot := 0
+	if value, ok := c.Get("console_session_slot"); ok {
+		if selected, valid := value.(int); valid && selected >= 0 && selected < maxConsoleAccountSlots {
+			slot = selected
+		}
+	}
+	s.setConsoleCookieAtSlot(c, slot, "", -1)
+	s.setCSRFCookieAtSlot(c, slot, "", -1)
+	nextSlot := -1
+	nextAgentID := int64(0)
+	for candidateSlot := 0; candidateSlot < maxConsoleAccountSlots; candidateSlot++ {
+		if candidateSlot == slot {
+			continue
+		}
+		credential, present := consoleCredential(c, candidateSlot)
+		if !present {
+			continue
+		}
+		session, loadErr := s.loadConsoleSessionCredential(s.db, credential)
+		if loadErr == nil && validConsoleSessionAt(session, now) {
+			nextSlot, nextAgentID = candidateSlot, session.AgentID
+			break
+		}
+	}
+	if nextSlot >= 0 {
+		s.setActiveConsoleSlot(c, nextSlot, int(consoleAbsoluteTTL/time.Second))
+	} else {
+		s.setActiveConsoleSlot(c, 0, -1)
+	}
+	reply(c, http.StatusOK, map[string]interface{}{
+		"revoked": true, "active_agent_id": func() string {
+			if nextAgentID <= 0 {
+				return ""
+			}
+			return strconv.FormatInt(nextAgentID, 10)
+		}(),
+	})
 }
 
 type putDraftRequest struct {

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/app/server"
-	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/lib/pq"
 	redis "github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
@@ -40,8 +39,10 @@ import (
 )
 
 const (
-	consoleCookieName = "ef_console_v2"
-	csrfCookieName    = "ef_console_v2_csrf"
+	consoleCookieName           = "ef_console_v2"
+	csrfCookieName              = "ef_console_v2_csrf"
+	activeConsoleSlotCookieName = "ef_console_v2_active"
+	maxConsoleAccountSlots      = 5
 	// Browser sessions use a long idle window while retaining a hard upper
 	// bound. Keep these values centralized so handoff and email-OTP login
 	// cannot drift apart.
@@ -58,10 +59,12 @@ const (
 )
 
 var (
-	errConflict           = errors.New("conflict")
-	errUnauthorized       = errors.New("unauthorized")
-	errOnboardingRequired = errors.New("onboarding required")
-	errCLIUpgradeRequired = errors.New("CLI upgrade required")
+	errConflict              = errors.New("conflict")
+	errUnauthorized          = errors.New("unauthorized")
+	errOnboardingRequired    = errors.New("onboarding required")
+	errCLIUpgradeRequired    = errors.New("CLI upgrade required")
+	errConsoleAccountLimit   = errors.New("console account limit reached")
+	errConsoleSessionInvalid = errors.New("console session invalid")
 )
 
 type IDGenerator interface {
@@ -344,6 +347,9 @@ func (s *Service) Register(h *server.Hertz) {
 	h.POST("/api/v2/console/handoffs/exchange", s.requireSameOrigin(), s.exchangeHandoff)
 	h.GET("/api/v2/console/session", s.consoleAuth(false), s.getConsoleSession)
 	h.DELETE("/api/v2/console/session", s.consoleAuth(true), s.deleteConsoleSession)
+	h.GET("/api/v2/console/accounts", s.consoleAuth(false), s.listConsoleAccounts)
+	h.POST("/api/v2/console/accounts/:agent_id/activate", s.consoleAuth(true), s.activateConsoleAccount)
+	h.DELETE("/api/v2/console/accounts/:agent_id", s.consoleAuth(true), s.removeConsoleAccount)
 
 	h.PUT("/api/v2/agents/me/onboarding-draft", s.agentAuth("onboarding:write"), s.putOnboardingDraft)
 	h.PUT("/api/v2/console/onboarding-draft", s.consoleAuth(true), s.putOnboardingDraft)
@@ -529,12 +535,11 @@ func validActiveIdentityBinding(agentID, principalAgentID int64, identityState, 
 }
 
 func (s *Service) setConsoleCookie(c *app.RequestContext, value string, maxAge int) {
-	c.SetCookie(consoleCookieName, value, maxAge, "/", "", protocol.CookieSameSiteLaxMode, s.secureCookie, true)
-	c.Header("Referrer-Policy", "no-referrer")
+	s.setConsoleCookieAtSlot(c, 0, value, maxAge)
 }
 
 func (s *Service) setCSRFCookie(c *app.RequestContext, value string, maxAge int) {
-	c.SetCookie(csrfCookieName, value, maxAge, "/", "", protocol.CookieSameSiteStrictMode, s.secureCookie, false)
+	s.setCSRFCookieAtSlot(c, 0, value, maxAge)
 }
 
 type agentPrincipal struct {
@@ -614,37 +619,14 @@ func (s *Service) consoleAuth(requireCSRF bool) app.HandlerFunc {
 			c.Abort()
 			return
 		}
-		parts := strings.SplitN(string(c.Cookie(consoleCookieName)), ".", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console V2 session is required", nil)
-			c.Abort()
-			return
-		}
-		var session consoleSession
 		now := time.Now().UnixMilli()
-		err := s.db.Raw(`SELECT s.session_id, s.agent_id, s.principal_id,
-					p.agent_id AS principal_agent_id, p.status AS principal_status,
-					p.revoked_at AS principal_revoked_at,
-					a.identity_state,
-					s.session_secret_hash, s.csrf_secret_hash, s.scopes,
-			s.idle_expires_at, s.absolute_expires_at, s.last_seen_at,
-			s.auth_method, s.recent_auth_at
-				FROM console_v2_sessions s
-				JOIN agent_principals p ON p.principal_id = s.principal_id
-				JOIN agents a ON a.agent_id = s.agent_id
-				WHERE s.session_id = ? AND s.status = 'active'
-				  AND s.idle_expires_at > ? AND s.absolute_expires_at > ?`, parts[0], now, now).
-			Scan(&session).Error
-		if err != nil || session.SessionID == "" || subtle.ConstantTimeCompare([]byte(session.SecretHash), []byte(hashString(parts[1]))) != 1 {
-			fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_INVALID", "Console V2 session is invalid or expired", nil)
-			c.Abort()
-			return
-		}
-		if !validActiveIdentityBinding(session.AgentID, session.PrincipalAgentID, session.IdentityState,
-			session.PrincipalStatus, session.PrincipalRevokedAt) {
-			s.db.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
-				WHERE session_id = ? AND status = 'active'`, now, session.SessionID)
-			fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_INVALID", "Console V2 session is invalid or expired", nil)
+		slot, session, err := s.resolveActiveConsoleSession(c, now)
+		if err != nil || session.SessionID == "" {
+			if errors.Is(err, errConsoleSessionInvalid) {
+				fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_INVALID", "Console V2 session is invalid or expired", nil)
+			} else {
+				fail(c, http.StatusUnauthorized, "CONSOLE_SESSION_REQUIRED", "Console V2 session is required", nil)
+			}
 			c.Abort()
 			return
 		}
@@ -668,6 +650,7 @@ func (s *Service) consoleAuth(requireCSRF bool) app.HandlerFunc {
 		c.Set("agent_id", session.AgentID)
 		c.Set("principal_id", session.PrincipalID)
 		c.Set("console_session_id", session.SessionID)
+		c.Set("console_session_slot", slot)
 		c.Set("console_auth_method", session.AuthMethod)
 		if session.RecentAuthAt != nil {
 			c.Set("console_recent_auth_at", *session.RecentAuthAt)

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -37,6 +37,33 @@ func TestConsoleHandoffTTL(t *testing.T) {
 	}
 }
 
+func TestConsoleSessionCookieSlotsPreserveLegacySlotZero(t *testing.T) {
+	if maxConsoleAccountSlots != 5 {
+		t.Fatalf("maxConsoleAccountSlots = %d, want 5", maxConsoleAccountSlots)
+	}
+	wantSessions := []string{"ef_console_v2", "ef_console_v2_1", "ef_console_v2_2", "ef_console_v2_3", "ef_console_v2_4"}
+	wantCSRF := []string{"ef_console_v2_csrf", "ef_console_v2_csrf_1", "ef_console_v2_csrf_2", "ef_console_v2_csrf_3", "ef_console_v2_csrf_4"}
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		if got := consoleSessionCookieName(slot); got != wantSessions[slot] {
+			t.Fatalf("session cookie slot %d = %q, want %q", slot, got, wantSessions[slot])
+		}
+		if got := consoleCSRFCookieName(slot); got != wantCSRF[slot] {
+			t.Fatalf("CSRF cookie slot %d = %q, want %q", slot, got, wantCSRF[slot])
+		}
+	}
+}
+
+func TestParseReplacementAgentID(t *testing.T) {
+	for _, input := range []string{"0", "-1", "not-an-id"} {
+		if _, err := parseReplacementAgentID(input); err == nil {
+			t.Fatalf("parseReplacementAgentID(%q) unexpectedly succeeded", input)
+		}
+	}
+	if got, err := parseReplacementAgentID(" 42 "); err != nil || got != 42 {
+		t.Fatalf("parseReplacementAgentID valid result = %d, %v", got, err)
+	}
+}
+
 func TestCompletedPrincipalScopesCoverAgentV2Surfaces(t *testing.T) {
 	want := []string{
 		"attention:write",

--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -80,6 +80,28 @@ Agents resume at their stored `current_step`. Never manually reactivate or
 delete a recovery tombstone; the migration down path intentionally refuses once
 recovery history exists.
 
+## Console V2 Browser Multi-account Sessions
+
+A browser can retain up to five independent Console V2 sessions. Slot zero keeps
+the existing `ef_console_v2` and `ef_console_v2_csrf` cookie names, so deployment
+does not invalidate existing sign-ins. Slots one through four use the same names
+with `_1` through `_4` suffixes. `ef_console_v2_active` identifies the active
+slot and contains no credential material. Session cookies remain HttpOnly and
+CSRF cookies remain readable only for the matching active slot.
+
+`GET /api/v2/console/accounts` lists browser accounts,
+`POST /api/v2/console/accounts/{agent_id}/activate` switches the active slot,
+and `DELETE /api/v2/console/accounts/{agent_id}` revokes and removes one slot.
+Logging out revokes only the active slot and falls through to another valid
+slot when available.
+
+Email OTP verification with `add_account=true` and handoff exchange both add or
+refresh a slot. At five valid accounts they return
+`CONSOLE_ACCOUNT_LIMIT_REACHED` with the replaceable account list. The verified
+OTP challenge or handoff remains unconsumed. Retrying with `replace_agent_id`
+atomically revokes the selected session, consumes the proof, creates the new
+session, and activates its slot. Credentials are never stored in localStorage.
+
 ## Mock OTP Whitelist
 
 After configuring `MOCK_OTP_EMAIL_SUFFIXES` + `MOCK_OTP_IP_WHITELIST`, requests matching both email suffix and IP use mock verification code logic (no email sent, verify using `MOCK_UNIVERSAL_OTP`), and skip IP rate limiting for login/verification endpoints. Suitable for production backend operation accounts. Both conditions must be satisfied simultaneously.


### PR DESCRIPTION
## Summary
- retain up to five independent Console V2 cookie sessions while preserving legacy slot-zero cookie names
- add account list, activation, removal, and current-slot logout behavior
- support email OTP and handoff account addition with atomic replacement when the browser is full
- leave verified OTP challenges and handoffs unconsumed until a replacement is confirmed

## Verification
- go test ./api/consolev2
- go test ./... (Console V2 and other self-contained packages pass; infrastructure-dependent packages require local PostgreSQL/Redis)