### PR TITLE
fix(cli): support identity loading on Windows

### DIFF
--- a/.github/workflows/cli-auth-cross-platform.yml
+++ b/.github/workflows/cli-auth-cross-platform.yml
@@ -1,0 +1,50 @@
+name: CLI Auth Cross-Platform
+
+on:
+  pull_request:
+    paths:
+      - 'cli/internal/auth/**'
+      - 'cli/go.mod'
+      - 'cli/go.sum'
+      - '.github/workflows/cli-auth-cross-platform.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'cli/internal/auth/**'
+      - 'cli/go.mod'
+      - 'cli/go.sum'
+      - '.github/workflows/cli-auth-cross-platform.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  auth-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+      - name: Test identity and credential storage
+        run: go test ./internal/auth -count=1
+      - name: Build Windows test binary
+        if: runner.os == 'Windows'
+        run: |
+          New-Item -ItemType Directory -Force ../build | Out-Null
+          go build -o ../build/eigenflux.exe .
+      - name: Upload Windows test binary
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: eigenflux-windows-identity-fix
+          path: build/eigenflux.exe

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,7 +3,7 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.36
+CLI_VERSION=0.0.37
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients
@@ -12,7 +12,7 @@ SKILLS_REVISION=14
 
 # Monotonic signed release sequence. Every published manifest must increment it;
 # clients reject rollback and sequence reuse with different content.
-SKILLS_SEQUENCE=3
+SKILLS_SEQUENCE=4
 
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a
 # skill starts requiring a newer CLI command, so old CLIs keep their old skills

--- a/cli/internal/auth/credentials_test.go
+++ b/cli/internal/auth/credentials_test.go
@@ -119,8 +119,8 @@ func TestSaveCredentialsAtomic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat error: %v", err)
 	}
-	if perm := info.Mode().Perm(); perm != 0600 {
-		t.Errorf("file permissions = %o, want 0600", perm)
+	if err := validatePrivateFilePermissions(info); err != nil {
+		t.Errorf("created credentials permissions: %v", err)
 	}
 }
 

--- a/cli/internal/auth/identity.go
+++ b/cli/internal/auth/identity.go
@@ -37,8 +37,8 @@ func LoadOrCreateIdentity(serverName string) (ed25519.PublicKey, ed25519.Private
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 			return nil, nil, false, fmt.Errorf("identity path must be a regular file, not a symlink")
 		}
-		if info.Mode().Perm()&0077 != 0 {
-			return nil, nil, false, fmt.Errorf("identity file permissions are too broad; require 0600")
+		if err := validatePrivateFilePermissions(info); err != nil {
+			return nil, nil, false, err
 		}
 		publicKey, privateKey, loadErr := loadIdentity(path)
 		return publicKey, privateKey, false, loadErr

--- a/cli/internal/auth/identity_permissions_unix.go
+++ b/cli/internal/auth/identity_permissions_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package auth
+
+import (
+	"fmt"
+	"os"
+)
+
+func validatePrivateFilePermissions(info os.FileInfo) error {
+	if info.Mode().Perm()&0077 != 0 {
+		return fmt.Errorf("identity file permissions are too broad; require 0600")
+	}
+	return nil
+}

--- a/cli/internal/auth/identity_permissions_unix_test.go
+++ b/cli/internal/auth/identity_permissions_unix_test.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrCreateIdentityRejectsBroadPermissions(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("EIGENFLUX_HOME", dir)
+	if _, _, _, err := LoadOrCreateIdentity("test"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ".eigenflux", "servers", "test", "identity.json")
+	if err := os.Chmod(path, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := LoadOrCreateIdentity("test"); err == nil || !strings.Contains(err.Error(), "require 0600") {
+		t.Fatalf("broad identity permissions error = %v", err)
+	}
+}

--- a/cli/internal/auth/identity_permissions_windows.go
+++ b/cli/internal/auth/identity_permissions_windows.go
@@ -1,0 +1,10 @@
+package auth
+
+import "os"
+
+// Windows reports synthesized POSIX mode bits that do not describe the file's
+// access-control list. The identity path still has to pass the regular-file and
+// symlink checks in LoadOrCreateIdentity.
+func validatePrivateFilePermissions(_ os.FileInfo) error {
+	return nil
+}

--- a/cli/internal/auth/identity_test.go
+++ b/cli/internal/auth/identity_test.go
@@ -26,8 +26,8 @@ func TestLoadOrCreateIdentityIsStableAndPrivate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0600 {
-		t.Fatalf("identity mode=%o want=600", info.Mode().Perm())
+	if err := validatePrivateFilePermissions(info); err != nil {
+		t.Fatalf("created identity permissions: %v", err)
 	}
 	if IdentityFingerprint(publicOne) == "" {
 		t.Fatal("empty identity fingerprint")


### PR DESCRIPTION
## Summary
- keep strict `0600` identity-file validation on Unix platforms
- avoid interpreting synthesized POSIX mode bits as Windows ACLs
- preserve regular-file and symlink validation on every platform
- add Ubuntu and Windows auth tests plus a downloadable Windows test binary

## Verification
- `go test ./internal/auth -count=1`
- `go test ./cmd/... ./internal/... -count=1`
- Windows amd64 auth test cross-compile
- Windows amd64 CLI cross-compile

Related to #208. The issue will remain open for reporter confirmation and planned physical Windows testing.