### PR TITLE
fix(console): complete CLI account switches atomically

### DIFF
--- a/api/consolev2/account_switch_handlers.go
+++ b/api/consolev2/account_switch_handlers.go
@@ -67,15 +67,22 @@ func expireCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int6
 	if record.Status != "pending_target" && record.Status != "pending_onboarding" {
 		return nil
 	}
-	if err := tx.Exec(`UPDATE agent_cli_account_switches SET status = 'expired'
-		WHERE switch_id_hash = ? AND status IN ('pending_target', 'pending_onboarding')`, record.SwitchIDHash).Error; err != nil {
-		return err
+	res := tx.Exec(`UPDATE agent_cli_account_switches SET status = 'expired'
+		WHERE switch_id_hash = ? AND status IN ('pending_target', 'pending_onboarding')`, record.SwitchIDHash)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
+		return errConflict
 	}
 	return auditCLIAccountSwitch(tx, record, "expired", now)
 }
 
 func finalizeCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int64) error {
-	if record.TargetAgentID == nil || *record.TargetAgentID <= 0 || record.TargetConsoleSession == "" {
+	if record.SwitchIDHash == "" || record.SourceAgentID <= 0 || record.PrincipalID <= 0 ||
+		record.TargetAgentID == nil || *record.TargetAgentID <= 0 || *record.TargetAgentID == record.SourceAgentID ||
+		record.TargetConsoleSession == "" ||
+		record.OwnershipVerifiedAt == nil || *record.OwnershipVerifiedAt <= 0 || *record.OwnershipVerifiedAt > now {
 		return errConflict
 	}
 	var principal struct {
@@ -111,18 +118,34 @@ func finalizeCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now in
 	if activeCredentials == 0 {
 		return errConflict
 	}
-	if res := tx.Exec(`UPDATE agent_principals SET agent_id = ?, status = 'active', last_seen_at = ?
+	res := tx.Exec(`UPDATE agent_principals SET agent_id = ?, status = 'active', last_seen_at = ?
 		WHERE principal_id = ? AND agent_id = ? AND revoked_at IS NULL`, *record.TargetAgentID, now,
-		record.PrincipalID, record.SourceAgentID); res.Error != nil || res.RowsAffected != 1 {
+		record.PrincipalID, record.SourceAgentID)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
 		return errConflict
 	}
 	if err := tx.Exec(`UPDATE agent_credential_sessions SET scopes = ?, access_refresh_required = TRUE
 		WHERE principal_id = ? AND revoked_at IS NULL`, pq.Array(principalScopesForOnboarding("completed")), record.PrincipalID).Error; err != nil {
 		return err
 	}
-	if res := tx.Exec(`UPDATE agent_cli_account_switches
-		SET status = 'completed', completed_at = ?
-		WHERE switch_id_hash = ? AND status IN ('pending_target', 'pending_onboarding')`, now, record.SwitchIDHash); res.Error != nil || res.RowsAffected != 1 {
+	// Persist the verified target binding and the terminal state in one
+	// statement. A pending_target row deliberately has no target, and the
+	// database CHECK constraint must never observe a fabricated intermediate
+	// pending_onboarding state for an already-completed target account.
+	res = tx.Exec(`UPDATE agent_cli_account_switches
+		SET target_agent_id = ?, target_console_session_id = ?, ownership_verified_at = ?,
+			status = 'completed', completed_at = ?
+		WHERE switch_id_hash = ? AND source_agent_id = ? AND principal_id = ?
+		  AND status IN ('pending_target', 'pending_onboarding')`, *record.TargetAgentID,
+		record.TargetConsoleSession, *record.OwnershipVerifiedAt, now, record.SwitchIDHash,
+		record.SourceAgentID, record.PrincipalID)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
 		return errConflict
 	}
 	record.Status = "completed"
@@ -164,7 +187,7 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 	targetSessionValue, sessionOK := c.Get("console_session_id")
 	targetSessionID, sessionTypeOK := targetSessionValue.(string)
 	now := time.Now().UnixMilli()
-	if !strings.HasPrefix(token, "efas_") || !targetOK || !sessionOK || !sessionTypeOK {
+	if !strings.HasPrefix(token, "efas_") || !targetOK || !sessionOK || !sessionTypeOK || targetSessionID == "" {
 		fail(c, http.StatusBadRequest, "ACCOUNT_SWITCH_INVALID", "CLI account switch is invalid or expired", nil)
 		return
 	}
@@ -173,6 +196,8 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 		return
 	}
 	status := ""
+	resultAgentID := targetAgentID
+	expired := false
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		record, err := loadCLIAccountSwitch(tx, token, true)
 		if err != nil {
@@ -182,9 +207,14 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 			if err := expireCLIAccountSwitch(tx, record, now); err != nil {
 				return err
 			}
-			return errUnauthorized
+			expired = true
+			return nil
 		}
 		if record.Status == "completed" {
+			if record.TargetAgentID == nil || *record.TargetAgentID != targetAgentID {
+				return errConflict
+			}
+			resultAgentID = *record.TargetAgentID
 			status = "completed"
 			return nil
 		}
@@ -203,13 +233,10 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 		}
 		if onboardingState == "completed" {
 			target := targetAgentID
+			verifiedAt := now
 			record.TargetAgentID = &target
 			record.TargetConsoleSession = targetSessionID
-			if err := tx.Exec(`UPDATE agent_cli_account_switches
-				SET target_agent_id = ?, target_console_session_id = ?, ownership_verified_at = ?
-				WHERE switch_id_hash = ?`, targetAgentID, targetSessionID, now, record.SwitchIDHash).Error; err != nil {
-				return err
-			}
+			record.OwnershipVerifiedAt = &verifiedAt
 			if err := finalizeCLIAccountSwitch(tx, record, now); err != nil {
 				return err
 			}
@@ -217,10 +244,14 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 			return nil
 		}
 		if record.Status == "pending_target" {
-			if err := tx.Exec(`UPDATE agent_cli_account_switches SET target_agent_id = ?,
+			res := tx.Exec(`UPDATE agent_cli_account_switches SET target_agent_id = ?,
 				target_console_session_id = ?, ownership_verified_at = ?, status = 'pending_onboarding'
-				WHERE switch_id_hash = ? AND status = 'pending_target'`, targetAgentID, targetSessionID, now, record.SwitchIDHash).Error; err != nil {
-				return err
+				WHERE switch_id_hash = ? AND status = 'pending_target'`, targetAgentID, targetSessionID, now, record.SwitchIDHash)
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected != 1 {
+				return errConflict
 			}
 			target := targetAgentID
 			record.TargetAgentID = &target
@@ -245,9 +276,13 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 		fail(c, http.StatusInternalServerError, "ACCOUNT_SWITCH_FAILED", "could not switch the CLI account", nil)
 		return
 	}
+	if expired {
+		fail(c, http.StatusUnauthorized, "ACCOUNT_SWITCH_INVALID", "CLI account switch is invalid or expired", nil)
+		return
+	}
 	if status == "completed" {
 		s.setCLIAccountSwitchCookie(c, "", -1)
-		reply(c, http.StatusOK, map[string]interface{}{"status": status, "agent_id": fmt.Sprintf("%d", targetAgentID), "refresh_required": true})
+		reply(c, http.StatusOK, map[string]interface{}{"status": status, "agent_id": fmt.Sprintf("%d", resultAgentID), "refresh_required": true})
 		return
 	}
 	reply(c, http.StatusAccepted, map[string]interface{}{

--- a/api/consolev2/account_switch_postgres_test.go
+++ b/api/consolev2/account_switch_postgres_test.go
@@ -1,0 +1,234 @@
+package consolev2
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+)
+
+// This regression exercises PostgreSQL's non-deferrable switch-state CHECK
+// constraints. SQLite/unit tests cannot detect the production failure where a
+// pending_target row was given a target before it became completed.
+func TestPostgresCLIAccountSwitchCompletesAtomically(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fixture struct {
+		record      cliAccountSwitchRecord
+		sourceID    int64
+		targetID    int64
+		principalID int64
+	}
+	seed := func(label string, validTargetSession, storedTarget bool) fixture {
+		t.Helper()
+		now := time.Now().UnixMilli()
+		base := time.Now().UnixNano()
+		sourceID, targetID := base, base+1
+		sourceShortID, shortErr := agentidentity.GenerateShortID()
+		if shortErr != nil {
+			t.Fatal(shortErr)
+		}
+		targetShortID, shortErr := agentidentity.GenerateShortID()
+		if shortErr != nil {
+			t.Fatal(shortErr)
+		}
+		if err := db.Exec(`INSERT INTO agents
+			(agent_id, short_id, email, email_kind, agent_name, bio, created_at, updated_at)
+			VALUES (?, ?, ?, 'internal_alias', 'Switch Source', '', ?, ?),
+			       (?, ?, ?, 'v2_bound', 'Switch Target', '', ?, ?)`,
+			sourceID, sourceShortID, fmt.Sprintf("switch-source-%d@agent.eigenflux.internal", sourceID), now, now,
+			targetID, targetShortID, fmt.Sprintf("switch-target-%d@example.test", targetID), now, now).Error; err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			db.Exec(`DELETE FROM agent_cli_account_switch_audit WHERE source_agent_id = ?`, sourceID)
+			db.Exec(`DELETE FROM agent_cli_account_switches WHERE source_agent_id = ?`, sourceID)
+			db.Exec(`DELETE FROM console_v2_sessions WHERE agent_id IN (?, ?)`, sourceID, targetID)
+			db.Exec(`DELETE FROM agents WHERE agent_id IN (?, ?)`, sourceID, targetID)
+		})
+
+		var sourcePrincipalID, targetPrincipalID int64
+		if err := db.Raw(`INSERT INTO agent_principals
+			(agent_id, key_type, key_fingerprint, public_key, key_version, status, created_at, last_seen_at)
+			VALUES (?, 'ed25519-v1', ?, decode(repeat('11', 32), 'hex'), 1, 'active', ?, ?)
+			RETURNING principal_id`, sourceID, fmt.Sprintf("switch-source-%d", sourceID), now, now).Scan(&sourcePrincipalID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Raw(`INSERT INTO agent_principals
+			(agent_id, key_type, key_fingerprint, public_key, key_version, status, created_at, last_seen_at)
+			VALUES (?, 'ed25519-v1', ?, decode(repeat('22', 32), 'hex'), 1, 'active', ?, ?)
+			RETURNING principal_id`, targetID, fmt.Sprintf("switch-target-%d", targetID), now, now).Scan(&targetPrincipalID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec(`INSERT INTO agent_credential_sessions
+			(principal_id, family_id, access_token_hash, refresh_token_hash, audience, scopes,
+			 issued_at, expires_at, absolute_expires_at, last_seen_at)
+			VALUES (?, ?, ?, ?, 'agent-api', ARRAY['console:handoff:create'], ?, ?, ?, ?)`,
+			sourcePrincipalID, fmt.Sprintf("switch-family-%d", sourceID), fmt.Sprintf("switch-access-%d", sourceID),
+			fmt.Sprintf("switch-refresh-%d", sourceID), now, now+3600000, now+7200000, now).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec(`INSERT INTO agent_context_revisions
+			(agent_id, revision, compiled_context, schema_version, generated_at)
+			VALUES (?, 1, '{}'::jsonb, 1, ?)`, targetID, now).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec(`INSERT INTO agent_onboarding_v2
+			(agent_id, state, current_step, revision, active_context_revision, completed_at, created_at, updated_at)
+			VALUES (?, 'completed', 5, 1, 1, ?, ?, ?)`, targetID, now, now, now).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		sourceSession := fmt.Sprintf("switch-source-session-%d", sourceID)
+		targetSession := fmt.Sprintf("switch-target-session-%d", targetID)
+		if err := db.Exec(`INSERT INTO console_v2_sessions
+			(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash, status, scopes,
+			 issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method, recent_auth_at)
+			VALUES (?, ?, ?, ?, ?, 'active', '{}'::text[], ?, ?, ?, ?, 'handoff', NULL)`,
+			sourceSession, fmt.Sprintf("switch-source-secret-%d", sourceID), sourceID, sourcePrincipalID,
+			fmt.Sprintf("switch-source-csrf-%d", sourceID), now, now+3600000, now+7200000, now).Error; err != nil {
+			t.Fatal(err)
+		}
+		if validTargetSession {
+			if err := db.Exec(`INSERT INTO console_v2_sessions
+				(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash, status, scopes,
+				 issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method, recent_auth_at)
+				VALUES (?, ?, ?, ?, ?, 'active', '{}'::text[], ?, ?, ?, ?, 'email_otp', ?)`,
+				targetSession, fmt.Sprintf("switch-target-secret-%d", targetID), targetID, targetPrincipalID,
+				fmt.Sprintf("switch-target-csrf-%d", targetID), now, now+3600000, now+7200000, now, now).Error; err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		switchHash := fmt.Sprintf("switch-hash-%s-%d", label, sourceID)
+		status := "pending_target"
+		if storedTarget {
+			status = "pending_onboarding"
+			if err := db.Exec(`INSERT INTO agent_cli_account_switches
+				(switch_id_hash, source_agent_id, target_agent_id, principal_id, source_console_session_id,
+				 target_console_session_id, status, ownership_verified_at, expires_at, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, 'pending_onboarding', ?, ?, ?)`, switchHash, sourceID, targetID,
+				sourcePrincipalID, sourceSession, targetSession, now, now+3600000, now).Error; err != nil {
+				t.Fatal(err)
+			}
+		} else if err := db.Exec(`INSERT INTO agent_cli_account_switches
+			(switch_id_hash, source_agent_id, principal_id, source_console_session_id,
+			 status, expires_at, created_at)
+			VALUES (?, ?, ?, ?, 'pending_target', ?, ?)`, switchHash, sourceID, sourcePrincipalID,
+			sourceSession, now+3600000, now).Error; err != nil {
+			t.Fatal(err)
+		}
+		verifiedAt := now
+		return fixture{
+			record: cliAccountSwitchRecord{
+				SwitchIDHash: switchHash, SourceAgentID: sourceID, TargetAgentID: &targetID,
+				PrincipalID: sourcePrincipalID, SourceConsoleSession: sourceSession,
+				TargetConsoleSession: targetSession, Status: status,
+				OwnershipVerifiedAt: &verifiedAt, ExpiresAt: now + 3600000,
+			},
+			sourceID: sourceID, targetID: targetID, principalID: sourcePrincipalID,
+		}
+	}
+
+	t.Run("completed target moves directly from pending_target to completed", func(t *testing.T) {
+		fx := seed("success", true, false)
+		now := time.Now().UnixMilli()
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			return finalizeCLIAccountSwitch(tx, fx.record, now)
+		}); err != nil {
+			t.Fatalf("atomic completion failed: %v", err)
+		}
+		var result struct {
+			Status              string `gorm:"column:status"`
+			TargetAgentID       *int64 `gorm:"column:target_agent_id"`
+			OwnershipVerifiedAt *int64 `gorm:"column:ownership_verified_at"`
+			CompletedAt         *int64 `gorm:"column:completed_at"`
+		}
+		if err := db.Raw(`SELECT status, target_agent_id, ownership_verified_at, completed_at
+			FROM agent_cli_account_switches WHERE switch_id_hash = ?`, fx.record.SwitchIDHash).Scan(&result).Error; err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != "completed" || result.TargetAgentID == nil || *result.TargetAgentID != fx.targetID ||
+			result.OwnershipVerifiedAt == nil || result.CompletedAt == nil {
+			t.Fatalf("switch did not reach a complete terminal state: %#v", result)
+		}
+		var principalAgentID int64
+		if err := db.Raw(`SELECT agent_id FROM agent_principals WHERE principal_id = ?`, fx.principalID).Scan(&principalAgentID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if principalAgentID != fx.targetID {
+			t.Fatalf("principal agent_id=%d, want %d", principalAgentID, fx.targetID)
+		}
+		var refreshed bool
+		if err := db.Raw(`SELECT access_refresh_required FROM agent_credential_sessions
+			WHERE principal_id = ?`, fx.principalID).Scan(&refreshed).Error; err != nil || !refreshed {
+			t.Fatalf("credential refresh flag=%v err=%v", refreshed, err)
+		}
+		var audits int64
+		if err := db.Raw(`SELECT COUNT(*) FROM agent_cli_account_switch_audit
+			WHERE switch_id_hash = ? AND result = 'completed'`, fx.record.SwitchIDHash).Scan(&audits).Error; err != nil || audits != 1 {
+			t.Fatalf("completed audits=%d err=%v", audits, err)
+		}
+	})
+
+	t.Run("onboarding completion retains the verified pending target", func(t *testing.T) {
+		fx := seed("onboarding", true, true)
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			return finalizeCLIAccountSwitch(tx, fx.record, time.Now().UnixMilli())
+		}); err != nil {
+			t.Fatalf("pending onboarding completion failed: %v", err)
+		}
+		var status string
+		var targetID int64
+		if err := db.Raw(`SELECT status, target_agent_id FROM agent_cli_account_switches
+			WHERE switch_id_hash = ?`, fx.record.SwitchIDHash).Row().Scan(&status, &targetID); err != nil {
+			t.Fatal(err)
+		}
+		if status != "completed" || targetID != fx.targetID {
+			t.Fatalf("pending onboarding completed as status=%q target=%d", status, targetID)
+		}
+	})
+
+	t.Run("terminal write failure rolls back principal and credentials", func(t *testing.T) {
+		fx := seed("rollback", false, false)
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return finalizeCLIAccountSwitch(tx, fx.record, time.Now().UnixMilli())
+		})
+		if err == nil {
+			t.Fatal("missing target Console session unexpectedly completed")
+		}
+		var principalAgentID int64
+		if err := db.Raw(`SELECT agent_id FROM agent_principals WHERE principal_id = ?`, fx.principalID).Scan(&principalAgentID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if principalAgentID != fx.sourceID {
+			t.Fatalf("failed transaction moved principal to %d", principalAgentID)
+		}
+		var refreshed bool
+		if err := db.Raw(`SELECT access_refresh_required FROM agent_credential_sessions
+			WHERE principal_id = ?`, fx.principalID).Scan(&refreshed).Error; err != nil || refreshed {
+			t.Fatalf("failed transaction refresh flag=%v err=%v", refreshed, err)
+		}
+		var status string
+		var targetID *int64
+		if err := db.Raw(`SELECT status, target_agent_id FROM agent_cli_account_switches
+			WHERE switch_id_hash = ?`, fx.record.SwitchIDHash).Row().Scan(&status, &targetID); err != nil {
+			t.Fatal(err)
+		}
+		if status != "pending_target" || targetID != nil {
+			t.Fatalf("failed transaction left status=%q target=%v", status, targetID)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- complete already-onboarded CLI account switches in one terminal database update
- preserve the pending_target and pending_onboarding state semantics and existing CHECK constraints
- commit expired confirmations, validate idempotent completed targets, and preserve database errors
- add PostgreSQL regressions for direct completion, onboarding completion, and transactional rollback

## Verification
- go test ./api/consolev2 ./migrations -count=1
- go vet ./api/consolev2
- go test -race ./api/consolev2 -run 'TestCLIAccountSwitch|TestConsoleHandoffTTL' -count=1
- PostgreSQL 16 with migrations 1-93: TestPostgresCLIAccountSwitchCompletesAtomically