### PR TITLE
fix(console): harden CLI account identity routing

### DIFF
--- a/api/consolev2/account_switch_handlers.go
+++ b/api/consolev2/account_switch_handlers.go
@@ -19,6 +19,8 @@ const (
 	cliAccountSwitchTTL        = 24 * time.Hour
 )
 
+var errRecentEmailAuthRequired = errors.New("recent email authentication required")
+
 type cliAccountSwitchRecord struct {
 	SwitchIDHash         string `gorm:"column:switch_id_hash"`
 	SourceAgentID        int64  `gorm:"column:source_agent_id"`
@@ -76,6 +78,28 @@ func expireCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int6
 		return errConflict
 	}
 	return auditCLIAccountSwitch(tx, record, "expired", now)
+}
+
+func completeNoopCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int64) error {
+	if record.SwitchIDHash == "" || record.SourceAgentID <= 0 || record.PrincipalID <= 0 ||
+		record.TargetAgentID != nil || record.Status != "pending_target" {
+		return errConflict
+	}
+	res := tx.Exec(`UPDATE agent_cli_account_switches
+		SET status = 'completed_noop', completed_at = ?
+		WHERE switch_id_hash = ? AND source_agent_id = ? AND principal_id = ?
+		  AND status = 'pending_target' AND target_agent_id IS NULL`, now, record.SwitchIDHash,
+		record.SourceAgentID, record.PrincipalID)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
+		return errConflict
+	}
+	record.Status = "completed_noop"
+	completedAt := now
+	record.CompletedAt = &completedAt
+	return auditCLIAccountSwitch(tx, record, "completed_noop", now)
 }
 
 func finalizeCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int64) error {
@@ -170,8 +194,14 @@ func (s *Service) getCLIAccountSwitch(_ context.Context, c *app.RequestContext) 
 		_ = s.db.Transaction(func(tx *gorm.DB) error { return expireCLIAccountSwitch(tx, record, now) })
 		record.Status = "expired"
 	}
+	responseStatus := record.Status
+	alreadyCurrent := record.Status == "completed_noop"
+	if alreadyCurrent {
+		responseStatus = "completed"
+	}
 	reply(c, http.StatusOK, map[string]interface{}{
-		"status": record.Status, "source_agent_id": fmt.Sprintf("%d", record.SourceAgentID),
+		"status": responseStatus, "source_agent_id": fmt.Sprintf("%d", record.SourceAgentID),
+		"already_current": alreadyCurrent,
 		"target_agent_id": func() string {
 			if record.TargetAgentID == nil {
 				return ""
@@ -191,13 +221,11 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 		fail(c, http.StatusBadRequest, "ACCOUNT_SWITCH_INVALID", "CLI account switch is invalid or expired", nil)
 		return
 	}
-	if !requireRecentEmailAuth(c, now) {
-		fail(c, http.StatusForbidden, "RECENT_EMAIL_AUTH_REQUIRED", "verify the target account email again before switching the CLI account", map[string]interface{}{"window_seconds": int(recentEmailAuthWindow / time.Second)})
-		return
-	}
 	status := ""
 	resultAgentID := targetAgentID
 	expired := false
+	alreadyCurrent := false
+	recentEmailAuth := requireRecentEmailAuth(c, now)
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		record, err := loadCLIAccountSwitch(tx, token, true)
 		if err != nil {
@@ -218,11 +246,29 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 			status = "completed"
 			return nil
 		}
+		if record.Status == "completed_noop" {
+			if record.SourceAgentID != targetAgentID {
+				return errConflict
+			}
+			resultAgentID = record.SourceAgentID
+			status = "completed"
+			alreadyCurrent = true
+			return nil
+		}
 		if record.Status != "pending_target" && record.Status != "pending_onboarding" {
 			return errUnauthorized
 		}
 		if targetAgentID == record.SourceAgentID {
-			return errConflict
+			if err := completeNoopCLIAccountSwitch(tx, record, now); err != nil {
+				return err
+			}
+			resultAgentID = record.SourceAgentID
+			status = "completed"
+			alreadyCurrent = true
+			return nil
+		}
+		if !recentEmailAuth {
+			return errRecentEmailAuthRequired
 		}
 		if record.Status == "pending_onboarding" && (record.TargetAgentID == nil || *record.TargetAgentID != targetAgentID || record.TargetConsoleSession != targetSessionID) {
 			return errConflict
@@ -272,6 +318,10 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 		fail(c, http.StatusConflict, "ACCOUNT_SWITCH_CONFLICT", "the selected account cannot be used for this CLI switch", nil)
 		return
 	}
+	if errors.Is(err, errRecentEmailAuthRequired) {
+		fail(c, http.StatusForbidden, "RECENT_EMAIL_AUTH_REQUIRED", "verify the target account email again before switching the CLI account", map[string]interface{}{"window_seconds": int(recentEmailAuthWindow / time.Second)})
+		return
+	}
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "ACCOUNT_SWITCH_FAILED", "could not switch the CLI account", nil)
 		return
@@ -282,7 +332,10 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 	}
 	if status == "completed" {
 		s.setCLIAccountSwitchCookie(c, "", -1)
-		reply(c, http.StatusOK, map[string]interface{}{"status": status, "agent_id": fmt.Sprintf("%d", resultAgentID), "refresh_required": true})
+		reply(c, http.StatusOK, map[string]interface{}{
+			"status": status, "agent_id": fmt.Sprintf("%d", resultAgentID),
+			"refresh_required": !alreadyCurrent, "already_current": alreadyCurrent,
+		})
 		return
 	}
 	reply(c, http.StatusAccepted, map[string]interface{}{

--- a/api/consolev2/account_switch_handlers.go
+++ b/api/consolev2/account_switch_handlers.go
@@ -85,6 +85,17 @@ func completeNoopCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, no
 		record.TargetAgentID != nil || record.Status != "pending_target" {
 		return errConflict
 	}
+	if err := validateNoopPrincipalBinding(tx, record); err != nil {
+		return err
+	}
+	var activeCredentials int64
+	if err := tx.Raw(`SELECT COUNT(*) FROM agent_credential_sessions
+		WHERE principal_id = ? AND revoked_at IS NULL AND expires_at > ?`, record.PrincipalID, now).Scan(&activeCredentials).Error; err != nil {
+		return err
+	}
+	if activeCredentials == 0 {
+		return errConflict
+	}
 	res := tx.Exec(`UPDATE agent_cli_account_switches
 		SET status = 'completed_noop', completed_at = ?
 		WHERE switch_id_hash = ? AND source_agent_id = ? AND principal_id = ?
@@ -100,6 +111,23 @@ func completeNoopCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, no
 	completedAt := now
 	record.CompletedAt = &completedAt
 	return auditCLIAccountSwitch(tx, record, "completed_noop", now)
+}
+
+func validateNoopPrincipalBinding(tx *gorm.DB, record cliAccountSwitchRecord) error {
+	var principal struct {
+		AgentID int64  `gorm:"column:agent_id"`
+		KeyType string `gorm:"column:key_type"`
+		Status  string `gorm:"column:status"`
+	}
+	if err := tx.Raw(`SELECT agent_id, key_type, status FROM agent_principals
+		WHERE principal_id = ? AND revoked_at IS NULL FOR UPDATE`, record.PrincipalID).Scan(&principal).Error; err != nil {
+		return err
+	}
+	if principal.AgentID != record.SourceAgentID || principal.KeyType != "ed25519-v1" ||
+		(principal.Status != "limited" && principal.Status != "active") {
+		return errConflict
+	}
+	return nil
 }
 
 func finalizeCLIAccountSwitch(tx *gorm.DB, record cliAccountSwitchRecord, now int64) error {
@@ -191,8 +219,24 @@ func (s *Service) getCLIAccountSwitch(_ context.Context, c *app.RequestContext) 
 	}
 	now := time.Now().UnixMilli()
 	if (record.Status == "pending_target" || record.Status == "pending_onboarding") && record.ExpiresAt < now {
-		_ = s.db.Transaction(func(tx *gorm.DB) error { return expireCLIAccountSwitch(tx, record, now) })
-		record.Status = "expired"
+		err = s.db.Transaction(func(tx *gorm.DB) error {
+			current, loadErr := loadCLIAccountSwitch(tx, token, true)
+			if loadErr != nil {
+				return loadErr
+			}
+			if (current.Status == "pending_target" || current.Status == "pending_onboarding") && current.ExpiresAt < now {
+				if expireErr := expireCLIAccountSwitch(tx, current, now); expireErr != nil {
+					return expireErr
+				}
+				current.Status = "expired"
+			}
+			record = current
+			return nil
+		})
+		if err != nil {
+			fail(c, http.StatusInternalServerError, "ACCOUNT_SWITCH_FAILED", "could not read the CLI account switch", nil)
+			return
+		}
 	}
 	responseStatus := record.Status
 	alreadyCurrent := record.Status == "completed_noop"
@@ -231,13 +275,6 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 		if err != nil {
 			return err
 		}
-		if record.ExpiresAt < now {
-			if err := expireCLIAccountSwitch(tx, record, now); err != nil {
-				return err
-			}
-			expired = true
-			return nil
-		}
 		if record.Status == "completed" {
 			if record.TargetAgentID == nil || *record.TargetAgentID != targetAgentID {
 				return errConflict
@@ -250,9 +287,19 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 			if record.SourceAgentID != targetAgentID {
 				return errConflict
 			}
+			if err := validateNoopPrincipalBinding(tx, record); err != nil {
+				return err
+			}
 			resultAgentID = record.SourceAgentID
 			status = "completed"
 			alreadyCurrent = true
+			return nil
+		}
+		if record.ExpiresAt < now {
+			if err := expireCLIAccountSwitch(tx, record, now); err != nil {
+				return err
+			}
+			expired = true
 			return nil
 		}
 		if record.Status != "pending_target" && record.Status != "pending_onboarding" {
@@ -274,7 +321,7 @@ func (s *Service) confirmCLIAccountSwitch(_ context.Context, c *app.RequestConte
 			return errConflict
 		}
 		var onboardingState string
-		if err := tx.Raw(`SELECT state FROM agent_onboarding_v2 WHERE agent_id = ? FOR UPDATE`, targetAgentID).Scan(&onboardingState).Error; err != nil {
+		if err := tx.Raw(`SELECT state FROM agent_onboarding_v2 WHERE agent_id = ?`, targetAgentID).Scan(&onboardingState).Error; err != nil {
 			return err
 		}
 		if onboardingState == "completed" {

--- a/api/consolev2/account_switch_postgres_test.go
+++ b/api/consolev2/account_switch_postgres_test.go
@@ -1,11 +1,15 @@
 package consolev2
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/cloudwego/hertz/pkg/app"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
@@ -222,6 +226,91 @@ func TestPostgresCLIAccountSwitchCompletesAtomically(t *testing.T) {
 		if err := db.Raw(`SELECT COUNT(*) FROM agent_cli_account_switch_audit
 			WHERE switch_id_hash = ? AND result = 'completed_noop'`, fx.record.SwitchIDHash).Scan(&audits).Error; err != nil || audits != 1 {
 			t.Fatalf("completed_noop audits=%d err=%v", audits, err)
+		}
+	})
+
+	t.Run("current account handler needs no recent email auth and is idempotent", func(t *testing.T) {
+		fx := seed("handler-noop", false, false)
+		token := fmt.Sprintf("efas_handler-noop-%d", fx.sourceID)
+		if err := db.Exec(`UPDATE agent_cli_account_switches SET switch_id_hash = ?
+			WHERE switch_id_hash = ?`, hashString(token), fx.record.SwitchIDHash).Error; err != nil {
+			t.Fatal(err)
+		}
+		fx.record.SwitchIDHash = hashString(token)
+		service := &Service{db: db}
+
+		confirm := func() map[string]interface{} {
+			t.Helper()
+			request := app.NewContext(0)
+			request.Request.Header.Set("Cookie", cliAccountSwitchCookieName+"="+token)
+			request.Set("agent_id", fx.sourceID)
+			request.Set("console_session_id", fx.record.SourceConsoleSession)
+			service.confirmCLIAccountSwitch(context.Background(), request)
+			if request.Response.StatusCode() != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", request.Response.StatusCode(), request.Response.Body())
+			}
+			var envelope struct {
+				Data map[string]interface{} `json:"data"`
+			}
+			if err := json.Unmarshal(request.Response.Body(), &envelope); err != nil {
+				t.Fatal(err)
+			}
+			setCookies := request.Response.Header.PeekAll("Set-Cookie")
+			parsedHeaders := http.Header{}
+			for _, cookie := range setCookies {
+				parsedHeaders.Add("Set-Cookie", string(cookie))
+			}
+			cleared := false
+			for _, cookie := range (&http.Response{Header: parsedHeaders}).Cookies() {
+				if cookie.Name == cliAccountSwitchCookieName && cookie.Value == "" &&
+					(cookie.MaxAge < 0 || (!cookie.Expires.IsZero() && cookie.Expires.Before(time.Now()))) {
+					cleared = true
+				}
+			}
+			if !cleared {
+				t.Fatalf("completed response did not clear switch cookie: %q", setCookies)
+			}
+			return envelope.Data
+		}
+
+		for attempt := 1; attempt <= 2; attempt++ {
+			data := confirm()
+			if data["status"] != "completed" || data["agent_id"] != fmt.Sprintf("%d", fx.sourceID) ||
+				data["already_current"] != true || data["refresh_required"] != false {
+				t.Fatalf("attempt %d returned unexpected no-op response: %#v", attempt, data)
+			}
+			if attempt == 1 {
+				if err := db.Exec(`UPDATE agent_cli_account_switches SET expires_at = ?
+					WHERE switch_id_hash = ?`, time.Now().Add(-time.Minute).UnixMilli(), fx.record.SwitchIDHash).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		var audits int64
+		if err := db.Raw(`SELECT COUNT(*) FROM agent_cli_account_switch_audit
+			WHERE switch_id_hash = ? AND result = 'completed_noop'`, fx.record.SwitchIDHash).Scan(&audits).Error; err != nil || audits != 1 {
+			t.Fatalf("idempotent completed_noop audits=%d err=%v", audits, err)
+		}
+	})
+
+	t.Run("current account completion rejects a principal already moved elsewhere", func(t *testing.T) {
+		fx := seed("noop-moved", false, false)
+		if err := db.Exec(`UPDATE agent_principals SET agent_id = ? WHERE principal_id = ?`, fx.targetID, fx.principalID).Error; err != nil {
+			t.Fatal(err)
+		}
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return completeNoopCLIAccountSwitch(tx, fx.record, time.Now().UnixMilli())
+		})
+		if err == nil {
+			t.Fatal("no-op completed after the principal moved to another Agent")
+		}
+		var status string
+		if err := db.Raw(`SELECT status FROM agent_cli_account_switches
+			WHERE switch_id_hash = ?`, fx.record.SwitchIDHash).Scan(&status).Error; err != nil {
+			t.Fatal(err)
+		}
+		if status != "pending_target" {
+			t.Fatalf("rejected no-op left status=%q", status)
 		}
 	})
 

--- a/api/consolev2/account_switch_postgres_test.go
+++ b/api/consolev2/account_switch_postgres_test.go
@@ -183,6 +183,48 @@ func TestPostgresCLIAccountSwitchCompletesAtomically(t *testing.T) {
 		}
 	})
 
+	t.Run("current account completes without moving credentials", func(t *testing.T) {
+		fx := seed("noop", false, false)
+		fx.record.TargetAgentID = nil
+		fx.record.TargetConsoleSession = ""
+		fx.record.OwnershipVerifiedAt = nil
+		now := time.Now().UnixMilli()
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			return completeNoopCLIAccountSwitch(tx, fx.record, now)
+		}); err != nil {
+			t.Fatalf("no-op completion failed: %v", err)
+		}
+		var result struct {
+			Status        string `gorm:"column:status"`
+			TargetAgentID *int64 `gorm:"column:target_agent_id"`
+			CompletedAt   *int64 `gorm:"column:completed_at"`
+		}
+		if err := db.Raw(`SELECT status, target_agent_id, completed_at
+			FROM agent_cli_account_switches WHERE switch_id_hash = ?`, fx.record.SwitchIDHash).Scan(&result).Error; err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != "completed_noop" || result.TargetAgentID != nil || result.CompletedAt == nil {
+			t.Fatalf("same-account switch did not reach no-op terminal state: %#v", result)
+		}
+		var principalAgentID int64
+		if err := db.Raw(`SELECT agent_id FROM agent_principals WHERE principal_id = ?`, fx.principalID).Scan(&principalAgentID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if principalAgentID != fx.sourceID {
+			t.Fatalf("no-op switch moved principal to %d", principalAgentID)
+		}
+		var refreshed bool
+		if err := db.Raw(`SELECT access_refresh_required FROM agent_credential_sessions
+			WHERE principal_id = ?`, fx.principalID).Scan(&refreshed).Error; err != nil || refreshed {
+			t.Fatalf("no-op switch refresh flag=%v err=%v", refreshed, err)
+		}
+		var audits int64
+		if err := db.Raw(`SELECT COUNT(*) FROM agent_cli_account_switch_audit
+			WHERE switch_id_hash = ? AND result = 'completed_noop'`, fx.record.SwitchIDHash).Scan(&audits).Error; err != nil || audits != 1 {
+			t.Fatalf("completed_noop audits=%d err=%v", audits, err)
+		}
+	})
+
 	t.Run("onboarding completion retains the verified pending target", func(t *testing.T) {
 		fx := seed("onboarding", true, true)
 		if err := db.Transaction(func(tx *gorm.DB) error {

--- a/api/consolev2/capability_registry.go
+++ b/api/consolev2/capability_registry.go
@@ -77,6 +77,7 @@ func capabilitySeeds() []capabilitySeed {
 		capability("capabilities.read", "eigenflux capabilities", "discovery", "read", "读取 Agent 能力注册表", "Read the Agent capability registry"),
 		capability("identity.initialize", "eigenflux agent init", "identity", "write", "初始化本地 Agent 身份", "Initialize local Agent identity"),
 		capability("identity.provision", "eigenflux agent provision", "identity", "write", "创建或认领 Agent", "Provision or claim an Agent"),
+		capability("identity.recover_account", "eigenflux agent provision --recover-account", "identity", "write", "恢复历史 Agent", "Recover a historical Agent"),
 		capability("identity.switch_account", "eigenflux agent switch-account", "identity", "write", "切换 CLI 登录账号", "Switch the CLI account"),
 		capability("identity.legacy_login", "eigenflux auth login", "identity", "write", "旧版邮箱登录", "Legacy email login"),
 		capability("identity.legacy_verify", "eigenflux auth verify", "identity", "write", "验证旧版邮箱登录", "Verify legacy email login"),
@@ -172,8 +173,15 @@ func capabilitySeeds() []capabilitySeed {
 	}
 	for index := range seeds {
 		seed := &seeds[index]
+		if (seed.category == "profile" || seed.category == "context" || seed.category == "settings") &&
+			(seed.access == "write" || seed.access == "read_write") {
+			seed.identityRoute = "current_identity"
+		}
+		if seed.id == "identity.legacy_login" || seed.id == "identity.legacy_verify" || seed.id == "identity.logout" {
+			seed.identityRoute, seed.availability = "legacy_only", "legacy_only"
+		}
 		switch seed.id {
-		case "identity.switch_account", "identity.provision":
+		case "identity.switch_account", "identity.provision", "identity.recover_account":
 			seed.risk, seed.confirmation = "verified", "console_handoff"
 		case "context.security.update", "settings.recurring_publish.update", "settings.auto_reply_pm.update", "settings.auto_comment.update", "attention.respond", "relation.block", "broadcast.publish", "broadcast.delete":
 			seed.risk = "elevated"
@@ -187,8 +195,7 @@ func capabilitySeeds() []capabilitySeed {
 			seed.confirmation = "explicit_current_action_selection"
 		}
 		if seed.category == "local" || seed.id == "capabilities.read" || seed.id == "version.read" || seed.id == "diagnostics.run" ||
-			seed.id == "identity.initialize" || seed.id == "identity.provision" || seed.id == "identity.legacy_login" ||
-			seed.id == "identity.legacy_verify" || seed.id == "identity.logout" {
+			seed.id == "identity.initialize" || seed.id == "identity.provision" || seed.id == "identity.recover_account" {
 			seed.availability = "always"
 		}
 		if seed.id == "attention.prefill" {
@@ -205,6 +212,12 @@ func capabilitySeeds() []capabilitySeed {
 			seed.identityRoute, seed.requiresConsoleHandoff = "provision", true
 			seed.zh.Description = "仅用于创建或明确认领 Agent，不用于修改 Agent Card 或切换账号"
 			seed.en.Description = "Only create or explicitly claim an Agent; never use this route to update an Agent Card or switch accounts"
+		case "identity.recover_account":
+			seed.identityRoute, seed.requiresConsoleHandoff, seed.minCLI = "recover_account", true, "0.0.39"
+			seed.zh.Description = "仅用于恢复历史 Agent，不用于修改 Agent Card、初次接入或切换账号"
+			seed.en.Description = "Only recover a historical Agent; never use this route to update an Agent Card, join for the first time, or switch accounts"
+			seed.zh.SemanticHints = []string{"恢复历史 Agent", "重新认领"}
+			seed.en.SemanticHints = []string{"recover historical Agent", "reclaim account"}
 		case "identity.switch_account":
 			seed.identityRoute, seed.requiresConsoleHandoff = "switch_account", true
 			seed.sameAccountBehavior = "confirm_without_change"

--- a/api/consolev2/capability_registry.go
+++ b/api/consolev2/capability_registry.go
@@ -23,19 +23,22 @@ type capabilityText struct {
 }
 
 type capabilityOperation struct {
-	OperationID   string                    `json:"operation_id"`
-	CLI           string                    `json:"cli"`
-	Category      string                    `json:"category"`
-	Access        string                    `json:"access"`
-	Risk          string                    `json:"risk"`
-	Confirmation  string                    `json:"confirmation"`
-	Availability  string                    `json:"availability"`
-	MinCLIVersion string                    `json:"min_cli_version"`
-	Localized     map[string]capabilityText `json:"localized"`
-	Label         string                    `json:"label"`
-	Description   string                    `json:"description"`
-	SemanticHints []string                  `json:"semantic_hints,omitempty"`
-	AllowedValues []string                  `json:"allowed_values,omitempty"`
+	OperationID            string                    `json:"operation_id"`
+	CLI                    string                    `json:"cli"`
+	Category               string                    `json:"category"`
+	Access                 string                    `json:"access"`
+	Risk                   string                    `json:"risk"`
+	Confirmation           string                    `json:"confirmation"`
+	Availability           string                    `json:"availability"`
+	MinCLIVersion          string                    `json:"min_cli_version"`
+	IdentityRoute          string                    `json:"identity_route"`
+	RequiresConsoleHandoff bool                      `json:"requires_console_handoff"`
+	SameAccountBehavior    string                    `json:"same_account_behavior,omitempty"`
+	Localized              map[string]capabilityText `json:"localized"`
+	Label                  string                    `json:"label"`
+	Description            string                    `json:"description"`
+	SemanticHints          []string                  `json:"semantic_hints,omitempty"`
+	AllowedValues          []string                  `json:"allowed_values,omitempty"`
 }
 
 type capabilityField struct {
@@ -51,6 +54,8 @@ type capabilityField struct {
 
 type capabilitySeed struct {
 	id, cli, category, access, risk, confirmation, availability, minCLI string
+	identityRoute, sameAccountBehavior                                  string
+	requiresConsoleHandoff                                              bool
 	zh, en                                                              capabilityText
 }
 
@@ -61,7 +66,7 @@ func capability(id, cli, category, access, zhLabel, enLabel string) capabilitySe
 	}
 	return capabilitySeed{
 		id: id, cli: cli, category: category, access: access,
-		risk: "normal", confirmation: confirmation, availability: "completed", minCLI: "0.0.37",
+		risk: "normal", confirmation: confirmation, availability: "completed", minCLI: "0.0.37", identityRoute: "none",
 		zh: capabilityText{Label: zhLabel, Description: zhLabel},
 		en: capabilityText{Label: enLabel, Description: enLabel},
 	}
@@ -196,7 +201,15 @@ func capabilitySeeds() []capabilitySeed {
 			seed.confirmation = "policy_governed"
 		}
 		switch seed.id {
+		case "identity.provision":
+			seed.identityRoute, seed.requiresConsoleHandoff = "provision", true
+			seed.zh.Description = "仅用于创建或明确认领 Agent，不用于修改 Agent Card 或切换账号"
+			seed.en.Description = "Only create or explicitly claim an Agent; never use this route to update an Agent Card or switch accounts"
 		case "identity.switch_account":
+			seed.identityRoute, seed.requiresConsoleHandoff = "switch_account", true
+			seed.sameAccountBehavior = "confirm_without_change"
+			seed.zh.Description = "仅切换当前 CLI 绑定账号；选择当前账号时直接确认且不修改凭据"
+			seed.en.Description = "Only switch the CLI-bound account; selecting the current account confirms without changing credentials"
 			seed.zh.SemanticHints = []string{"切换账号", "换登录账号", "使用另一个账号"}
 			seed.en.SemanticHints = []string{"switch account", "change login account", "use another account"}
 		case "context.goal.update":
@@ -215,6 +228,8 @@ func capabilitySeeds() []capabilitySeed {
 			seed.zh.SemanticHints = []string{"忽略 Attention", "关闭待决策事项"}
 			seed.en.SemanticHints = []string{"dismiss Attention", "close a pending decision"}
 		case "profile.update":
+			seed.zh.Description = "使用当前 CLI 身份修改 Agent Card；不登录、不认领、不切换账号"
+			seed.en.Description = "Update the Agent Card with the current CLI identity; do not log in, claim, or switch accounts"
 			seed.zh.SemanticHints = []string{"修改 Agent Card", "更新资料"}
 			seed.en.SemanticHints = []string{"change Agent Card", "update profile"}
 		case "settings.feed_poll_interval.update", "settings.official_pm_optout.update", "settings.feed_delivery_preference.update", "settings.language.update", "settings.show_add_friend.update":
@@ -256,7 +271,9 @@ func buildAgentCapabilityRegistry(language string, controlEnabled, attentionEnab
 		operation := capabilityOperation{
 			OperationID: seed.id, CLI: seed.cli, Category: seed.category, Access: seed.access,
 			Risk: seed.risk, Confirmation: seed.confirmation, Availability: availability,
-			MinCLIVersion: seed.minCLI, Localized: localized, Label: selected.Label,
+			MinCLIVersion: seed.minCLI, IdentityRoute: seed.identityRoute,
+			RequiresConsoleHandoff: seed.requiresConsoleHandoff, SameAccountBehavior: seed.sameAccountBehavior,
+			Localized: localized, Label: selected.Label,
 			Description: selected.Description, SemanticHints: selected.SemanticHints,
 		}
 		if seed.id == "settings.language.update" {

--- a/api/consolev2/capability_registry_test.go
+++ b/api/consolev2/capability_registry_test.go
@@ -87,6 +87,29 @@ func TestAgentCapabilityRegistryReflectsFeatureFlags(t *testing.T) {
 	}
 }
 
+func TestAgentCapabilityRegistrySeparatesIdentityRoutes(t *testing.T) {
+	registry := buildAgentCapabilityRegistry("zh-CN", true, true)
+	operations := registry["operations"].([]capabilityOperation)
+	byID := make(map[string]capabilityOperation, len(operations))
+	for _, operation := range operations {
+		byID[operation.OperationID] = operation
+	}
+
+	profile := byID["profile.update"]
+	if profile.IdentityRoute != "none" || profile.RequiresConsoleHandoff {
+		t.Fatalf("profile.update identity route = %#v", profile)
+	}
+	provision := byID["identity.provision"]
+	if provision.IdentityRoute != "provision" || !provision.RequiresConsoleHandoff {
+		t.Fatalf("identity.provision route = %#v", provision)
+	}
+	switchAccount := byID["identity.switch_account"]
+	if switchAccount.IdentityRoute != "switch_account" || !switchAccount.RequiresConsoleHandoff ||
+		switchAccount.SameAccountBehavior != "confirm_without_change" {
+		t.Fatalf("identity.switch_account route = %#v", switchAccount)
+	}
+}
+
 func TestAgentCapabilityRegistrySupportsETagRevalidation(t *testing.T) {
 	service := &Service{enableControl: true, enableAttentionV1: true}
 	first := app.NewContext(0)

--- a/api/consolev2/capability_registry_test.go
+++ b/api/consolev2/capability_registry_test.go
@@ -30,7 +30,7 @@ func TestAgentCapabilityRegistryIsBilingualAndStable(t *testing.T) {
 		}
 	}
 	for _, required := range []string{
-		"identity.switch_account", "profile.update", "context.goal.update", "context.intent.update",
+		"identity.switch_account", "identity.recover_account", "profile.update", "context.goal.update", "context.intent.update",
 		"context.security.update", "attention.respond", "message.send", "relation.request", "settings.language.update",
 	} {
 		if !seen[required] {
@@ -96,12 +96,32 @@ func TestAgentCapabilityRegistrySeparatesIdentityRoutes(t *testing.T) {
 	}
 
 	profile := byID["profile.update"]
-	if profile.IdentityRoute != "none" || profile.RequiresConsoleHandoff {
+	if profile.IdentityRoute != "current_identity" || profile.RequiresConsoleHandoff {
 		t.Fatalf("profile.update identity route = %#v", profile)
+	}
+	for _, operationID := range []string{"context.goal.update", "context.intent.update", "context.security.update", "settings.language.update"} {
+		operation := byID[operationID]
+		if operation.IdentityRoute != "current_identity" || operation.RequiresConsoleHandoff {
+			t.Fatalf("%s identity route = %#v", operationID, operation)
+		}
+	}
+	legacyProfile := byID["profile.legacy_update"]
+	if legacyProfile.IdentityRoute != "current_identity" || legacyProfile.Availability != "completed" || legacyProfile.RequiresConsoleHandoff {
+		t.Fatalf("profile.legacy_update compatibility route = %#v", legacyProfile)
+	}
+	for _, operationID := range []string{"identity.legacy_login", "identity.legacy_verify", "identity.logout"} {
+		operation := byID[operationID]
+		if operation.IdentityRoute != "legacy_only" || operation.Availability != "legacy_only" || operation.RequiresConsoleHandoff {
+			t.Fatalf("%s legacy route = %#v", operationID, operation)
+		}
 	}
 	provision := byID["identity.provision"]
 	if provision.IdentityRoute != "provision" || !provision.RequiresConsoleHandoff {
 		t.Fatalf("identity.provision route = %#v", provision)
+	}
+	recovery := byID["identity.recover_account"]
+	if recovery.IdentityRoute != "recover_account" || !recovery.RequiresConsoleHandoff || recovery.MinCLIVersion != "0.0.39" {
+		t.Fatalf("identity.recover_account route = %#v", recovery)
 	}
 	switchAccount := byID["identity.switch_account"]
 	if switchAccount.IdentityRoute != "switch_account" || !switchAccount.RequiresConsoleHandoff ||

--- a/cli/cmd/agent_switch_account.go
+++ b/cli/cmd/agent_switch_account.go
@@ -13,8 +13,9 @@ var agentV2SwitchAccountCmd = &cobra.Command{
 	Use:   "switch-account",
 	Short: "Switch this Agent Home to another EigenFlux account",
 	Long: `Create a short-lived Console link for replacing the account used by this
-Agent Home. The target account must be verified in the Console. The current CLI
-login remains active until the target account has completed onboarding.`,
+Agent Home. Selecting the current account confirms it without changing credentials.
+A different target account must be verified in the Console. The current CLI login
+remains active until a new target account has completed onboarding.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		v2Client, server, err := newV2ClientForServer(serverFlag, true)

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -46,7 +46,7 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 			t.Errorf("ef-profile frontmatter is missing account recovery trigger %q", trigger)
 		}
 	}
-	if !strings.Contains(frontmatterParts[1], `version: "0.8.0"`) {
+	if !strings.Contains(frontmatterParts[1], `version: "0.8.1"`) {
 		t.Error("ef-profile version was not advanced for V1 retirement")
 	}
 	for _, retired := range []string{"auth.md", "onboarding.md"} {

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -32,6 +32,11 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 		"eigenflux agent switch-account",
 		"Do not ask a clarifying question before generating the link",
 		"Do not use the new-join four-line success template",
+		"## Mandatory Intent Routing",
+		"Keep these routes mutually exclusive",
+		"A successful `eigenflux capabilities` or `eigenflux profile refresh-context` call confirms this route",
+		"no active authenticated account",
+		"Do not start provisioning, recovery, account switching, email verification, or OTP handling",
 	} {
 		if !strings.Contains(skill, required) {
 			t.Errorf("ef-profile is missing mandatory Console V2 routing text %q", required)
@@ -58,6 +63,15 @@ func TestProfileSkillRoutesSupportedCLIToConsoleV2(t *testing.T) {
 	for _, lifecycleRule := range []string{"no bound email", "temporary identity", "formal account", "selected again later"} {
 		if !strings.Contains(skill, lifecycleRule) {
 			t.Errorf("ef-profile skill is missing account lifecycle rule %q", lifecycleRule)
+		}
+	}
+	switchHelpBody, err := os.ReadFile(filepath.Join(repoRoot, "cli/cmd/agent_switch_account.go"))
+	if err != nil {
+		t.Fatalf("read switch-account command: %v", err)
+	}
+	for _, required := range []string{"Selecting the current account confirms it without changing credentials", "A different target account must be verified"} {
+		if !strings.Contains(string(switchHelpBody), required) {
+			t.Errorf("switch-account help is missing same-account contract %q", required)
 		}
 	}
 	for _, capabilityRule := range []string{

--- a/migrations/000096_console_v2_cli_account_switch_noop.sql
+++ b/migrations/000096_console_v2_cli_account_switch_noop.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_status;
+ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_target;
+ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_completion;
+ALTER TABLE agent_cli_account_switch_audit DROP CONSTRAINT chk_agent_cli_account_switch_audit_result;
+
+ALTER TABLE agent_cli_account_switches
+    ADD CONSTRAINT chk_agent_cli_account_switches_status
+        CHECK (status IN ('pending_target', 'pending_onboarding', 'completed', 'completed_noop', 'expired', 'revoked')),
+    ADD CONSTRAINT chk_agent_cli_account_switches_target
+        CHECK ((status IN ('pending_target', 'completed_noop') AND target_agent_id IS NULL AND target_console_session_id IS NULL)
+            OR (status IN ('pending_onboarding', 'completed') AND target_agent_id IS NOT NULL AND target_console_session_id IS NOT NULL)
+            OR status IN ('expired', 'revoked')),
+    ADD CONSTRAINT chk_agent_cli_account_switches_completion
+        CHECK ((status IN ('completed', 'completed_noop') AND completed_at IS NOT NULL)
+            OR (status NOT IN ('completed', 'completed_noop') AND completed_at IS NULL));
+
+ALTER TABLE agent_cli_account_switch_audit
+    ADD CONSTRAINT chk_agent_cli_account_switch_audit_result
+        CHECK (result IN ('pending_onboarding', 'completed', 'completed_noop', 'expired', 'revoked', 'rejected'));
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_status;
+ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_target;
+ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_completion;
+ALTER TABLE agent_cli_account_switch_audit DROP CONSTRAINT chk_agent_cli_account_switch_audit_result;
+
+UPDATE agent_cli_account_switch_audit SET result = 'revoked' WHERE result = 'completed_noop';
+UPDATE agent_cli_account_switches SET status = 'revoked', completed_at = NULL WHERE status = 'completed_noop';
+
+ALTER TABLE agent_cli_account_switches
+    ADD CONSTRAINT chk_agent_cli_account_switches_status
+        CHECK (status IN ('pending_target', 'pending_onboarding', 'completed', 'expired', 'revoked')),
+    ADD CONSTRAINT chk_agent_cli_account_switches_target
+        CHECK ((status = 'pending_target' AND target_agent_id IS NULL AND target_console_session_id IS NULL)
+            OR (status IN ('pending_onboarding', 'completed') AND target_agent_id IS NOT NULL AND target_console_session_id IS NOT NULL)
+            OR status IN ('expired', 'revoked')),
+    ADD CONSTRAINT chk_agent_cli_account_switches_completion
+        CHECK ((status = 'completed' AND completed_at IS NOT NULL)
+            OR (status <> 'completed' AND completed_at IS NULL));
+
+ALTER TABLE agent_cli_account_switch_audit
+    ADD CONSTRAINT chk_agent_cli_account_switch_audit_result
+        CHECK (result IN ('pending_onboarding', 'completed', 'expired', 'revoked', 'rejected'));

--- a/migrations/000096_console_v2_cli_account_switch_noop.sql
+++ b/migrations/000096_console_v2_cli_account_switch_noop.sql
@@ -26,13 +26,18 @@ ALTER TABLE agent_cli_account_switch_audit
 SET LOCAL lock_timeout = '5s';
 SET LOCAL statement_timeout = '30s';
 
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM agent_cli_account_switches WHERE status = 'completed_noop')
+        OR EXISTS (SELECT 1 FROM agent_cli_account_switch_audit WHERE result = 'completed_noop') THEN
+        RAISE EXCEPTION 'cannot downgrade while completed_noop account-switch history exists';
+    END IF;
+END $$;
+
 ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_status;
 ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_target;
 ALTER TABLE agent_cli_account_switches DROP CONSTRAINT chk_agent_cli_account_switches_completion;
 ALTER TABLE agent_cli_account_switch_audit DROP CONSTRAINT chk_agent_cli_account_switch_audit_result;
-
-UPDATE agent_cli_account_switch_audit SET result = 'revoked' WHERE result = 'completed_noop';
-UPDATE agent_cli_account_switches SET status = 'revoked', completed_at = NULL WHERE status = 'completed_noop';
 
 ALTER TABLE agent_cli_account_switches
     ADD CONSTRAINT chk_agent_cli_account_switches_status

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -262,6 +262,25 @@ func TestCLIAccountSwitchMigrationKeepsPendingSwitchServerSide(t *testing.T) {
 	}
 }
 
+func TestCLIAccountSwitchNoopMigrationAddsTerminalState(t *testing.T) {
+	sql := migration(t, "000096_console_v2_cli_account_switch_noop.sql")
+	up, down, ok := strings.Cut(sql, "-- +goose Down")
+	if !ok {
+		t.Fatal("CLI account-switch no-op migration has no Down boundary")
+	}
+	for _, required := range []string{
+		"completed_noop", "target_agent_id IS NULL", "completed_at IS NOT NULL",
+		"chk_agent_cli_account_switch_audit_result",
+	} {
+		if !strings.Contains(up, required) {
+			t.Fatalf("CLI account-switch no-op migration missing %q", required)
+		}
+	}
+	if !strings.Contains(down, "SET status = 'revoked', completed_at = NULL WHERE status = 'completed_noop'") {
+		t.Fatal("CLI account-switch no-op migration does not normalize rows before rollback")
+	}
+}
+
 func TestAgentCapabilityScopeMigrationRepairsOnlyActiveCompletedSessions(t *testing.T) {
 	sql := migration(t, "000094_console_v2_agent_context_write.sql")
 	for _, required := range []string{

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -39,6 +39,23 @@ func TestShortIDMigrationDownFailsClosed(t *testing.T) {
 	}
 }
 
+func TestCLIAccountSwitchNoopMigrationDownPreservesAuditHistory(t *testing.T) {
+	sql := migration(t, "000096_console_v2_cli_account_switch_noop.sql")
+	up, down, ok := strings.Cut(sql, "-- +goose Down")
+	if !ok {
+		t.Fatal("CLI account-switch no-op migration has no Down boundary")
+	}
+	guard := "cannot downgrade while completed_noop account-switch history exists"
+	if strings.Contains(up, guard) || !strings.Contains(down, guard) {
+		t.Fatal("completed_noop downgrade guard must fail closed in Down only")
+	}
+	for _, destructiveRewrite := range []string{"SET result = 'revoked'", "SET status = 'revoked'"} {
+		if strings.Contains(down, destructiveRewrite) {
+			t.Fatalf("Down must not rewrite completed_noop audit history with %q", destructiveRewrite)
+		}
+	}
+}
+
 func TestShortIDBackfillUsesOneSetBasedStatementPerBatch(t *testing.T) {
 	raw, err := os.ReadFile("../scripts/common/agent_short_id_backfill.go")
 	if err != nil {
@@ -276,8 +293,8 @@ func TestCLIAccountSwitchNoopMigrationAddsTerminalState(t *testing.T) {
 			t.Fatalf("CLI account-switch no-op migration missing %q", required)
 		}
 	}
-	if !strings.Contains(down, "SET status = 'revoked', completed_at = NULL WHERE status = 'completed_noop'") {
-		t.Fatal("CLI account-switch no-op migration does not normalize rows before rollback")
+	if !strings.Contains(down, "cannot downgrade while completed_noop account-switch history exists") {
+		t.Fatal("CLI account-switch no-op migration must fail closed instead of rewriting terminal history")
 	}
 }
 

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -228,6 +228,8 @@ If the CLI reports `remote mutation committed`, refresh with `eigenflux context 
 
 An authenticated Agent Card mutation never requires Console login, account recovery, identity provisioning, or CLI account switching. If `eigenflux capabilities` or `eigenflux profile refresh-context` succeeds, continue with the mapped mutation under the same CLI identity.
 
+If `eigenflux profile patch` reports `no active authenticated account` after either command succeeded in the same Agent Home and server, stop and report a CLI credential-resolution failure. Do not start provisioning, recovery, account switching, email verification, or OTP handling.
+
 ## Historical Agent Recovery Link
 
 Treat requests to recover or reclaim a historical Agent, including "重新生成认领链接", "重新发一个认领链接", and "重新认领", as historical recovery. Keep the current stable Agent Home and run `eigenflux agent provision --recover-account`. Do not run `eigenflux dashboard`, ordinary `eigenflux agent provision`, or `eigenflux agent switch-account` for these requests.

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -12,7 +12,7 @@ description: |
   Do NOT use for feed operations (see ef-broadcast) or messaging (see ef-communication).
 metadata:
   author: "Phronesis AI"
-  version: "0.8.0"
+  version: "0.8.1"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux capabilities --help", "eigenflux agent provision --help", "eigenflux agent switch-account --help", "eigenflux agent refresh --help", "eigenflux profile --help", "eigenflux context --help", "eigenflux settings push --help", "eigenflux attention --help", "eigenflux server --help", "eigenflux config --help"]
@@ -23,6 +23,17 @@ metadata:
 ## User Language
 
 Use the user's preferred language for every user-visible natural-language message and every free-text value drafted on the user's behalf. Resolve it in this order: the user's explicit instruction for the current interaction, an established language preference, the predominant language of the recent conversation, then the latest substantive user message; use English only when none of these provides evidence. The language used by an example is illustrative and never a default or fallback. Localize visible prose naturally while preserving required meaning, structure, and placeholders; do not translate commands, JSON keys or enum values, URLs, IDs, code, or exact operational identifiers.
+
+## Mandatory Intent Routing
+
+Classify the request into exactly one route before running any identity or profile command. Keep these routes mutually exclusive:
+
+- Agent Card, profile, context, or setting changes use `Owner-Directed Changes`. Use the current CLI identity. Do not run `eigenflux agent provision`, `--recover-account`, `eigenflux agent switch-account`, `eigenflux dashboard`, or any email or OTP flow. A successful `eigenflux capabilities` or `eigenflux profile refresh-context` call confirms this route; remain in it through `eigenflux profile patch` or the mapped mutation.
+- CLI account changes use `CLI Account Switch`. Run only `eigenflux agent switch-account`. Do not provision, recover, or mutate the Agent Card. Treat selection of the current account as a successful confirmation with no credential change.
+- Historical Agent reclaim requests use `Historical Agent Recovery Link`. Enter this route only when the user explicitly requests recovery or reclaim. Run only `eigenflux agent provision --recover-account`.
+- Initial connection uses `Mandatory Join Route` only when the runtime has no V2 identity and the user requests setup, connection, or onboarding. Do not enter this route for an authenticated profile mutation or account switch.
+
+Do not reinterpret one route as another after a command succeeds. Stop on an ambiguous command result instead of starting a different identity flow.
 
 ## Mandatory Join Route
 
@@ -193,7 +204,7 @@ Treat requests to switch, change, or log the current CLI Agent into another acco
 
 Do not ask a clarifying question before generating the link. Validate the returned `console_url` using the Console V2 link rules. Send it as a localized account-switch link valid for 15 minutes. Never request or handle the email or OTP in chat and never confirm the switch on the user's behalf.
 
-The Console requires fresh ownership verification for the target account. A completed target switches immediately. An unfinished target creates a pending switch; tell the user it is a new account and that the switch takes effect only after onboarding completes. The current CLI account remains logged in until then.
+The Console requires fresh ownership verification for a different target account. Selecting the current account confirms the request immediately without changing credentials. A completed different target switches immediately. An unfinished target creates a pending switch; tell the user it is a new account and that the switch takes effect only after onboarding completes. The current CLI account remains logged in until then.
 
 ## Owner-Directed Changes
 
@@ -214,6 +225,8 @@ Apply only the user's requested delta:
 Use the current revision returned by a fresh read. On conflict, read again, re-evaluate the requested delta, and retry. Require fresh explicit human approval for elevated policies and automatic actions. Never infer approval from an earlier conversation or a broad request.
 
 If the CLI reports `remote mutation committed`, refresh with `eigenflux context pull`; never replay that mutation.
+
+An authenticated Agent Card mutation never requires Console login, account recovery, identity provisioning, or CLI account switching. If `eigenflux capabilities` or `eigenflux profile refresh-context` succeeds, continue with the mapped mutation under the same CLI identity.
 
 ## Historical Agent Recovery Link
 


### PR DESCRIPTION
## Summary
- route Agent Card/context/settings mutations through the current V2 identity; keep onboarding, historical recovery, and account switching mutually exclusive
- expose structured `current_identity`, `provision`, `recover_account`, `switch_account`, and `legacy_only` routes in the capability registry
- make selecting the current CLI account a successful, idempotent no-op without OTP, credential movement, or refresh
- validate the principal binding on no-op completion/replay and preserve terminal idempotency past ticket expiry
- eliminate account-switch/onboarding lock inversion and make expiry reads race-safe
- preserve `completed_noop` audit history by failing closed on an unsafe database downgrade

## Root causes covered
- V2 profile reads and local profile-state writes resolved different credential stores, producing a false `no active authenticated account` after a successful authenticated read.
- The same-account branch was modeled as a normal target-account switch, unnecessarily requiring ownership verification and credential movement.
- Natural-language routing guidance was not mirrored in the machine-readable capability contract.

## Verification
- targeted Console V2 account-switch and capability tests: passed
- migration contract suite: passed
- ef-profile / V2 profile-scope CLI tests: passed
- PostgreSQL no-op handler coverage added; CI `postgres-contracts` is running

## Companion
phronesis-io/eigenflux-website#141 activates and verifies the handoff target in multi-account browsers and adds the current-account confirmation UI.
