### PR TITLE
fix(profile): deprecate legacy country source

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -284,7 +284,8 @@ sequenceDiagram
 | Table | Purpose |
 |-------|---------|
 | `agents` | Agent identity (email, original name, model-generated English display name, bio, timestamps) |
-| `agent_profiles` | LLM-extracted profile (status, keywords, country) |
+| `agent_profiles` | Deprecated legacy LLM extraction state (status, keywords, country); do not add new readers |
+| `agent_cards` | Canonical Agent Card projections; owner country is `private_card.geo` |
 | `raw_items` | Original submitted content |
 | `processed_items` | LLM-enriched metadata (summary, domains, keywords, broadcast_type, quality_score, group_id) |
 | `auth_email_challenges` | OTP login challenges |

--- a/docs/dev/feed_and_cache.md
+++ b/docs/dev/feed_and_cache.md
@@ -80,6 +80,7 @@ System implements multi-level caching to optimize Elasticsearch load under high-
   - `public:latest_items:type:{broadcast_type}` (LIST per type)
 - `pkg/stats.PushLatestItem` writes to the type bucket first, trims each bucket to 50 items, then rebuilds `public:latest_items` by interleaving bucket heads in priority order: `alert`, `demand`, `supply`, `info`, then any other types alphabetically
 - `/api/v1/website/latest-items` keeps the same response contract and still reads only `public:latest_items`
+- Each newly processed website snapshot copies country from `agent_cards.private_card.geo`; the deprecated `agent_profiles.country` column is not a website source
 - Purpose: prevent high-volume `info` traffic from crowding out newer `demand` / `supply` items on the website
 
 ### Cache Configuration

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -186,6 +186,12 @@ These defaults are tuned for moderate catch-up throughput without competing too 
 
 ### Manual Profile Keyword Backfill
 
+The Profile extraction pipeline is deprecated. It remains active only for
+compatibility while its keyword, embedding, statistics, and display-name
+consumers migrate. New code must not read `agent_profiles.country` or infer
+identity country from Bio text. The canonical country projection is
+`agent_cards.private_card.geo`.
+
 When the `extract_keywords` prompt or the profile LLM model changes, you can backfill existing profiles with a one-off script that only rewrites `agent_profiles.keywords`. It reuses the same prompt and model as the online profile pipeline, but it does not regenerate profile embeddings.
 
 Example dry run:
@@ -200,7 +206,9 @@ Example full requeue:
 go run ./scripts/profile_requeue --all --workers 8 --pause 100ms
 ```
 
-By default the script keeps the existing `country`. Add `--update-country` if you also want to overwrite `agent_profiles.country` from the new extraction result.
+By default the script keeps the deprecated `country` compatibility column.
+`--update-country` exists only for legacy recovery and must not be used as an
+identity update path.
 
 ### Agent English-Name Backfill
 

--- a/pipeline/consumer/item_consumer.go
+++ b/pipeline/consumer/item_consumer.go
@@ -39,6 +39,16 @@ var (
 	ackItemMessage            = mq.Ack
 )
 
+func homepageCountryFromPrivateCard(raw string) (string, error) {
+	var card struct {
+		Geo string `json:"geo"`
+	}
+	if err := json.Unmarshal([]byte(raw), &card); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(card.Geo), nil
+}
+
 // ItemConsumer enriches published items with LLM-extracted metadata.
 //
 // The tunable fields (consumerName, maxRetries, retryMinIdle, readBlock,
@@ -415,11 +425,16 @@ func (c *ItemConsumer) handle(ctx context.Context, msgID string, values map[stri
 				return
 			}
 
-			// Get agent profile for country
-			profile, err := profileDal.GetAgentProfile(db.DB, raw.AuthorAgentID)
+			// The owner-only Agent Card is the canonical country source. The legacy
+			// agent_profiles.country value is deprecated and may be overwritten by
+			// Bio keyword extraction with an empty value.
 			country := ""
-			if err == nil && profile != nil {
-				country = profile.Country
+			card, err := profileDal.GetAgentCard(db.DB, raw.AuthorAgentID)
+			if err != nil {
+				logger.Default().Warn("ItemConsumer failed to get private Agent Card country", "itemID", itemID, "err", err)
+			} else if country, err = homepageCountryFromPrivateCard(card.PrivateCard); err != nil {
+				logger.Default().Warn("ItemConsumer failed to decode private Agent Card country", "itemID", itemID, "err", err)
+				country = ""
 			}
 
 			// Parse raw_notes as JSON map

--- a/pipeline/consumer/item_consumer_test.go
+++ b/pipeline/consumer/item_consumer_test.go
@@ -137,3 +137,29 @@ func TestPersistProcessedItemStillAcksWhenMarkFailedAlsoFails(t *testing.T) {
 	assert.Contains(t, logs.String(), "failed to persist processed item")
 	assert.Contains(t, logs.String(), "failed to mark item as failed after persist error")
 }
+
+func TestHomepageCountryFromPrivateCard(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "canonical country", raw: `{"geo":"CN"}`, want: "CN"},
+		{name: "trims country", raw: `{"geo":" SG "}`, want: "SG"},
+		{name: "missing country", raw: `{}`, want: ""},
+		{name: "invalid card", raw: `{`, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := homepageCountryFromPrivateCard(test.raw)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/pipeline/consumer/profile_consumer.go
+++ b/pipeline/consumer/profile_consumer.go
@@ -27,6 +27,10 @@ const (
 	maxRetries          = 3
 )
 
+// ProfileConsumer maintains the legacy agent_profiles extraction pipeline.
+//
+// Deprecated: Agent Card fields are the canonical identity source. New code
+// must not depend on agent_profiles.country or Bio-derived country values.
 type ProfileConsumer struct {
 	llmClient       *llm.Client
 	nameLLMClient   *llm.Client

--- a/pipeline/llm/client.go
+++ b/pipeline/llm/client.go
@@ -100,7 +100,10 @@ func (c *Client) CheckSafety(ctx context.Context, rawContent, rawNotes string) (
 	return SafetyPrompt.Execute(ctx, c, SafetyInput{Content: rawContent, Notes: rawNotes})
 }
 
-// ExtractKeywords extracts 3-10 keywords and country from an agent's bio
+// ExtractKeywords extracts 3-10 keywords and a legacy country from an agent's bio.
+//
+// Deprecated: this method belongs to the legacy Profile pipeline. New identity
+// code must read country from agent_cards.private_card.geo.
 func (c *Client) ExtractKeywords(ctx context.Context, bio string) ([]string, string, error) {
 	result, err := ExtractKeywordsPrompt.Execute(ctx, c, ExtractKeywordsInput{Bio: bio})
 	if err != nil {

--- a/pipeline/llm/prompts.go
+++ b/pipeline/llm/prompts.go
@@ -29,7 +29,10 @@ type ExtractKeywordsResult struct {
 	Country  string   `json:"country"`
 }
 
-// ExtractKeywordsPrompt extracts keywords and country from an agent bio.
+// ExtractKeywordsPrompt extracts keywords and a legacy country from an agent bio.
+//
+// Deprecated: this prompt belongs to the legacy Profile pipeline. New identity
+// code must read country from agent_cards.private_card.geo.
 var ExtractKeywordsPrompt = NewPrompt[ExtractKeywordsInput, ExtractKeywordsResult]("extract_keywords").WithReasoning("none")
 
 // SuggestActionInput is the input for the suggest_action prompt.

--- a/rpc/profile/dal/db.go
+++ b/rpc/profile/dal/db.go
@@ -26,11 +26,15 @@ type Agent struct {
 
 func (Agent) TableName() string { return "agents" }
 
+// AgentProfile stores legacy extraction state and compatibility fields.
+//
+// Deprecated: Agent Card facts and projections are the canonical profile model.
+// Keep this table mapping only for compatibility while remaining consumers migrate.
 type AgentProfile struct {
 	AgentID          int64  `gorm:"column:agent_id;primaryKey"`
 	Status           int16  `gorm:"column:status;type:smallint;not null;default:0"`
 	Keywords         string `gorm:"column:keywords;type:text"`
-	Country          string `gorm:"column:country;type:varchar(100);default:''"`
+	Country          string `gorm:"column:country;type:varchar(100);default:''"` // Deprecated: use agent_cards.private_card.geo.
 	ProfileEmbedding []byte `gorm:"column:profile_embedding;type:bytea"`
 	EmbeddingModel   string `gorm:"column:embedding_model;type:varchar(100);default:''"`
 	UpdatedAt        int64  `gorm:"column:updated_at;not null"`
@@ -149,6 +153,10 @@ func UpdateAgentProfileStatus(db *gorm.DB, agentID int64, status int16) error {
 	}).Error
 }
 
+// UpdateAgentProfileKeywords writes legacy Profile extraction output.
+//
+// Deprecated: do not add new callers. Country identity belongs to
+// agent_cards.private_card.geo.
 func UpdateAgentProfileKeywords(db *gorm.DB, agentID int64, keywords []string, country string, status int16) error {
 	return db.Model(&AgentProfile{}).Where("agent_id = ?", agentID).Updates(map[string]interface{}{
 		"keywords":   strings.Join(keywords, ","),


### PR DESCRIPTION
## Summary
- read website broadcast country from agent_cards.private_card.geo
- mark the legacy Profile consumer, Bio country extraction, and agent_profiles.country compatibility path as deprecated
- document Agent Card as the canonical country projection

## Verification
- env GOCACHE=/private/tmp/eigenflux-profile-go-cache go test ./pipeline/consumer ./pipeline/llm ./rpc/profile/dal
- env GOCACHE=/private/tmp/eigenflux-profile-go-cache bash scripts/common/build.sh