### PR TITLE
fix(console): recover legacy-only email identities

### DIFF
--- a/api/consolev2/recovery_abandon_postgres_test.go
+++ b/api/consolev2/recovery_abandon_postgres_test.go
@@ -141,6 +141,11 @@ func TestHistoricalRecoveryAbandonsUnboundTemporaryAgent(t *testing.T) {
 		VALUES (?, ?, 1, 'verified', 'active', ?, ?, ?)`, targetID, historicalEmail, now, now, now).Error; err != nil {
 		t.Fatal(err)
 	}
+	// Reproduce a legacy-only production identity whose email predates the
+	// Console V2 binding table and was never copied by the one-time backfill.
+	if err := gdb.Exec(`DELETE FROM agent_email_bindings WHERE agent_id = ?`, targetID).Error; err != nil {
+		t.Fatal(err)
+	}
 	if err := gdb.Exec(`INSERT INTO agent_cards
 		(agent_id, public_card, private_card, schema_version, source_version, rebuild_fence,
 		 card_version, public_card_version, generated_at, public_card_generated_at)
@@ -272,7 +277,7 @@ func TestHistoricalRecoveryAbandonsUnboundTemporaryAgent(t *testing.T) {
 	if err := gdb.Raw(`SELECT agent_id FROM agent_principals WHERE principal_id = ?`, principalID).Scan(&movedAgentID).Error; err != nil {
 		t.Fatal(err)
 	}
-	var sourceProjectionCount, sourceBindingCount, relationCount int64
+	var sourceProjectionCount, sourceBindingCount, targetVerifiedBindingCount, relationCount int64
 	if err := gdb.Raw(`SELECT
 		(EXISTS (SELECT 1 FROM agent_onboarding_drafts WHERE agent_id = ?))::int +
 		(EXISTS (SELECT 1 FROM agent_cards WHERE agent_id = ?))::int +
@@ -282,6 +287,11 @@ func TestHistoricalRecoveryAbandonsUnboundTemporaryAgent(t *testing.T) {
 	}
 	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND status = 'active'`, sourceID).
 		Scan(&sourceBindingCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Raw(`SELECT COUNT(*) FROM agent_email_bindings
+		WHERE agent_id = ? AND normalized_email = ? AND status = 'active' AND verification_state = 'verified'`,
+		targetID, historicalEmail).Scan(&targetVerifiedBindingCount).Error; err != nil {
 		t.Fatal(err)
 	}
 	if err := gdb.Raw(`SELECT COUNT(*) FROM friend_requests WHERE id = ? AND from_uid = ? AND to_uid = ?`,
@@ -302,11 +312,11 @@ func TestHistoricalRecoveryAbandonsUnboundTemporaryAgent(t *testing.T) {
 		Row().Scan(&orphanConsoleStatus, &orphanConsoleRevokedAt); err != nil {
 		t.Fatal(err)
 	}
-	if movedAgentID != targetID || sourceProjectionCount != 0 || sourceBindingCount != 0 || relationCount != 1 ||
+	if movedAgentID != targetID || sourceProjectionCount != 0 || sourceBindingCount != 0 || targetVerifiedBindingCount != 1 || relationCount != 1 ||
 		orphanPrincipalStatus != "revoked" || orphanPrincipalRevokedAt == 0 || orphanCredentialRevokedAt == 0 ||
 		orphanConsoleStatus != "revoked" || orphanConsoleRevokedAt == 0 {
-		t.Fatalf("abandonment cleanup mismatch: moved_agent=%d projections=%d bindings=%d relations=%d orphan_principal=%q/%d credential_revoked=%d orphan_console=%q/%d",
-			movedAgentID, sourceProjectionCount, sourceBindingCount, relationCount, orphanPrincipalStatus,
+		t.Fatalf("abandonment cleanup mismatch: moved_agent=%d projections=%d source_bindings=%d target_verified_bindings=%d relations=%d orphan_principal=%q/%d credential_revoked=%d orphan_console=%q/%d",
+			movedAgentID, sourceProjectionCount, sourceBindingCount, targetVerifiedBindingCount, relationCount, orphanPrincipalStatus,
 			orphanPrincipalRevokedAt, orphanCredentialRevokedAt, orphanConsoleStatus, orphanConsoleRevokedAt)
 	}
 

--- a/api/consolev2/recovery_handlers.go
+++ b/api/consolev2/recovery_handlers.go
@@ -193,14 +193,19 @@ func (s *Service) confirmAccountRecovery(_ context.Context, c *app.RequestContex
 			return errUnauthorized
 		}
 
-		var sourceState, targetState string
+		var sourceState string
+		var target struct {
+			IdentityState string `gorm:"column:identity_state"`
+			Email         string `gorm:"column:email"`
+			EmailKind     string `gorm:"column:email_kind"`
+		}
 		if err := tx.Raw(`SELECT identity_state FROM agents WHERE agent_id = ? FOR UPDATE`, recovery.SourceAgentID).Scan(&sourceState).Error; err != nil {
 			return err
 		}
-		if err := tx.Raw(`SELECT identity_state FROM agents WHERE agent_id = ? FOR UPDATE`, recovery.TargetAgentID).Scan(&targetState).Error; err != nil {
+		if err := tx.Raw(`SELECT identity_state, email, email_kind FROM agents WHERE agent_id = ? FOR UPDATE`, recovery.TargetAgentID).Scan(&target).Error; err != nil {
 			return err
 		}
-		if sourceState != "active" || targetState != "active" {
+		if sourceState != "active" || target.IdentityState != "active" {
 			return errConflict
 		}
 		var sourceBindingID int64
@@ -236,7 +241,24 @@ func (s *Service) confirmAccountRecovery(_ context.Context, c *app.RequestContex
 			WHERE agent_id = ? AND status = 'active' FOR UPDATE`, recovery.TargetAgentID).Scan(&binding).Error; err != nil {
 			return err
 		}
-		if binding.BindingID == 0 || keyedHash(s.otpPepper, binding.NormalizedEmail) != recovery.NormalizedEmailHash {
+		if binding.BindingID == 0 {
+			normalizedLegacyEmail := strings.ToLower(strings.TrimSpace(target.Email))
+			if target.EmailKind != "legacy_real" || normalizedLegacyEmail == "" ||
+				keyedHash(s.otpPepper, normalizedLegacyEmail) != recovery.NormalizedEmailHash {
+				return errConflict
+			}
+			binding.NormalizedEmail = normalizedLegacyEmail
+			binding.VerificationState = "verified"
+			if err := tx.Raw(`INSERT INTO agent_email_bindings
+				(agent_id, normalized_email, normalization_version, verification_state, status,
+				 verified_at, created_at, updated_at)
+				VALUES (?, ?, 1, 'verified', 'active', ?, ?, ?)
+				RETURNING binding_id`, recovery.TargetAgentID, normalizedLegacyEmail, now, now, now).
+				Row().Scan(&binding.BindingID); err != nil {
+				return err
+			}
+		}
+		if keyedHash(s.otpPepper, binding.NormalizedEmail) != recovery.NormalizedEmailHash {
 			return errConflict
 		}
 		var emailOwnerCount, suspendedCount int64

--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -44,6 +44,14 @@ temporary identity and is abandoned, while an email-bound Agent is a formal
 account and remains active. Onboarding or source-side activity never blocks the
 switch, and no account data is merged. A successful request:
 
+Historical Agents created before the binding table may have a unique
+`legacy_real` email without an `agent_email_bindings` row. After the owner has
+passed the bound OTP challenge, recovery confirmation accepts that legacy-only
+shape only when the canonical email hash still matches the recovery record. It
+atomically creates the verified active binding before moving the principal;
+duplicate ownership, invalid identity state, or a hash mismatch still fails
+closed.
+
 - moves the current principal to the requested Agent and preserves that Agent's
   data and other principals;
 - switches the Console session and marks current Agent access credentials for


### PR DESCRIPTION
## Summary
- allow historical recovery to materialize a verified binding for unique legacy-only email owners
- keep the fallback inside the locked recovery transaction and validate the OTP-bound email hash
- cover the production data shape with the PostgreSQL recovery regression test

## Verification
- go test ./api/consolev2
- PostgreSQL TestHistoricalRecoveryAbandonsUnboundTemporaryAgent
- bash scripts/common/build.sh