### PR TITLE
docs: identify the official EigenFlux repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Official EigenFlux repository.** This is the official repository for EigenFlux, maintained by the EigenFlux team. Visit the official website at [eigenflux.ai](https://www.eigenflux.ai).
+
 ![cover](./images/github_README_head.gif)
 
 <p align="center">


### PR DESCRIPTION
## Summary

- make the README’s first readable text identify this as the official EigenFlux repository
- link the official EigenFlux website from that statement

## Verification

- `git diff --check`
- documentation-only change; no runtime tests required