### PR TITLE
docs(cli): clarify friends pagination

### DIFF
--- a/cli/cmd/relation.go
+++ b/cli/cmd/relation.go
@@ -174,9 +174,17 @@ var relationFriendsCmd = &cobra.Command{
 	Short: "List all friends",
 	Long: `List your friend list with remarks and timestamps.
 
+The server returns at most 100 friends per page. Values above 100 are capped
+at 100. To fetch the next page, pass the response's next_cursor to --cursor.
+
+A non-zero next_cursor is a page boundary, not a guarantee that more friends
+remain. Stop when the number of friends collected reaches total. If total is
+unavailable, continue until friends is empty or next_cursor is "0".
+
 Examples:
   eigenflux relation friends
-  eigenflux relation friends --limit 50`,
+  eigenflux relation friends --limit 100
+  eigenflux relation friends --limit 100 --cursor "123456"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		limit, _ := cmd.Flags().GetString("limit")
 		cursor, _ := cmd.Flags().GetString("cursor")
@@ -356,8 +364,8 @@ func init() {
 	relationListCmd.Flags().String("direction", "", "incoming or outgoing")
 	relationListCmd.Flags().String("limit", "", "max results to return")
 	relationListCmd.Flags().String("cursor", "", "pagination cursor")
-	relationFriendsCmd.Flags().String("limit", "", "max friends to return")
-	relationFriendsCmd.Flags().String("cursor", "", "pagination cursor")
+	relationFriendsCmd.Flags().String("limit", "", "friends per page (max 100; larger values are capped)")
+	relationFriendsCmd.Flags().String("cursor", "", "previous response's next_cursor")
 	relationUnfriendCmd.Flags().String("uid", "", "agent ID to unfriend (required)")
 	relationBlockCmd.Flags().String("uid", "", "agent ID to block (required)")
 	relationBlockCmd.Flags().String("remark", "", "private note for block reason")

--- a/cli/cmd/relation_friends_help_test.go
+++ b/cli/cmd/relation_friends_help_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRelationFriendsHelpDocumentsPaginationContract(t *testing.T) {
+	help := strings.Join(strings.Fields(relationFriendsCmd.Long), " ")
+	for _, want := range []string{
+		"at most 100 friends per page",
+		"pass the response's next_cursor to --cursor",
+		"not a guarantee that more friends remain",
+		"reaches total",
+		`next_cursor is "0"`,
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("relation friends help missing %q", want)
+		}
+	}
+
+	limitFlag := relationFriendsCmd.Flags().Lookup("limit")
+	if limitFlag == nil || !strings.Contains(limitFlag.Usage, "max 100") {
+		t.Fatalf("limit flag must document the maximum: %#v", limitFlag)
+	}
+
+	cursorFlag := relationFriendsCmd.Flags().Lookup("cursor")
+	if cursorFlag == nil || !strings.Contains(cursorFlag.Usage, "next_cursor") {
+		t.Fatalf("cursor flag must document next_cursor usage: %#v", cursorFlag)
+	}
+}

--- a/skills/ef-communication/references/relations.md
+++ b/skills/ef-communication/references/relations.md
@@ -135,6 +135,8 @@ Use `--cursor` (last `request_id`) for pagination. `next_cursor` of `"0"` means 
 eigenflux relation friends --limit 20
 ```
 
+The server returns at most 100 friends per page. Values above 100 are capped at 100.
+
 Response:
 
 ```json
@@ -155,7 +157,7 @@ Response:
 }
 ```
 
-Pagination is based on the internal relation `id`. Always pass the `next_cursor` returned by the previous page as the next request's `cursor`. `next_cursor` of `"0"` means no more results. The `remark` field is the nickname you set for this friend (omitted if empty).
+Pagination is based on the internal relation `id`. Pass each response's `next_cursor` to the next request's `--cursor`. A non-zero `next_cursor` is a page boundary and does not guarantee another non-empty page. Stop when the accumulated friend count reaches `total`. If `total` is unavailable, continue until `friends` is empty or `next_cursor` is `"0"`. The `remark` field is the nickname you set for this friend (omitted if empty).
 
 When presenting friends, use `display_name`; use `eigenflux#<short_id>` for a shareable contact handle. Never surface numeric `agent_id` or email as the handle.
 


### PR DESCRIPTION
## Summary
- document the 100-friend page limit in relation friends help
- explain how next_cursor maps to --cursor
- document accurate pagination termination semantics
- align the bundled ef-communication skill and add a help contract test

## Testing
- go test ./...
- go run . relation friends --help

No CLI version bump; ship with the next CLI release.