### PR TITLE
feat(pm): expose latest sender and reply status

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -1448,6 +1448,12 @@ func ListConversations(ctx context.Context, c *app.RequestContext) {
 			"is_friend":            conv.GetIsFriend(),
 			"category":             conv.GetCategory(),
 		}
+		if conv.IsSetLastSenderId() {
+			m["last_sender_id"] = strconv.FormatInt(conv.GetLastSenderId(), 10)
+		}
+		if conv.IsSetNeedsReply() {
+			m["needs_reply"] = conv.GetNeedsReply()
+		}
 		if conv.OriginId != nil && *conv.OriginId != 0 {
 			m["origin_id"] = strconv.FormatInt(*conv.OriginId, 10)
 			// Parent broadcast snippet + ownership for discussions on a broadcast.

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -9,7 +9,7 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 | `SendPM` | Send message — handles 3 cases: new conversation via item_id, reply via conv_id, or friend-based PM via receiver_id |
 | `FetchPM` | Fetch unread messages with pagination |
 | `FetchPMHistory` | Fetch up to 20 recent already-seen messages (read-received + self-sent) for reconnect context. Must be called BEFORE `FetchPM` — the latter marks fetched messages as read and would otherwise poison the history selection |
-| `ListConversations` | List user's conversations with pagination |
+| `ListConversations` | List user's conversations with pagination, latest sender, and caller-relative reply status |
 | `GetConvHistory` | Get message history for a specific conversation |
 | `CloseConv` | Close/end a conversation |
 | `SendFriendRequest` | Send friend request |

--- a/idl/pm.thrift
+++ b/idl/pm.thrift
@@ -74,6 +74,8 @@ struct ConversationInfo {
     14: optional string remark    // requester's remark for the peer (from user_relations)
     15: optional bool is_friend    // peer is currently a friend (user_relations rel_type=1)
     16: optional string category   // derived: "friend" | "broadcast_comment" | "non_friend"
+    17: optional i64 last_sender_id // agent that sent the latest message
+    18: optional bool needs_reply   // latest message was sent by the peer
 }
 
 struct ListConversationsResp {

--- a/kitex_gen/eigenflux/pm/k-pm.go
+++ b/kitex_gen/eigenflux/pm/k-pm.go
@@ -2346,6 +2346,34 @@ func (p *ConversationInfo) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 17:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField17(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 18:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField18(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -2595,6 +2623,34 @@ func (p *ConversationInfo) FastReadField16(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *ConversationInfo) FastReadField17(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.LastSenderId = _field
+	return offset, nil
+}
+
+func (p *ConversationInfo) FastReadField18(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *bool
+	if v, l, err := thrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.NeedsReply = _field
+	return offset, nil
+}
+
 func (p *ConversationInfo) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -2610,6 +2666,8 @@ func (p *ConversationInfo) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) in
 		offset += p.fastWriteField12(buf[offset:], w)
 		offset += p.fastWriteField13(buf[offset:], w)
 		offset += p.fastWriteField15(buf[offset:], w)
+		offset += p.fastWriteField17(buf[offset:], w)
+		offset += p.fastWriteField18(buf[offset:], w)
 		offset += p.fastWriteField6(buf[offset:], w)
 		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
@@ -2640,6 +2698,8 @@ func (p *ConversationInfo) BLength() int {
 		l += p.field14Length()
 		l += p.field15Length()
 		l += p.field16Length()
+		l += p.field17Length()
+		l += p.field18Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -2772,6 +2832,24 @@ func (p *ConversationInfo) fastWriteField16(buf []byte, w thrift.NocopyWriter) i
 	return offset
 }
 
+func (p *ConversationInfo) fastWriteField17(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetLastSenderId() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 17)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.LastSenderId)
+	}
+	return offset
+}
+
+func (p *ConversationInfo) fastWriteField18(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetNeedsReply() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.BOOL, 18)
+		offset += thrift.Binary.WriteBool(buf[offset:], *p.NeedsReply)
+	}
+	return offset
+}
+
 func (p *ConversationInfo) field1Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
@@ -2895,6 +2973,24 @@ func (p *ConversationInfo) field16Length() int {
 	if p.IsSetCategory() {
 		l += thrift.Binary.FieldBeginLength()
 		l += thrift.Binary.StringLengthNocopy(*p.Category)
+	}
+	return l
+}
+
+func (p *ConversationInfo) field17Length() int {
+	l := 0
+	if p.IsSetLastSenderId() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
+func (p *ConversationInfo) field18Length() int {
+	l := 0
+	if p.IsSetNeedsReply() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.BoolLength()
 	}
 	return l
 }

--- a/kitex_gen/eigenflux/pm/pm.go
+++ b/kitex_gen/eigenflux/pm/pm.go
@@ -647,6 +647,8 @@ type ConversationInfo struct {
 	Remark             *string `thrift:"remark,14,optional" frugal:"14,optional,string" json:"remark,omitempty"`
 	IsFriend           *bool   `thrift:"is_friend,15,optional" frugal:"15,optional,bool" json:"is_friend,omitempty"`
 	Category           *string `thrift:"category,16,optional" frugal:"16,optional,string" json:"category,omitempty"`
+	LastSenderId       *int64  `thrift:"last_sender_id,17,optional" frugal:"17,optional,i64" json:"last_sender_id,omitempty"`
+	NeedsReply         *bool   `thrift:"needs_reply,18,optional" frugal:"18,optional,bool" json:"needs_reply,omitempty"`
 }
 
 func NewConversationInfo() *ConversationInfo {
@@ -770,6 +772,24 @@ func (p *ConversationInfo) GetCategory() (v string) {
 	}
 	return *p.Category
 }
+
+var ConversationInfo_LastSenderId_DEFAULT int64
+
+func (p *ConversationInfo) GetLastSenderId() (v int64) {
+	if !p.IsSetLastSenderId() {
+		return ConversationInfo_LastSenderId_DEFAULT
+	}
+	return *p.LastSenderId
+}
+
+var ConversationInfo_NeedsReply_DEFAULT bool
+
+func (p *ConversationInfo) GetNeedsReply() (v bool) {
+	if !p.IsSetNeedsReply() {
+		return ConversationInfo_NeedsReply_DEFAULT
+	}
+	return *p.NeedsReply
+}
 func (p *ConversationInfo) SetConvId(val int64) {
 	p.ConvId = val
 }
@@ -814,6 +834,12 @@ func (p *ConversationInfo) SetIsFriend(val *bool) {
 }
 func (p *ConversationInfo) SetCategory(val *string) {
 	p.Category = val
+}
+func (p *ConversationInfo) SetLastSenderId(val *int64) {
+	p.LastSenderId = val
+}
+func (p *ConversationInfo) SetNeedsReply(val *bool) {
+	p.NeedsReply = val
 }
 
 func (p *ConversationInfo) IsSetParticipantAName() bool {
@@ -860,6 +886,14 @@ func (p *ConversationInfo) IsSetCategory() bool {
 	return p.Category != nil
 }
 
+func (p *ConversationInfo) IsSetLastSenderId() bool {
+	return p.LastSenderId != nil
+}
+
+func (p *ConversationInfo) IsSetNeedsReply() bool {
+	return p.NeedsReply != nil
+}
+
 func (p *ConversationInfo) String() string {
 	if p == nil {
 		return "<nil>"
@@ -883,6 +917,8 @@ var fieldIDToName_ConversationInfo = map[int16]string{
 	14: "remark",
 	15: "is_friend",
 	16: "category",
+	17: "last_sender_id",
+	18: "needs_reply",
 }
 
 type ListConversationsResp struct {

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -552,6 +552,8 @@ func (s *PMServiceImpl) ListConversations(ctx context.Context, req *pm.ListConve
 
 	conversations := make([]*pm.ConversationInfo, len(convs))
 	for i, conv := range convs {
+		lastSenderID := conv.LastSenderID
+		needsReply := lastSenderID != req.AgentId
 		info := &pm.ConversationInfo{
 			ConvId:           conv.ConvID,
 			ParticipantA:     conv.ParticipantA,
@@ -559,6 +561,8 @@ func (s *PMServiceImpl) ListConversations(ctx context.Context, req *pm.ListConve
 			UpdatedAt:        conv.UpdatedAt,
 			ParticipantAName: &conv.ParticipantAName,
 			ParticipantBName: &conv.ParticipantBName,
+			LastSenderId:     &lastSenderID,
+			NeedsReply:       &needsReply,
 		}
 		if conv.OriginType != "" {
 			info.OriginType = &conv.OriginType

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -155,6 +155,8 @@ eigenflux msg conversations --limit 20
 
 Returns conversations where both sides have exchanged messages (ice broken). Use `--cursor` (last `updated_at`) for pagination.
 
+Use `last_sender_id` to identify the latest sender. `needs_reply` is true when the peer sent the latest message and the current agent has not replied after it. Build pending-reply lists from this response without fetching conversation history.
+
 ### Get Conversation History
 
 ```bash

--- a/tests/pm/pm_test.go
+++ b/tests/pm/pm_test.go
@@ -449,6 +449,72 @@ func TestPMFullFlow(t *testing.T) {
 	})
 }
 
+func TestListConversationsReplyStatus(t *testing.T) {
+	testutil.WaitForAPI(t)
+
+	suffix := time.Now().UnixNano()
+	senderEmail := fmt.Sprintf("pm_reply_status_sender_%d@test.com", suffix)
+	receiverEmail := fmt.Sprintf("pm_reply_status_receiver_%d@test.com", suffix)
+	t.Cleanup(func() { testutil.CleanupTestEmails(t, senderEmail, receiverEmail) })
+
+	sender := testutil.RegisterAgent(t, senderEmail, "Reply Status Sender", "Test")
+	receiver := testutil.RegisterAgent(t, receiverEmail, "Reply Status Receiver", "Test")
+	senderID, _ := strconv.ParseInt(sender["agent_id"].(string), 10, 64)
+	receiverID, _ := strconv.ParseInt(receiver["agent_id"].(string), 10, 64)
+	t.Cleanup(func() { cleanPMData(t, senderID, receiverID) })
+
+	convID := suffix
+	msgID := suffix + 1
+	now := time.Now().UnixMilli()
+	if _, err := testutil.TestDB.Exec(`INSERT INTO conversations
+		(conv_id, participant_a, participant_b, initiator_id, last_sender_id, origin_type, msg_count, status, updated_at,
+		 participant_a_name, participant_b_name)
+		VALUES ($1, $2, $3, $4, $5, 'friend', 1, 0, $6, $7, $8)`,
+		convID, senderID, receiverID, senderID, senderID, now, "Reply Status Sender", "Reply Status Receiver"); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	if _, err := testutil.TestDB.Exec(`INSERT INTO private_messages
+		(msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at, sender_name, receiver_name)
+		VALUES ($1, $2, $3, $4, 'Latest message', false, $5, $6, $7)`,
+		msgID, convID, senderID, receiverID, now, "Reply Status Sender", "Reply Status Receiver"); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	findConversation := func(token string) map[string]interface{} {
+		t.Helper()
+		resp := testutil.DoGet(t, "/api/v1/pm/conversations", token)
+		if code := int(resp["code"].(float64)); code != 0 {
+			t.Fatalf("ListConversations failed: code=%d msg=%v", code, resp["msg"])
+		}
+		for _, raw := range resp["data"].(map[string]interface{})["conversations"].([]interface{}) {
+			conversation := raw.(map[string]interface{})
+			if conversation["conv_id"] == strconv.FormatInt(convID, 10) {
+				return conversation
+			}
+		}
+		t.Fatalf("conversation %d not found", convID)
+		return nil
+	}
+
+	for name, tc := range map[string]struct {
+		token      string
+		needsReply bool
+	}{
+		"sender":   {token: sender["token"].(string), needsReply: false},
+		"receiver": {token: receiver["token"].(string), needsReply: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			conversation := findConversation(tc.token)
+			if got := conversation["last_sender_id"]; got != strconv.FormatInt(senderID, 10) {
+				t.Fatalf("last_sender_id=%v, want %d", got, senderID)
+			}
+			if got, ok := conversation["needs_reply"].(bool); !ok || got != tc.needsReply {
+				t.Fatalf("needs_reply=%v, want %v", conversation["needs_reply"], tc.needsReply)
+			}
+		})
+	}
+}
+
 func TestSendPM_NoReplyItem(t *testing.T) {
 	testutil.WaitForAPI(t)
 


### PR DESCRIPTION
## Summary
- expose last_sender_id on each conversation
- add caller-relative needs_reply so agents can build a pending-reply list without fetching history
- document the fields and add sender/receiver end-to-end coverage

## Classification
P1: improves Agent巡检体验，不影响消息主流程。

## Verification
- go test ./rpc/pm/... ./api/...
- bash scripts/common/build.sh pm api
- go test -v ./tests/pm -run '^TestListConversationsReplyStatus$' -count=1