### PR TITLE
fix(api): preserve bigint friend request cursors

### DIFF
--- a/api/consolev2/communication_handlers.go
+++ b/api/consolev2/communication_handlers.go
@@ -567,9 +567,15 @@ func (s *Service) listCommunicationFriendRequests(_ context.Context, c *app.Requ
 	}
 	var requests []communicationFriendRequest
 	query := `SELECT id, from_uid, to_uid, greeting, ` + remarkProjection + `, created_at FROM friend_requests
-		WHERE status = 0 AND ` + subjectColumn + ` = ? AND (? = 0 OR id < ?)
-		ORDER BY id DESC LIMIT ?`
-	if err := s.db.Raw(query, viewerID, cursor, cursor, limit+1).Scan(&requests).Error; err != nil {
+		WHERE status = 0 AND ` + subjectColumn + ` = ?`
+	args := []interface{}{viewerID}
+	if cursor > 0 {
+		query += ` AND id < ?`
+		args = append(args, cursor)
+	}
+	query += ` ORDER BY id DESC LIMIT ?`
+	args = append(args, limit+1)
+	if err := s.db.Raw(query, args...).Scan(&requests).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "FRIEND_REQUESTS_READ_FAILED", "could not read friend requests", nil)
 		return
 	}

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -1348,6 +1348,12 @@ func testCommunicationProjection(t *testing.T, gdb *gorm.DB, h *server.Hertz, id
 	if len(requests) != 1 || requests[0].(map[string]interface{})["peer_agent_id"] != strconv.FormatInt(requestPeerID, 10) {
 		t.Fatalf("outgoing request did not reference its recipient: %#v", requests)
 	}
+	friendRequestCursor := strconv.FormatInt(requestID+1, 10)
+	status, cursorPayload, _ := performJSON(t, h, "GET", "/api/v2/console/relations/friend-requests?direction=outgoing&cursor="+friendRequestCursor, map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != 200 || len(responseData(t, cursorPayload)["friend_requests"].([]interface{})) != 1 {
+		t.Fatalf("Snowflake friend request cursor failed: status=%d payload=%#v", status, cursorPayload)
+	}
 
 	status, unauthorizedPayload, _ := performJSON(t, h, "GET", fmt.Sprintf("/api/v2/console/pm/conversations/%d/messages", foreignConvID), map[string]interface{}{},
 		ut.Header{Key: "Cookie", Value: cookieHeader})


### PR DESCRIPTION
## Summary
- omit the optional friend request cursor predicate when no cursor is supplied
- bind Snowflake cursor values directly as PostgreSQL bigint-compatible parameters
- cover Snowflake-sized cursor pagination in the PostgreSQL integration flow

## Verification
- `bash scripts/common/build.sh`
- `go test -v ./api/consolev2/... -count=1`
- `./tests/run.sh --skip-start auth`
- `./tests/run.sh --skip-start website` *(existing origin/main template expectations fail; LLM-backed cases also fail with placeholder API keys)*
- `./tests/run.sh --skip-start e2e` *(LLM/profile cases fail because local OpenAI/Volcengine placeholder keys return 401; non-LLM cases pass)*
- `git diff --check`