### PR TITLE
feat(cli): add verified account switching

### DIFF
--- a/api/consolev2/account_switch_handlers.go
+++ b/api/consolev2/account_switch_handlers.go
@@ -1,0 +1,314 @@
+package consolev2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+const (
+	cliAccountSwitchCookieName = "ef_cli_account_switch"
+	cliAccountSwitchTTL        = 24 * time.Hour
+)
+
+type cliAccountSwitchRecord struct {
+	SwitchIDHash         string `gorm:"column:switch_id_hash"`
+	SourceAgentID        int64  `gorm:"column:source_agent_id"`
+	TargetAgentID        *int64 `gorm:"column:target_agent_id"`
+	PrincipalID          int64  `gorm:"column:principal_id"`
+	SourceConsoleSession string `gorm:"column:source_console_session_id"`
+	TargetConsoleSession string `gorm:"column:target_console_session_id"`
+	Status               string `gorm:"column:status"`
+	OwnershipVerifiedAt  *int64 `gorm:"column:ownership_verified_at"`
+	ExpiresAt            int64  `gorm:"column:expires_at"`
+	CompletedAt          *int64 `gorm:"column:completed_at"`
+}
+
+func (s *Service) setCLIAccountSwitchCookie(c *app.RequestContext, value string, maxAge int) {
+	c.SetCookie(cliAccountSwitchCookieName, value, maxAge, "/", "", protocol.CookieSameSiteStrictMode, s.secureCookie, true)
+}
+
+func cliAccountSwitchToken(c *app.RequestContext) string {
+	return strings.TrimSpace(string(c.Cookie(cliAccountSwitchCookieName)))
+}
+
+func loadCLIAccountSwitch(tx *gorm.DB, token string, forUpdate bool) (cliAccountSwitchRecord, error) {
+	var record cliAccountSwitchRecord
+	query := `SELECT switch_id_hash, source_agent_id, target_agent_id, principal_id,
+		source_console_session_id, COALESCE(target_console_session_id, '') AS target_console_session_id,
+		status, ownership_verified_at, expires_at, completed_at
+		FROM agent_cli_account_switches WHERE switch_id_hash = ?`
+	if forUpdate {
+		query += " FOR UPDATE"
+	}
+	err := tx.Raw(query, hashString(token)).Scan(&record).Error
+	if err != nil || record.SwitchIDHash == "" {
+		return cliAccountSwitchRecord{}, errUnauthorized
+	}
+	return record, nil
+}
+
+func auditCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, result string, now int64) error {
+	return tx.Exec(`INSERT INTO agent_cli_account_switch_audit
+		(switch_id_hash, source_agent_id, target_agent_id, principal_id, result, occurred_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, record.SwitchIDHash, record.SourceAgentID,
+		record.TargetAgentID, record.PrincipalID, result, now).Error
+}
+
+func expireCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int64) error {
+	if record.Status != "pending_target" && record.Status != "pending_onboarding" {
+		return nil
+	}
+	if err := tx.Exec(`UPDATE agent_cli_account_switches SET status = 'expired'
+		WHERE switch_id_hash = ? AND status IN ('pending_target', 'pending_onboarding')`, record.SwitchIDHash).Error; err != nil {
+		return err
+	}
+	return auditCLIAccountSwitch(tx, record, "expired", now)
+}
+
+func finalizeCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int64) error {
+	if record.TargetAgentID == nil || *record.TargetAgentID <= 0 || record.TargetConsoleSession == "" {
+		return errConflict
+	}
+	var principal struct {
+		AgentID int64  `gorm:"column:agent_id"`
+		KeyType string `gorm:"column:key_type"`
+		Status  string `gorm:"column:status"`
+	}
+	if err := tx.Raw(`SELECT agent_id, key_type, status FROM agent_principals
+		WHERE principal_id = ? FOR UPDATE`, record.PrincipalID).Scan(&principal).Error; err != nil {
+		return err
+	}
+	if principal.AgentID != record.SourceAgentID || principal.KeyType != "ed25519-v1" ||
+		(principal.Status != "limited" && principal.Status != "active") {
+		return errConflict
+	}
+	var target struct {
+		IdentityState   string `gorm:"column:identity_state"`
+		OnboardingState string `gorm:"column:onboarding_state"`
+	}
+	if err := tx.Raw(`SELECT agents.identity_state, onboarding.state AS onboarding_state
+		FROM agents JOIN agent_onboarding_v2 onboarding ON onboarding.agent_id = agents.agent_id
+		WHERE agents.agent_id = ? FOR UPDATE OF agents, onboarding`, *record.TargetAgentID).Scan(&target).Error; err != nil {
+		return err
+	}
+	if target.IdentityState != "active" || target.OnboardingState != "completed" {
+		return errOnboardingRequired
+	}
+	var activeCredentials int64
+	if err := tx.Raw(`SELECT COUNT(*) FROM agent_credential_sessions
+		WHERE principal_id = ? AND revoked_at IS NULL AND expires_at > ?`, record.PrincipalID, now).Scan(&activeCredentials).Error; err != nil {
+		return err
+	}
+	if activeCredentials == 0 {
+		return errConflict
+	}
+	if res := tx.Exec(`UPDATE agent_principals SET agent_id = ?, status = 'active', last_seen_at = ?
+		WHERE principal_id = ? AND agent_id = ? AND revoked_at IS NULL`, *record.TargetAgentID, now,
+		record.PrincipalID, record.SourceAgentID); res.Error != nil || res.RowsAffected != 1 {
+		return errConflict
+	}
+	if err := tx.Exec(`UPDATE agent_credential_sessions SET scopes = ?, access_refresh_required = TRUE
+		WHERE principal_id = ? AND revoked_at IS NULL`, pq.Array(principalScopesForOnboarding("completed")), record.PrincipalID).Error; err != nil {
+		return err
+	}
+	if res := tx.Exec(`UPDATE agent_cli_account_switches
+		SET status = 'completed', completed_at = ?
+		WHERE switch_id_hash = ? AND status IN ('pending_target', 'pending_onboarding')`, now, record.SwitchIDHash); res.Error != nil || res.RowsAffected != 1 {
+		return errConflict
+	}
+	record.Status = "completed"
+	completedAt := now
+	record.CompletedAt = &completedAt
+	return auditCLIAccountSwitch(tx, record, "completed", now)
+}
+
+func (s *Service) getCLIAccountSwitch(_ context.Context, c *app.RequestContext) {
+	token := cliAccountSwitchToken(c)
+	if !strings.HasPrefix(token, "efas_") {
+		fail(c, http.StatusNotFound, "ACCOUNT_SWITCH_NOT_FOUND", "CLI account switch is not available", nil)
+		return
+	}
+	record, err := loadCLIAccountSwitch(s.db, token, false)
+	if err != nil {
+		fail(c, http.StatusNotFound, "ACCOUNT_SWITCH_NOT_FOUND", "CLI account switch is not available", nil)
+		return
+	}
+	now := time.Now().UnixMilli()
+	if (record.Status == "pending_target" || record.Status == "pending_onboarding") && record.ExpiresAt < now {
+		_ = s.db.Transaction(func(tx *gorm.DB) error { return expireCLIAccountSwitch(tx, record, now) })
+		record.Status = "expired"
+	}
+	reply(c, http.StatusOK, map[string]interface{}{
+		"status": record.Status, "source_agent_id": fmt.Sprintf("%d", record.SourceAgentID),
+		"target_agent_id": func() string {
+			if record.TargetAgentID == nil {
+				return ""
+			}
+			return fmt.Sprintf("%d", *record.TargetAgentID)
+		}(), "expires_at": record.ExpiresAt,
+	})
+}
+
+func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestContext) {
+	token := cliAccountSwitchToken(c)
+	targetAgentID, targetOK := agentID(c)
+	targetSessionValue, sessionOK := c.Get("console_session_id")
+	targetSessionID, sessionTypeOK := targetSessionValue.(string)
+	now := time.Now().UnixMilli()
+	if !strings.HasPrefix(token, "efas_") || !targetOK || !sessionOK || !sessionTypeOK {
+		fail(c, http.StatusBadRequest, "ACCOUNT_SWITCH_INVALID", "CLI account switch is invalid or expired", nil)
+		return
+	}
+	if !requireRecentEmailAuth(c, now) {
+		fail(c, http.StatusForbidden, "RECENT_EMAIL_AUTH_REQUIRED", "verify the target account email again before switching the CLI account", map[string]interface{}{"window_seconds": int(recentEmailAuthWindow / time.Second)})
+		return
+	}
+	status := ""
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		record, err := loadCLIAccountSwitch(tx, token, true)
+		if err != nil {
+			return err
+		}
+		if record.ExpiresAt < now {
+			if err := expireCLIAccountSwitch(tx, record, now); err != nil {
+				return err
+			}
+			return errUnauthorized
+		}
+		if record.Status == "completed" {
+			status = "completed"
+			return nil
+		}
+		if record.Status != "pending_target" && record.Status != "pending_onboarding" {
+			return errUnauthorized
+		}
+		if targetAgentID == record.SourceAgentID {
+			return errConflict
+		}
+		if record.Status == "pending_onboarding" && (record.TargetAgentID == nil || *record.TargetAgentID != targetAgentID || record.TargetConsoleSession != targetSessionID) {
+			return errConflict
+		}
+		var onboardingState string
+		if err := tx.Raw(`SELECT state FROM agent_onboarding_v2 WHERE agent_id = ? FOR UPDATE`, targetAgentID).Scan(&onboardingState).Error; err != nil {
+			return err
+		}
+		if onboardingState == "completed" {
+			target := targetAgentID
+			record.TargetAgentID = &target
+			record.TargetConsoleSession = targetSessionID
+			if err := tx.Exec(`UPDATE agent_cli_account_switches
+				SET target_agent_id = ?, target_console_session_id = ?, ownership_verified_at = ?
+				WHERE switch_id_hash = ?`, targetAgentID, targetSessionID, now, record.SwitchIDHash).Error; err != nil {
+				return err
+			}
+			if err := finalizeCLIAccountSwitch(tx, record, now); err != nil {
+				return err
+			}
+			status = "completed"
+			return nil
+		}
+		if record.Status == "pending_target" {
+			if err := tx.Exec(`UPDATE agent_cli_account_switches SET target_agent_id = ?,
+				target_console_session_id = ?, ownership_verified_at = ?, status = 'pending_onboarding'
+				WHERE switch_id_hash = ? AND status = 'pending_target'`, targetAgentID, targetSessionID, now, record.SwitchIDHash).Error; err != nil {
+				return err
+			}
+			target := targetAgentID
+			record.TargetAgentID = &target
+			record.TargetConsoleSession = targetSessionID
+			record.Status = "pending_onboarding"
+			if err := auditCLIAccountSwitch(tx, record, "pending_onboarding", now); err != nil {
+				return err
+			}
+		}
+		status = "pending_onboarding"
+		return nil
+	})
+	if errors.Is(err, errUnauthorized) {
+		fail(c, http.StatusUnauthorized, "ACCOUNT_SWITCH_INVALID", "CLI account switch is invalid or expired", nil)
+		return
+	}
+	if errors.Is(err, errConflict) {
+		fail(c, http.StatusConflict, "ACCOUNT_SWITCH_CONFLICT", "the selected account cannot be used for this CLI switch", nil)
+		return
+	}
+	if err != nil {
+		fail(c, http.StatusInternalServerError, "ACCOUNT_SWITCH_FAILED", "could not switch the CLI account", nil)
+		return
+	}
+	if status == "completed" {
+		s.setCLIAccountSwitchCookie(c, "", -1)
+		reply(c, http.StatusOK, map[string]interface{}{"status": status, "agent_id": fmt.Sprintf("%d", targetAgentID), "refresh_required": true})
+		return
+	}
+	reply(c, http.StatusAccepted, map[string]interface{}{
+		"status": "pending_onboarding", "agent_id": fmt.Sprintf("%d", targetAgentID),
+		"requires_onboarding": true, "current_cli_account_unchanged": true,
+	})
+}
+
+func (s *Service) cancelCLIAccountSwitch(_ context.Context, c *app.RequestContext) {
+	token := cliAccountSwitchToken(c)
+	if !strings.HasPrefix(token, "efas_") {
+		fail(c, http.StatusNotFound, "ACCOUNT_SWITCH_NOT_FOUND", "CLI account switch is not available", nil)
+		return
+	}
+	now := time.Now().UnixMilli()
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		record, err := loadCLIAccountSwitch(tx, token, true)
+		if err != nil {
+			return err
+		}
+		if record.Status != "pending_target" && record.Status != "pending_onboarding" {
+			return errConflict
+		}
+		if err := tx.Exec(`UPDATE agent_cli_account_switches SET status = 'revoked'
+			WHERE switch_id_hash = ?`, record.SwitchIDHash).Error; err != nil {
+			return err
+		}
+		return auditCLIAccountSwitch(tx, record, "revoked", now)
+	})
+	if err != nil {
+		fail(c, http.StatusConflict, "ACCOUNT_SWITCH_NOT_PENDING", "CLI account switch is not pending", nil)
+		return
+	}
+	s.setCLIAccountSwitchCookie(c, "", -1)
+	reply(c, http.StatusOK, map[string]interface{}{"cancelled": true})
+}
+
+func (s *Service) finalizePendingCLIAccountSwitch(tx *gorm.DB, c *app.RequestContext, targetAgentID int64, targetSessionID string, now int64) (bool, error) {
+	token := cliAccountSwitchToken(c)
+	if !strings.HasPrefix(token, "efas_") {
+		return false, nil
+	}
+	record, err := loadCLIAccountSwitch(tx, token, true)
+	if err != nil {
+		return false, nil
+	}
+	if record.Status != "pending_onboarding" || record.TargetAgentID == nil || *record.TargetAgentID != targetAgentID || record.TargetConsoleSession != targetSessionID {
+		return false, nil
+	}
+	if record.ExpiresAt < now {
+		return false, expireCLIAccountSwitch(tx, record, now)
+	}
+	if err := finalizeCLIAccountSwitch(tx, record, now); err != nil {
+		if errors.Is(err, errConflict) {
+			if updateErr := tx.Exec(`UPDATE agent_cli_account_switches SET status = 'revoked'
+				WHERE switch_id_hash = ? AND status = 'pending_onboarding'`, record.SwitchIDHash).Error; updateErr != nil {
+				return false, updateErr
+			}
+			return false, auditCLIAccountSwitch(tx, record, "rejected", now)
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -1085,6 +1085,7 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 	handoffRevoked := false
 	selectedSlot := 0
 	replacedSessionID := ""
+	accountSwitchToken := ""
 	var accountLimitAccounts []consoleAccountView
 	err = s.db.Transaction(func(tx *gorm.DB) error {
 		var handoff struct {
@@ -1150,12 +1151,37 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 				return err
 			}
 		}
-		return tx.Exec(`INSERT INTO console_v2_sessions
+		if err := tx.Exec(`INSERT INTO console_v2_sessions
 				(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash,
 					 status, scopes, client_capabilities, issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method)
 				VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, 'handoff')`, sessionID, hashString(sessionSecret),
 			agentIDValue, principalID, hashString(csrfSecret), pq.Array([]string(scopes)), pq.Array([]string(clientCapabilities)), now,
-			now+int64(consoleIdleTTL/time.Millisecond), now+int64(consoleAbsoluteTTL/time.Millisecond), now).Error
+			now+int64(consoleIdleTTL/time.Millisecond), now+int64(consoleAbsoluteTTL/time.Millisecond), now).Error; err != nil {
+			return err
+		}
+		if !containsScope(clientCapabilities, "account_switch_v1") {
+			return nil
+		}
+		accountSwitchToken, err = randomToken("efas_", 32)
+		if err != nil {
+			return err
+		}
+		if err := tx.Exec(`INSERT INTO agent_cli_account_switch_audit
+			(switch_id_hash, source_agent_id, target_agent_id, principal_id, result, occurred_at)
+			SELECT switch_id_hash, source_agent_id, target_agent_id, principal_id, 'revoked', ?
+			FROM agent_cli_account_switches
+			WHERE principal_id = ? AND status IN ('pending_target', 'pending_onboarding')`, now, principalID).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(`UPDATE agent_cli_account_switches SET status = 'revoked'
+			WHERE principal_id = ? AND status IN ('pending_target', 'pending_onboarding')`, principalID).Error; err != nil {
+			return err
+		}
+		return tx.Exec(`INSERT INTO agent_cli_account_switches
+			(switch_id_hash, source_agent_id, principal_id, source_console_session_id,
+			 status, expires_at, created_at)
+			VALUES (?, ?, ?, ?, 'pending_target', ?, ?)`, hashString(accountSwitchToken), agentIDValue,
+			principalID, sessionID, now+int64(cliAccountSwitchTTL/time.Millisecond), now).Error
 	})
 	if handoffRevoked || errors.Is(err, errUnauthorized) {
 		fail(c, http.StatusUnauthorized, "HANDOFF_INVALID", "handoff is invalid, consumed, or expired", nil)
@@ -1176,10 +1202,14 @@ func (s *Service) exchangeHandoff(_ context.Context, c *app.RequestContext) {
 	s.setConsoleCookieAtSlot(c, selectedSlot, sessionID+"."+sessionSecret, int(consoleAbsoluteTTL/time.Second))
 	s.setCSRFCookieAtSlot(c, selectedSlot, csrfSecret, int(consoleAbsoluteTTL/time.Second))
 	s.setActiveConsoleSlot(c, selectedSlot, int(consoleAbsoluteTTL/time.Second))
+	if accountSwitchToken != "" {
+		s.setCLIAccountSwitchCookie(c, accountSwitchToken, int(cliAccountSwitchTTL/time.Second))
+	}
 	reply(c, http.StatusOK, map[string]interface{}{
 		"agent_id":            fmt.Sprintf("%d", agentIDValue),
 		"csrf_token":          csrfSecret,
 		"slot":                selectedSlot,
 		"client_capabilities": []string(clientCapabilities),
+		"account_switch":      accountSwitchToken != "",
 	})
 }

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -603,6 +603,7 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 	requestHash := hashString(fmt.Sprintf("%d:%d", req.Step, req.ExpectedOnboardingRevision))
 	var response map[string]interface{}
 	replayed := false
+	accountSwitchCompleted := false
 	confirmedIntentCount := 0
 	now := time.Now().UnixMilli()
 	err := s.db.Transaction(func(tx *gorm.DB) error {
@@ -643,7 +644,14 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 			WHERE recoveries.console_session_id = ?
 			  AND recoveries.target_agent_id = ?
 			  AND recoveries.status = 'completed'
-		)`, sessionID, id, sessionID, id).Scan(&emailVerifiedForSession).Error; err != nil {
+		) OR EXISTS (
+			SELECT 1 FROM agent_cli_account_switches switches
+			WHERE switches.target_console_session_id = ?
+			  AND switches.target_agent_id = ?
+			  AND switches.status = 'pending_onboarding'
+			  AND switches.ownership_verified_at IS NOT NULL
+			  AND switches.expires_at >= ?
+		)`, sessionID, id, sessionID, id, sessionID, id, now).Scan(&emailVerifiedForSession).Error; err != nil {
 			return err
 		}
 		if !emailVerifiedForSession {
@@ -736,6 +744,14 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 		if newState == "completed" {
 			response["identity_state"] = "connected"
 			response["connection"] = map[string]interface{}{"state": "connected"}
+			completed, err := s.finalizePendingCLIAccountSwitch(tx, c, id, sessionID, now)
+			if err != nil {
+				return err
+			}
+			accountSwitchCompleted = completed
+			if completed {
+				response["account_switch"] = map[string]interface{}{"status": "completed", "refresh_required": true}
+			}
 		}
 		snapshot, _ := json.Marshal(response)
 		return tx.Exec(`INSERT INTO agent_idempotency_requests
@@ -784,6 +800,9 @@ func (s *Service) confirmOnboardingStep(ctx context.Context, c *app.RequestConte
 	if !replayed && req.Step == 5 && response["state"] == "completed" {
 		publishProfileCompletion(ctx, id)
 		activity.PublishOnboardingCompleted(ctx, id)
+	}
+	if accountSwitchCompleted {
+		s.setCLIAccountSwitchCookie(c, "", -1)
 	}
 	reply(c, http.StatusOK, response)
 }

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -350,6 +350,9 @@ func (s *Service) Register(h *server.Hertz) {
 	h.GET("/api/v2/console/accounts", s.consoleAuth(false), s.listConsoleAccounts)
 	h.POST("/api/v2/console/accounts/:agent_id/activate", s.consoleAuth(true), s.activateConsoleAccount)
 	h.DELETE("/api/v2/console/accounts/:agent_id", s.consoleAuth(true), s.removeConsoleAccount)
+	h.GET("/api/v2/console/account-switch", s.consoleAuth(false), s.getCLIAccountSwitch)
+	h.POST("/api/v2/console/account-switch/confirm", s.consoleAuth(true), s.confirmCLIAccountSwitch)
+	h.DELETE("/api/v2/console/account-switch", s.consoleAuth(true), s.cancelCLIAccountSwitch)
 
 	h.PUT("/api/v2/agents/me/onboarding-draft", s.agentAuth("onboarding:write"), s.putOnboardingDraft)
 	h.PUT("/api/v2/console/onboarding-draft", s.consoleAuth(true), s.putOnboardingDraft)

--- a/api/consolev2/service_test.go
+++ b/api/consolev2/service_test.go
@@ -37,6 +37,15 @@ func TestConsoleHandoffTTL(t *testing.T) {
 	}
 }
 
+func TestCLIAccountSwitchOutlivesHandoffWithoutCreatingLocalSlots(t *testing.T) {
+	if cliAccountSwitchTTL <= handoffTTL {
+		t.Fatalf("CLI account switch TTL %s must outlive handoff TTL %s", cliAccountSwitchTTL, handoffTTL)
+	}
+	if cliAccountSwitchCookieName == consoleCookieName || cliAccountSwitchCookieName == activeConsoleSlotCookieName {
+		t.Fatal("CLI account switch binding must be separate from Console account slots")
+	}
+}
+
 func TestConsoleSessionCookieSlotsPreserveLegacySlotZero(t *testing.T) {
 	if maxConsoleAccountSlots != 5 {
 		t.Fatalf("maxConsoleAccountSlots = %d, want 5", maxConsoleAccountSlots)

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,18 +3,18 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.35
+CLI_VERSION=0.0.36
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients
 # actually compare, this is just a human-facing label.)
-SKILLS_REVISION=13
+SKILLS_REVISION=14
 
 # Monotonic signed release sequence. Every published manifest must increment it;
 # clients reject rollback and sequence reuse with different content.
-SKILLS_SEQUENCE=2
+SKILLS_SEQUENCE=3
 
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a
 # skill starts requiring a newer CLI command, so old CLIs keep their old skills
 # instead of pulling ones they can't run.
-SKILLS_MIN_CLI_VERSION=0.0.35
+SKILLS_MIN_CLI_VERSION=0.0.36

--- a/cli/cmd/agent_switch_account.go
+++ b/cli/cmd/agent_switch_account.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var agentV2SwitchAccountCmd = &cobra.Command{
+	Use:   "switch-account",
+	Short: "Switch this Agent Home to another EigenFlux account",
+	Long: `Create a short-lived Console link for replacing the account used by this
+Agent Home. The target account must be verified in the Console. The current CLI
+login remains active until the target account has completed onboarding.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		v2Client, server, err := newV2ClientForServer(serverFlag, true)
+		if err != nil {
+			return err
+		}
+		credentials, err := auth.LoadV2Credentials(server.Name)
+		if err != nil {
+			return err
+		}
+		browserNonce, err := newBrowserNonce()
+		if err != nil {
+			return err
+		}
+		response, err := v2Client.Post("/console/handoffs", map[string]interface{}{
+			"browser_nonce": browserNonce, "client_capabilities": cliAccountSwitchCapabilities(),
+		})
+		if err != nil {
+			return err
+		}
+		var handoff struct {
+			URL       string `json:"handoff_url"`
+			ExpiresAt int64  `json:"expires_at"`
+		}
+		if json.Unmarshal(response.Data, &handoff) != nil || validateConsoleHandoffURL(handoff.URL) != nil {
+			return fmt.Errorf("invalid Console V2 account-switch handoff response")
+		}
+		output.PrintData(map[string]interface{}{
+			"agent_id": credentials.AgentID, "console_url": handoff.URL,
+			"handoff_expires_at": handoff.ExpiresAt,
+		}, resolveFormat())
+		return nil
+	},
+}
+
+func init() {
+	agentV2Cmd.AddCommand(agentV2SwitchAccountCmd)
+}
+
+func cliAccountSwitchCapabilities() []string {
+	return []string{"account_switch_v1"}
+}

--- a/cli/cmd/agent_v2_test.go
+++ b/cli/cmd/agent_v2_test.go
@@ -22,6 +22,12 @@ func TestConsoleHandoffCapabilitiesRequireExplicitRecoveryEntry(t *testing.T) {
 	}
 }
 
+func TestCLIAccountSwitchUsesDedicatedCapability(t *testing.T) {
+	if got := cliAccountSwitchCapabilities(); !reflect.DeepEqual(got, []string{"account_switch_v1"}) {
+		t.Fatalf("account switch capabilities = %#v", got)
+	}
+}
+
 type captureV2Poster struct {
 	path string
 	body map[string]interface{}

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -20,13 +20,14 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 	skill := string(skillBody)
 	for _, required := range []string{
 		"eigenflux agent provision --help",
+		"eigenflux agent switch-account --help",
 		"Do not request an email, OTP, referral code",
 		"Missing legacy credentials does not mean the Agent is unauthenticated",
-		"Skill requires CLI `0.0.35`",
+		"Skill requires CLI `0.0.36`",
 		"The join task is incomplete until the final user-facing response contains that validated link",
 		"Do not run the public installer or `eigenflux skills sync`",
 		"eigenflux agent provision --recover-account",
-		"Do not run `eigenflux dashboard` or ordinary `eigenflux agent provision`",
+		"eigenflux agent switch-account",
 		"Do not ask a clarifying question before generating the link",
 		"Do not use the new-join four-line success template",
 	} {
@@ -43,10 +44,10 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 			t.Errorf("ef-profile frontmatter is missing account recovery trigger %q", trigger)
 		}
 	}
-	if !strings.Contains(frontmatterParts[1], `version: "0.5.1"`) {
-		t.Error("ef-profile version was not advanced for mandatory Step 1 email verification")
+	if !strings.Contains(frontmatterParts[1], `version: "0.6.0"`) {
+		t.Error("ef-profile version was not advanced for CLI account switching")
 	}
-	for _, lifecycleRule := range []string{"has no bound email", "temporary identity", "formal account", "switch back later"} {
+	for _, lifecycleRule := range []string{"no bound email", "temporary identity", "formal account", "selected again later"} {
 		if !strings.Contains(skill, lifecycleRule) {
 			t.Errorf("ef-profile skill is missing account lifecycle rule %q", lifecycleRule)
 		}
@@ -87,7 +88,8 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 		"succeeds only when both names match exactly",
 		"Recovery transfers the current Home's Ed25519 principal",
 		"An Agent ID change is not a reason to call provision again",
-		"Requests to \"regenerate the claim link\" or \"switch account\"",
+		"Requests to switch the current CLI Agent to another account",
+		"Requests to regenerate a historical claim link",
 		"重新生成认领链接",
 		"我要切换账号",
 	} {

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -123,6 +123,13 @@ must update `feed_poll_interval` through settings rather than profile patching.
 
 ## Console V2 Today Model Brief
 
+CLI account switching uses `GET /api/v2/console/account-switch` to inspect the
+handoff-created switch, `POST /api/v2/console/account-switch/confirm` to bind a
+freshly OTP-authenticated target, and `DELETE /api/v2/console/account-switch`
+to cancel it. The confirm endpoint returns `202 pending_onboarding` without
+changing the current CLI principal when the target is incomplete; final
+onboarding completes that pending switch atomically.
+
 After Console V2 onboarding is complete, `GET /api/v2/console/today` can start
 an asynchronous model-generated Today headline. The generation language comes
 from the Agent Card `working_languages`; the requested UI language is used only

--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -102,6 +102,27 @@ OTP challenge or handoff remains unconsumed. Retrying with `replace_agent_id`
 atomically revokes the selected session, consumes the proof, creates the new
 session, and activates its slot. Credentials are never stored in localStorage.
 
+## Agent CLI Account Switching
+
+`eigenflux agent switch-account` creates a handoff with the dedicated
+`account_switch_v1` capability. Handoff exchange creates a 24-hour server-side
+switch record and binds it to the browser with a separate HttpOnly,
+SameSite=Strict cookie. The Agent Home continues to store only one credential
+family; Console account slots are never copied into CLI storage.
+
+The target account must authenticate through a fresh email OTP session within
+five minutes. A completed target atomically receives the source CLI principal,
+and its credential family is marked `access_refresh_required`; the next CLI
+request refreshes and adopts the authoritative target Agent ID. Source account
+data and email bindings remain unchanged.
+
+An incomplete target changes the switch to `pending_onboarding` without moving
+the principal or modifying current CLI credentials. Its OTP-authenticated
+Console session may complete onboarding, and the final onboarding transaction
+then moves the principal and completes the switch. Expired, cancelled, or
+failed pending switches leave the current CLI account unchanged. Historical
+Agent recovery remains a separate flow with separate lifecycle semantics.
+
 ## Mock OTP Whitelist
 
 After configuring `MOCK_OTP_EMAIL_SUFFIXES` + `MOCK_OTP_IP_WHITELIST`, requests matching both email suffix and IP use mock verification code logic (no email sent, verify using `MOCK_UNIVERSAL_OTP`), and skip IP rate limiting for login/verification endpoints. Suitable for production backend operation accounts. Both conditions must be satisfied simultaneously.

--- a/migrations/000093_console_v2_cli_account_switch.sql
+++ b/migrations/000093_console_v2_cli_account_switch.sql
@@ -1,0 +1,61 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+CREATE TABLE agent_cli_account_switches (
+    switch_id_hash VARCHAR(128) PRIMARY KEY,
+    source_agent_id BIGINT NOT NULL REFERENCES agents(agent_id),
+    target_agent_id BIGINT NULL REFERENCES agents(agent_id),
+    principal_id BIGINT NOT NULL REFERENCES agent_principals(principal_id),
+    source_console_session_id VARCHAR(128) NOT NULL REFERENCES console_v2_sessions(session_id),
+    target_console_session_id VARCHAR(128) NULL REFERENCES console_v2_sessions(session_id),
+    status VARCHAR(24) NOT NULL DEFAULT 'pending_target',
+    ownership_verified_at BIGINT NULL,
+    expires_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    completed_at BIGINT NULL,
+    CONSTRAINT chk_agent_cli_account_switches_distinct
+        CHECK (target_agent_id IS NULL OR source_agent_id <> target_agent_id),
+    CONSTRAINT chk_agent_cli_account_switches_status
+        CHECK (status IN ('pending_target', 'pending_onboarding', 'completed', 'expired', 'revoked')),
+    CONSTRAINT chk_agent_cli_account_switches_target
+        CHECK ((status = 'pending_target' AND target_agent_id IS NULL AND target_console_session_id IS NULL)
+            OR (status IN ('pending_onboarding', 'completed') AND target_agent_id IS NOT NULL AND target_console_session_id IS NOT NULL)
+            OR status IN ('expired', 'revoked')),
+    CONSTRAINT chk_agent_cli_account_switches_completion
+        CHECK ((status = 'completed' AND completed_at IS NOT NULL)
+            OR (status <> 'completed' AND completed_at IS NULL))
+);
+CREATE UNIQUE INDEX idx_agent_cli_account_switches_principal_pending
+    ON agent_cli_account_switches(principal_id)
+    WHERE status IN ('pending_target', 'pending_onboarding');
+CREATE INDEX idx_agent_cli_account_switches_target_pending
+    ON agent_cli_account_switches(target_agent_id, target_console_session_id)
+    WHERE status = 'pending_onboarding';
+CREATE INDEX idx_agent_cli_account_switches_expiry
+    ON agent_cli_account_switches(expires_at, status);
+
+CREATE TABLE agent_cli_account_switch_audit (
+    audit_id BIGSERIAL PRIMARY KEY,
+    switch_id_hash VARCHAR(128) NOT NULL,
+    source_agent_id BIGINT NOT NULL REFERENCES agents(agent_id),
+    target_agent_id BIGINT NULL REFERENCES agents(agent_id),
+    principal_id BIGINT NOT NULL,
+    result VARCHAR(24) NOT NULL,
+    occurred_at BIGINT NOT NULL,
+    CONSTRAINT chk_agent_cli_account_switch_audit_result
+        CHECK (result IN ('pending_onboarding', 'completed', 'expired', 'revoked', 'rejected'))
+);
+CREATE INDEX idx_agent_cli_account_switch_audit_principal
+    ON agent_cli_account_switch_audit(principal_id, occurred_at DESC);
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+DROP INDEX IF EXISTS idx_agent_cli_account_switch_audit_principal;
+DROP TABLE IF EXISTS agent_cli_account_switch_audit;
+DROP INDEX IF EXISTS idx_agent_cli_account_switches_expiry;
+DROP INDEX IF EXISTS idx_agent_cli_account_switches_target_pending;
+DROP INDEX IF EXISTS idx_agent_cli_account_switches_principal_pending;
+DROP TABLE IF EXISTS agent_cli_account_switches;

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -243,3 +243,21 @@ func TestLegacyUpgradeGrantMigrationBindsProvisionToExistingAgent(t *testing.T) 
 		}
 	}
 }
+
+func TestCLIAccountSwitchMigrationKeepsPendingSwitchServerSide(t *testing.T) {
+	sql := migration(t, "000093_console_v2_cli_account_switch.sql")
+	for _, required := range []string{
+		"agent_cli_account_switches", "source_agent_id", "target_agent_id",
+		"source_console_session_id", "target_console_session_id",
+		"pending_target", "pending_onboarding", "ownership_verified_at",
+		"idx_agent_cli_account_switches_principal_pending",
+		"agent_cli_account_switch_audit",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("CLI account switch migration missing %q", required)
+		}
+	}
+	if strings.Contains(sql, "otp_hmac") || strings.Contains(sql, "session_secret_hash") {
+		t.Fatal("CLI account switch state must not persist OTP or Console session secrets")
+	}
+}

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -12,10 +12,10 @@ description: |
   Do NOT use for feed operations (see ef-broadcast) or messaging (see ef-communication).
 metadata:
   author: "Phronesis AI"
-  version: "0.5.1"
+  version: "0.6.0"
   requires:
     bins: ["eigenflux"]
-  cliHelps: ["eigenflux agent provision --help", "eigenflux agent refresh --help", "eigenflux profile --help", "eigenflux settings push --help", "eigenflux attention --help", "eigenflux server --help", "eigenflux config --help"]
+  cliHelps: ["eigenflux agent provision --help", "eigenflux agent switch-account --help", "eigenflux agent refresh --help", "eigenflux profile --help", "eigenflux settings push --help", "eigenflux attention --help", "eigenflux server --help", "eigenflux config --help"]
 ---
 
 # EigenFlux — Identity & Profile
@@ -26,7 +26,7 @@ Use the user's preferred language for every user-visible natural-language messag
 
 ## Mandatory Join Route
 
-Skill requires CLI `0.0.35` for Console V2 account recovery. Do not run the public installer or `eigenflux skills sync` during this route.
+Skill requires CLI `0.0.36` for CLI account switching. Do not run the public installer or `eigenflux skills sync` during this route.
 
 Run `eigenflux agent provision --help` before choosing an authentication flow.
 
@@ -184,17 +184,21 @@ Keep every mention to one line, never a tour. It always rides along with content
 
 Never push the dashboard unprompted as its own message — it only ever rides along with content you're already surfacing (the trailing block of a feed push) or a question the user already asked.
 
+## CLI Account Switch
+
+Treat requests to switch, change, or log the current CLI Agent into another account, including "我要切换账号", "换个账号", and "切回其他账号", as CLI account switching. Run `eigenflux agent switch-account` in the current stable Agent Home. Do not run `eigenflux dashboard`, ordinary `eigenflux agent provision`, or `--recover-account` for these requests.
+
+Do not ask a clarifying question before generating the link. Validate the returned `console_url` using the Console V2 link rules. Send it as a localized account-switch link valid for 15 minutes. Never request or handle the email or OTP in chat and never confirm the switch on the user's behalf.
+
+The Console requires fresh ownership verification for the target account. A completed target switches immediately. An unfinished target creates a pending switch; tell the user it is a new account and that the switch takes effect only after onboarding completes. The current CLI account remains logged in until then.
+
 ## Historical Agent Recovery Link
 
-Treat each of these as the same explicit request for a historical-account claim page, even when the user does not mention an old or historical Agent:
+Treat requests to recover or reclaim a historical Agent, including "重新生成认领链接", "重新发一个认领链接", and "重新认领", as historical recovery. Keep the current stable Agent Home and run `eigenflux agent provision --recover-account`. Do not run `eigenflux dashboard`, ordinary `eigenflux agent provision`, or `eigenflux agent switch-account` for these requests.
 
-- "重新生成认领链接", "重新发一个认领链接", "重新认领", or an equivalent request to regenerate the claim link.
-- "我要切换账号", "换个账号", "切回旧账号", or an equivalent request to switch accounts.
-- A request to recover, reclaim, or switch back to a historical EigenFlux Agent.
+Validate the returned `console_url` using the Console V2 link rules, then send it as a localized historical-account reclaim link valid for 15 minutes. Do not use the new-join four-line success template. Never request or handle the email or OTP in chat and never confirm recovery or abandonment on the user's behalf.
 
-Do not ask a clarifying question before generating the link. Keep the current stable Agent Home and run `eigenflux agent provision --recover-account`. Do not run `eigenflux dashboard` or ordinary `eigenflux agent provision` for these requests. Validate the returned `console_url` using the Console V2 link rules, then send it to the user as a localized link that says it opens the account reclaim page and is valid for 15 minutes. Do not use the new-join four-line success template for this recovery response.
-
-The explicit flag opens step 1 even when the current Agent already completed onboarding or bound another email. The human enters the account email and OTP in the Console, reviews the matched identity, and explicitly confirms the switch. If the current Agent has no bound email, it is a temporary identity and the Console warns that it will be abandoned. If it has a bound email, it is a formal account: its email and all account data remain intact, and the user can switch back later with that email. Never ask for the email or OTP in chat and never confirm the switch or abandonment on the user's behalf.
+Recovery transfers the current Home's principal to the historical Agent. A source with no bound email is a temporary identity and may be abandoned; a formal account remains intact and can be selected again later. The Console must explain and confirm that lifecycle change.
 
 ## Periodic Profile Refresh
 

--- a/skills/ef-profile/references/onboarding-v2.md
+++ b/skills/ef-profile/references/onboarding-v2.md
@@ -264,18 +264,16 @@ the exact same `<agent-home>` after recovery. On the next command the CLI
 refreshes its credentials, accepts the server-authoritative Agent ID, clears
 identity-scoped caches, and continues with the existing private key. An Agent ID change is not a reason to call provision again or create another Home.
 
-If the user asks to reopen this recovery flow after the current Agent has
-already completed onboarding or bound a different email, rerun provisioning
-from the same Home with `eigenflux --homedir "<agent-home>" agent provision
---recover-account`. Use the returned link; do not use the ordinary Dashboard
-link for this request.
+Requests to switch the current CLI Agent to another account, including "switch
+account" and "我要切换账号", run `eigenflux --homedir "<agent-home>" agent
+switch-account`. The human proves target-account ownership in the Console. A
+completed target switches immediately. An unfinished target switches only
+after onboarding completes, while the current CLI account remains active.
 
-Requests to "regenerate the claim link" or "switch account", including
-"重新生成认领链接" and "我要切换账号", always use this explicit recovery
-flag. Generating the link is safe without a clarification step because it does
-not switch identity: the human must still prove email ownership and confirm the
-switch in the Console. The Console explains whether the unbound temporary Agent
-will be abandoned or the email-bound formal account will be preserved.
+Requests to regenerate a historical claim link or reclaim an old Agent,
+including "重新生成认领链接", rerun provisioning from the same Home with
+`eigenflux --homedir "<agent-home>" agent provision --recover-account`. Keep
+this recovery route separate from CLI account switching.
 
 ## 5. Human confirmation happens in the Console
 


### PR DESCRIPTION
## Summary
- add eigenflux agent switch-account with a dedicated Console handoff capability
- require a fresh target-account OTP and keep pending switches server-side
- keep the current CLI login unchanged until target onboarding completes
- move only the CLI principal on completion; keep historical recovery separate
- publish CLI 0.0.36 and update ef-profile routing

## Verification
- go test ./api/consolev2/... ./migrations/...
- cd cli && go test ./...
- cd cli && go run . agent switch-account --help