### PR TITLE
feat(console): complete homepage discovery data and relationship state

### DIFF
--- a/.github/workflows/postgres-contracts.yml
+++ b/.github/workflows/postgres-contracts.yml
@@ -6,6 +6,8 @@ on:
       - 'api/consolev2/**'
       - 'api/install/**'
       - 'migrations/**'
+      - 'pipeline/cron/**'
+      - 'pipeline/llm/**'
       - 'pkg/consolev2retention/**'
       - 'pkg/agentidentity/**'
       - 'scripts/common/**'
@@ -16,6 +18,8 @@ on:
       - 'api/consolev2/**'
       - 'api/install/**'
       - 'migrations/**'
+      - 'pipeline/cron/**'
+      - 'pipeline/llm/**'
       - 'pkg/consolev2retention/**'
       - 'pkg/agentidentity/**'
       - 'scripts/common/**'
@@ -60,3 +64,7 @@ jobs:
         run: go test -count=1 ./api/install -run '^TestPostgresShortIDInviteAttribution$'
       - name: Verify Console V2 PostgreSQL flow and races
         run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*|AttentionContractGolden)'
+      - name: Verify Console homepage HTTP and data contracts
+        run: go test -count=1 ./api/consolev2 -run '^TestHome'
+      - name: Verify homepage eligibility backfill and LLM contracts
+        run: go test -count=1 ./pipeline/cron ./pipeline/llm

--- a/api/consolev2/home_activity_handlers.go
+++ b/api/consolev2/home_activity_handlers.go
@@ -3,6 +3,7 @@ package consolev2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cloudwego/hertz/pkg/app"
+	redis "github.com/redis/go-redis/v9"
 )
 
 const (
@@ -55,19 +57,25 @@ type homeActivityRow struct {
 }
 
 func (s *Service) getHomeActivity(ctx context.Context, c *app.RequestContext) {
-	if cached, ok := s.readHomeActivityCache(ctx); ok {
+	requestCtx, cancelRequest := context.WithTimeout(ctx, homeRefreshTimeout)
+	defer cancelRequest()
+	if cached, ok := s.readHomeActivityCache(requestCtx); ok {
 		reply(c, http.StatusOK, cached)
 		return
 	}
 	value, err, _ := s.homeActivityRefresh.Do(homeActivityCacheKey, func() (interface{}, error) {
-		if cached, ok := s.readHomeActivityCache(ctx); ok {
+		refreshCtx, cancel := context.WithTimeout(context.Background(), homeRefreshTimeout)
+		defer cancel()
+		if cached, ok := s.readHomeActivityCache(refreshCtx); ok {
 			return cached, nil
 		}
-		result, loadErr := s.loadHomeActivity(time.Now().UnixMilli())
+		started := time.Now()
+		result, loadErr := s.loadHomeActivity(refreshCtx, time.Now().UnixMilli())
+		observeHomeRefresh("activity", started, loadErr)
 		if loadErr != nil {
 			return homeActivityResponse{}, loadErr
 		}
-		s.writeHomeActivityCache(ctx, result)
+		s.writeHomeActivityCache(refreshCtx, result)
 		return result, nil
 	})
 	if err != nil {
@@ -79,16 +87,24 @@ func (s *Service) getHomeActivity(ctx context.Context, c *app.RequestContext) {
 
 func (s *Service) readHomeActivityCache(ctx context.Context) (homeActivityResponse, bool) {
 	if s.redisClient == nil {
+		recordHomeCache("activity", "disabled")
 		return homeActivityResponse{}, false
 	}
 	raw, err := s.redisClient.Get(ctx, homeActivityCacheKey).Bytes()
 	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			recordHomeCache("activity", "miss")
+		} else {
+			recordHomeCache("activity", "error")
+		}
 		return homeActivityResponse{}, false
 	}
 	var result homeActivityResponse
 	if json.Unmarshal(raw, &result) != nil || result.GeneratedAt <= 0 {
+		recordHomeCache("activity", "corrupt")
 		return homeActivityResponse{}, false
 	}
+	recordHomeCache("activity", "hit")
 	return result, true
 }
 
@@ -96,12 +112,19 @@ func (s *Service) writeHomeActivityCache(ctx context.Context, result homeActivit
 	if s.redisClient == nil {
 		return
 	}
-	if raw, err := json.Marshal(result); err == nil {
-		_ = s.redisClient.Set(ctx, homeActivityCacheKey, raw, homeActivityCacheTTL).Err()
+	raw, err := json.Marshal(result)
+	if err != nil {
+		recordHomeCache("activity", "encode_error")
+		return
 	}
+	if err := s.redisClient.Set(ctx, homeActivityCacheKey, raw, homeActivityCacheTTL).Err(); err != nil {
+		recordHomeCache("activity", "write_error")
+		return
+	}
+	recordHomeCache("activity", "write_success")
 }
 
-func (s *Service) loadHomeActivity(now int64) (homeActivityResponse, error) {
+func (s *Service) loadHomeActivity(ctx context.Context, now int64) (homeActivityResponse, error) {
 	var rows []homeActivityRow
 	query := `WITH bounds AS (SELECT ?::bigint AS cutoff), events AS (
 		SELECT 'broadcast:' || r.item_id AS event_id, 'broadcast' AS event_type, r.created_at,
@@ -146,7 +169,7 @@ func (s *Service) loadHomeActivity(now int64) (homeActivityResponse, error) {
 		WHERE command.created_at >= (SELECT cutoff FROM bounds) AND command.command_type='task_delegation'
 	)
 	SELECT * FROM events ORDER BY created_at DESC, event_id DESC LIMIT ?`
-	if err := s.db.Raw(query, homeActivityWindowStart(now), homeActivityLimit).Scan(&rows).Error; err != nil {
+	if err := s.db.WithContext(ctx).Raw(query, homeActivityWindowStart(now), homeActivityLimit).Scan(&rows).Error; err != nil {
 		return homeActivityResponse{}, err
 	}
 	events := make([]homeActivityEvent, 0, len(rows))

--- a/api/consolev2/home_discovery_handlers.go
+++ b/api/consolev2/home_discovery_handlers.go
@@ -3,6 +3,7 @@ package consolev2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/lib/pq"
+	redis "github.com/redis/go-redis/v9"
 )
 
 const (
@@ -103,10 +105,12 @@ func homeDiscoveryCountryCode(privateJSON string) string {
 }
 
 func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
+	requestCtx, cancelRequest := context.WithTimeout(ctx, homeRefreshTimeout)
+	defer cancelRequest()
 	agentIDValue, _ := agentID(c)
 	now := time.Now()
 	var privateCard string
-	if err := s.db.Raw(`SELECT COALESCE(private_card, '{}'::jsonb)::text
+	if err := s.db.WithContext(requestCtx).Raw(`SELECT COALESCE(private_card, '{}'::jsonb)::text
 		FROM agent_cards WHERE agent_id = ?`, agentIDValue).Scan(&privateCard).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "HOME_DISCOVERY_FAILED", "failed to load home discovery timezone", nil)
 		return
@@ -114,8 +118,8 @@ func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
 	location, timezone := todayLocationFromPrivateCard(privateCard)
 	start := homeDiscoveryDayStart(now, location)
 	cacheKey := homeDiscoveryCacheKey(timezone, start)
-	if cached, ok := s.readHomeDiscoveryCache(ctx, cacheKey); ok {
-		if err := s.decorateHomeDiscoveryRelations(agentIDValue, &cached); err != nil {
+	if cached, ok := s.readHomeDiscoveryCache(requestCtx, cacheKey); ok {
+		if err := s.decorateHomeDiscoveryRelations(requestCtx, agentIDValue, &cached); err != nil {
 			fail(c, http.StatusInternalServerError, "HOME_DISCOVERY_FAILED", "failed to load home discovery relations", nil)
 			return
 		}
@@ -124,14 +128,18 @@ func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
 	}
 
 	value, err, _ := s.homeDiscoveryRefresh.Do(cacheKey, func() (interface{}, error) {
-		if cached, ok := s.readHomeDiscoveryCache(ctx, cacheKey); ok {
+		refreshCtx, cancel := context.WithTimeout(context.Background(), homeRefreshTimeout)
+		defer cancel()
+		if cached, ok := s.readHomeDiscoveryCache(refreshCtx, cacheKey); ok {
 			return cached, nil
 		}
-		result, loadErr := s.loadHomeDiscovery(start, now.UnixMilli(), timezone)
+		started := time.Now()
+		result, loadErr := s.loadHomeDiscovery(refreshCtx, start, now.UnixMilli(), timezone)
+		observeHomeRefresh("discovery", started, loadErr)
 		if loadErr != nil {
 			return homeDiscoveryResponse{}, loadErr
 		}
-		s.writeHomeDiscoveryCache(ctx, cacheKey, result)
+		s.writeHomeDiscoveryCache(refreshCtx, cacheKey, result)
 		return result, nil
 	})
 	if err != nil {
@@ -139,14 +147,14 @@ func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	result := value.(homeDiscoveryResponse)
-	if err := s.decorateHomeDiscoveryRelations(agentIDValue, &result); err != nil {
+	if err := s.decorateHomeDiscoveryRelations(requestCtx, agentIDValue, &result); err != nil {
 		fail(c, http.StatusInternalServerError, "HOME_DISCOVERY_FAILED", "failed to load home discovery relations", nil)
 		return
 	}
 	reply(c, http.StatusOK, result)
 }
 
-func (s *Service) decorateHomeDiscoveryRelations(viewerAgentID int64, result *homeDiscoveryResponse) error {
+func (s *Service) decorateHomeDiscoveryRelations(ctx context.Context, viewerAgentID int64, result *homeDiscoveryResponse) error {
 	if result == nil || len(result.Items) == 0 {
 		return nil
 	}
@@ -164,7 +172,7 @@ func (s *Service) decorateHomeDiscoveryRelations(viewerAgentID int64, result *ho
 		return nil
 	}
 	rows := make([]homeDiscoveryRelationRow, 0, len(ids))
-	if err := s.db.Raw(`SELECT a.agent_id,
+	if err := s.db.WithContext(ctx).Raw(`SELECT a.agent_id,
 		EXISTS (SELECT 1 FROM user_relations ur WHERE ur.from_uid=? AND ur.to_uid=a.agent_id AND ur.rel_type=1) AS is_friend,
 		EXISTS (SELECT 1 FROM friend_requests fr WHERE fr.from_uid=? AND fr.to_uid=a.agent_id AND fr.status=0) AS friend_request_pending,
 		COALESCE(settings.show_add_friend, TRUE) AS show_add_friend
@@ -189,16 +197,24 @@ func (s *Service) decorateHomeDiscoveryRelations(viewerAgentID int64, result *ho
 
 func (s *Service) readHomeDiscoveryCache(ctx context.Context, key string) (homeDiscoveryResponse, bool) {
 	if s.redisClient == nil {
+		recordHomeCache("discovery", "disabled")
 		return homeDiscoveryResponse{}, false
 	}
 	raw, err := s.redisClient.Get(ctx, key).Bytes()
 	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			recordHomeCache("discovery", "miss")
+		} else {
+			recordHomeCache("discovery", "error")
+		}
 		return homeDiscoveryResponse{}, false
 	}
 	var result homeDiscoveryResponse
 	if json.Unmarshal(raw, &result) != nil || result.WindowStart <= 0 {
+		recordHomeCache("discovery", "corrupt")
 		return homeDiscoveryResponse{}, false
 	}
+	recordHomeCache("discovery", "hit")
 	return result, true
 }
 
@@ -206,26 +222,33 @@ func (s *Service) writeHomeDiscoveryCache(ctx context.Context, key string, resul
 	if s.redisClient == nil {
 		return
 	}
-	if raw, err := json.Marshal(result); err == nil {
-		_ = s.redisClient.Set(ctx, key, raw, homeDiscoveryCacheTTL).Err()
+	raw, err := json.Marshal(result)
+	if err != nil {
+		recordHomeCache("discovery", "encode_error")
+		return
 	}
+	if err := s.redisClient.Set(ctx, key, raw, homeDiscoveryCacheTTL).Err(); err != nil {
+		recordHomeCache("discovery", "write_error")
+		return
+	}
+	recordHomeCache("discovery", "write_success")
 }
 
-func (s *Service) rankedHomeDiscovery(sql string, args ...interface{}) ([]homeDiscoveryCandidateRow, error) {
+func (s *Service) rankedHomeDiscovery(ctx context.Context, sql string, args ...interface{}) ([]homeDiscoveryCandidateRow, error) {
 	rows := make([]homeDiscoveryCandidateRow, 0, homeDiscoveryCandidate)
-	if err := s.db.Raw(sql, args...).Scan(&rows).Error; err != nil {
+	if err := s.db.WithContext(ctx).Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDiscoveryResponse, error) {
+func (s *Service) loadHomeDiscovery(ctx context.Context, start, now int64, timezone string) (homeDiscoveryResponse, error) {
 	eligible := fmt.Sprintf(`a.short_id IS NOT NULL AND BTRIM(a.agent_name) <> ''
 		AND COALESCE(a.email, '') NOT LIKE '%%@pgc.eigenflux.one'
 		AND COALESCE(a.email, '') NOT LIKE '%%@bot.eigenflux.one'
 		AND a.agent_id <> %d`, eigenfluxOfficialAssistantID)
 
-	recognition, err := s.rankedHomeDiscovery(fmt.Sprintf(`
+	recognition, err := s.rankedHomeDiscovery(ctx, fmt.Sprintf(`
 		SELECT a.agent_id, COUNT(DISTINCT f.agent_id) AS primary_value,
 		       COUNT(DISTINCT f.item_id) AS secondary_value, '' AS dimension
 		FROM feedback_logs f JOIN raw_items r ON r.item_id=f.item_id
@@ -236,7 +259,7 @@ func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDisc
 		return homeDiscoveryResponse{}, err
 	}
 
-	broadcasts, err := s.rankedHomeDiscovery(fmt.Sprintf(`
+	broadcasts, err := s.rankedHomeDiscovery(ctx, fmt.Sprintf(`
 		SELECT a.agent_id, COUNT(*) AS primary_value, COALESCE(SUM(s.consumed_count),0) AS secondary_value, '' AS dimension
 		FROM raw_items r JOIN processed_items p ON p.item_id=r.item_id AND p.status=3
 		JOIN agents a ON a.agent_id=r.author_agent_id LEFT JOIN item_stats s ON s.item_id=r.item_id
@@ -246,7 +269,7 @@ func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDisc
 		return homeDiscoveryResponse{}, err
 	}
 
-	relations, err := s.rankedHomeDiscovery(fmt.Sprintf(`
+	relations, err := s.rankedHomeDiscovery(ctx, fmt.Sprintf(`
 		SELECT a.agent_id, COUNT(*) AS primary_value, 0 AS secondary_value, '' AS dimension
 		FROM user_relations r JOIN agents a ON a.agent_id=r.from_uid
 		WHERE r.rel_type=1 AND r.created_at >= ? AND %s
@@ -255,7 +278,7 @@ func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDisc
 		return homeDiscoveryResponse{}, err
 	}
 
-	discussion, err := s.rankedHomeDiscovery(fmt.Sprintf(`
+	discussion, err := s.rankedHomeDiscovery(ctx, fmt.Sprintf(`
 		SELECT a.agent_id, COUNT(DISTINCT pm.sender_id) FILTER (WHERE pm.sender_id <> a.agent_id) AS primary_value,
 		       COUNT(DISTINCT c.origin_id) AS secondary_value, '' AS dimension
 		FROM conversations c JOIN private_messages pm ON pm.conv_id=c.conv_id
@@ -267,7 +290,7 @@ func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDisc
 		return homeDiscoveryResponse{}, err
 	}
 
-	newStandout, err := s.rankedHomeDiscovery(fmt.Sprintf(`
+	newStandout, err := s.rankedHomeDiscovery(ctx, fmt.Sprintf(`
 		SELECT a.agent_id, COUNT(DISTINCT f.agent_id) FILTER (WHERE f.score > 0) AS primary_value,
 		       COUNT(DISTINCT r.item_id) AS secondary_value, '' AS dimension
 		FROM agents a JOIN raw_items r ON r.author_agent_id=a.agent_id AND r.created_at >= ?
@@ -279,7 +302,7 @@ func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDisc
 		return homeDiscoveryResponse{}, err
 	}
 
-	domain, err := s.rankedHomeDiscovery(fmt.Sprintf(`
+	domain, err := s.rankedHomeDiscovery(ctx, fmt.Sprintf(`
 		WITH domain_activity AS (
 		 SELECT r.author_agent_id AS agent_id, BTRIM(tag) AS dimension, COUNT(*) AS broadcasts,
 		        COALESCE(SUM(s.score_1_count+s.score_2_count),0) AS helpful,
@@ -307,7 +330,7 @@ func (s *Service) loadHomeDiscovery(start, now int64, timezone string) (homeDisc
 		{Key: "domain_representative_today", MetricKey: "recognitions_in_domain_today", Rows: domain},
 	}
 	selected := selectUniqueHomeDiscovery(rules, homeDiscoveryResultLimit)
-	items, err := s.hydrateHomeDiscovery(selected)
+	items, err := s.hydrateHomeDiscovery(ctx, selected)
 	if err != nil {
 		return homeDiscoveryResponse{}, err
 	}
@@ -344,7 +367,7 @@ func selectUniqueHomeDiscovery(rules []homeDiscoveryRule, limit int) []homeDisco
 	return selected
 }
 
-func (s *Service) hydrateHomeDiscovery(selected []homeDiscoveryRule) ([]homeDiscoveryAgent, error) {
+func (s *Service) hydrateHomeDiscovery(ctx context.Context, selected []homeDiscoveryRule) ([]homeDiscoveryAgent, error) {
 	if len(selected) == 0 {
 		return []homeDiscoveryAgent{}, nil
 	}
@@ -353,7 +376,7 @@ func (s *Service) hydrateHomeDiscovery(selected []homeDiscoveryRule) ([]homeDisc
 		ids = append(ids, rule.Rows[0].AgentID)
 	}
 	var rows []homeDiscoveryIdentityRow
-	if err := s.db.Raw(`SELECT a.agent_id, COALESCE(a.short_id,'') AS short_id, a.agent_name,
+	if err := s.db.WithContext(ctx).Raw(`SELECT a.agent_id, COALESCE(a.short_id,'') AS short_id, a.agent_name,
 		COALESCE(a.agent_name_en,'') AS agent_name_en,
 		COALESCE(c.public_card,'{}'::jsonb)::text AS public_card,
 		COALESCE(c.private_card,'{}'::jsonb)::text AS private_card, a.created_at

--- a/api/consolev2/home_discovery_handlers.go
+++ b/api/consolev2/home_discovery_handlers.go
@@ -39,6 +39,10 @@ type homeDiscoveryAgent struct {
 	HumanDescription string              `json:"human_description,omitempty"`
 	Capabilities     []string            `json:"capabilities,omitempty"`
 	Runtime          string              `json:"runtime,omitempty"`
+	IsFriend         bool                `json:"is_friend"`
+	RequestPending   bool                `json:"friend_request_pending"`
+	ShowAddFriend    bool                `json:"show_add_friend"`
+	IsSelf           bool                `json:"is_self"`
 	JoinedAt         int64               `json:"joined_at"`
 	Metric           homeDiscoveryMetric `json:"metric"`
 }
@@ -74,6 +78,13 @@ type homeDiscoveryRule struct {
 	Rows      []homeDiscoveryCandidateRow
 }
 
+type homeDiscoveryRelationRow struct {
+	AgentID       int64 `gorm:"column:agent_id"`
+	IsFriend      bool  `gorm:"column:is_friend"`
+	Pending       bool  `gorm:"column:friend_request_pending"`
+	ShowAddFriend bool  `gorm:"column:show_add_friend"`
+}
+
 func homeDiscoveryDayStart(now time.Time, location *time.Location) int64 {
 	local := now.In(location)
 	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, location).UTC().UnixMilli()
@@ -104,6 +115,10 @@ func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
 	start := homeDiscoveryDayStart(now, location)
 	cacheKey := homeDiscoveryCacheKey(timezone, start)
 	if cached, ok := s.readHomeDiscoveryCache(ctx, cacheKey); ok {
+		if err := s.decorateHomeDiscoveryRelations(agentIDValue, &cached); err != nil {
+			fail(c, http.StatusInternalServerError, "HOME_DISCOVERY_FAILED", "failed to load home discovery relations", nil)
+			return
+		}
 		reply(c, http.StatusOK, cached)
 		return
 	}
@@ -123,7 +138,53 @@ func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
 		fail(c, http.StatusInternalServerError, "HOME_DISCOVERY_FAILED", "failed to load home discovery", nil)
 		return
 	}
-	reply(c, http.StatusOK, value.(homeDiscoveryResponse))
+	result := value.(homeDiscoveryResponse)
+	if err := s.decorateHomeDiscoveryRelations(agentIDValue, &result); err != nil {
+		fail(c, http.StatusInternalServerError, "HOME_DISCOVERY_FAILED", "failed to load home discovery relations", nil)
+		return
+	}
+	reply(c, http.StatusOK, result)
+}
+
+func (s *Service) decorateHomeDiscoveryRelations(viewerAgentID int64, result *homeDiscoveryResponse) error {
+	if result == nil || len(result.Items) == 0 {
+		return nil
+	}
+	ids := make([]int64, 0, len(result.Items))
+	for index := range result.Items {
+		id, err := strconv.ParseInt(result.Items[index].AgentID, 10, 64)
+		if err != nil || id <= 0 {
+			continue
+		}
+		ids = append(ids, id)
+		result.Items[index].ShowAddFriend = true
+		result.Items[index].IsSelf = id == viewerAgentID
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	rows := make([]homeDiscoveryRelationRow, 0, len(ids))
+	if err := s.db.Raw(`SELECT a.agent_id,
+		EXISTS (SELECT 1 FROM user_relations ur WHERE ur.from_uid=? AND ur.to_uid=a.agent_id AND ur.rel_type=1) AS is_friend,
+		EXISTS (SELECT 1 FROM friend_requests fr WHERE fr.from_uid=? AND fr.to_uid=a.agent_id AND fr.status=0) AS friend_request_pending,
+		COALESCE(settings.show_add_friend, TRUE) AS show_add_friend
+		FROM agents a LEFT JOIN agent_settings settings ON settings.agent_id=a.agent_id
+		WHERE a.agent_id = ANY(?)`, viewerAgentID, viewerAgentID, pq.Array(ids)).Scan(&rows).Error; err != nil {
+		return err
+	}
+	byID := make(map[int64]homeDiscoveryRelationRow, len(rows))
+	for _, row := range rows {
+		byID[row.AgentID] = row
+	}
+	for index := range result.Items {
+		id, _ := strconv.ParseInt(result.Items[index].AgentID, 10, 64)
+		if row, ok := byID[id]; ok {
+			result.Items[index].IsFriend = row.IsFriend
+			result.Items[index].RequestPending = row.Pending
+			result.Items[index].ShowAddFriend = row.ShowAddFriend
+		}
+	}
+	return nil
 }
 
 func (s *Service) readHomeDiscoveryCache(ctx context.Context, key string) (homeDiscoveryResponse, bool) {

--- a/api/consolev2/home_discovery_handlers.go
+++ b/api/consolev2/home_discovery_handlers.go
@@ -63,8 +63,8 @@ type homeDiscoveryIdentityRow struct {
 	ShortID     string `gorm:"column:short_id"`
 	AgentName   string `gorm:"column:agent_name"`
 	AgentNameEn string `gorm:"column:agent_name_en"`
-	Country     string `gorm:"column:country"`
 	PublicCard  string `gorm:"column:public_card"`
+	PrivateCard string `gorm:"column:private_card"`
 	CreatedAt   int64  `gorm:"column:created_at"`
 }
 
@@ -81,6 +81,14 @@ func homeDiscoveryDayStart(now time.Time, location *time.Location) int64 {
 
 func homeDiscoveryCacheKey(timezone string, start int64) string {
 	return "console:v2:home:discovery:" + strings.ReplaceAll(timezone, "/", "_") + ":" + strconv.FormatInt(start, 10)
+}
+
+func homeDiscoveryCountryCode(privateJSON string) string {
+	privateCard := map[string]interface{}{}
+	if json.Unmarshal([]byte(privateJSON), &privateCard) != nil {
+		return ""
+	}
+	return todayCountryCode(cardString(privateCard, "geo"))
 }
 
 func (s *Service) getHomeDiscovery(ctx context.Context, c *app.RequestContext) {
@@ -285,9 +293,11 @@ func (s *Service) hydrateHomeDiscovery(selected []homeDiscoveryRule) ([]homeDisc
 	}
 	var rows []homeDiscoveryIdentityRow
 	if err := s.db.Raw(`SELECT a.agent_id, COALESCE(a.short_id,'') AS short_id, a.agent_name,
-		COALESCE(a.agent_name_en,'') AS agent_name_en, COALESCE(p.country,'') AS country, COALESCE(c.public_card,'{}'::jsonb)::text AS public_card, a.created_at
-		FROM agents a LEFT JOIN agent_profiles p ON p.agent_id=a.agent_id
-		LEFT JOIN agent_cards c ON c.agent_id=a.agent_id WHERE a.agent_id = ANY(?)`, pq.Array(ids)).Scan(&rows).Error; err != nil {
+		COALESCE(a.agent_name_en,'') AS agent_name_en,
+		COALESCE(c.public_card,'{}'::jsonb)::text AS public_card,
+		COALESCE(c.private_card,'{}'::jsonb)::text AS private_card, a.created_at
+		FROM agents a LEFT JOIN agent_cards c ON c.agent_id=a.agent_id
+		WHERE a.agent_id = ANY(?)`, pq.Array(ids)).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	identities := make(map[int64]homeDiscoveryIdentityRow, len(rows))
@@ -306,7 +316,7 @@ func (s *Service) hydrateHomeDiscovery(selected []homeDiscoveryRule) ([]homeDisc
 		result = append(result, homeDiscoveryAgent{
 			RuleKey: rule.Key, AgentID: strconv.FormatInt(identity.AgentID, 10), ShortID: identity.ShortID,
 			SharePath: "/agent/" + identity.ShortID, AgentName: identity.AgentName, AgentNameEn: identity.AgentNameEn,
-			CountryCode: todayCountryCode(identity.Country), AgentDescription: cardString(card, "agent_description"),
+			CountryCode: homeDiscoveryCountryCode(identity.PrivateCard), AgentDescription: cardString(card, "agent_description"),
 			HumanDescription: cardString(card, "human_description"), Capabilities: cardStrings(card, "capabilities", 3),
 			Runtime: cardString(card, "runtime"), JoinedAt: identity.CreatedAt,
 			Metric: homeDiscoveryMetric{Key: rule.MetricKey, Value: candidate.Primary, Secondary: candidate.Secondary, Dimension: candidate.Dimension},

--- a/api/consolev2/home_discovery_handlers_test.go
+++ b/api/consolev2/home_discovery_handlers_test.go
@@ -5,6 +5,18 @@ import (
 	"time"
 )
 
+func TestHomeDiscoveryCountryCodeUsesAgentCardGeo(t *testing.T) {
+	if got := homeDiscoveryCountryCode(`{"geo":"Singapore"}`); got != "SG" {
+		t.Fatalf("homeDiscoveryCountryCode()=%q want SG", got)
+	}
+	if got := homeDiscoveryCountryCode(`{"geo":""}`); got != "" {
+		t.Fatalf("empty geo=%q want empty", got)
+	}
+	if got := homeDiscoveryCountryCode(`not-json`); got != "" {
+		t.Fatalf("invalid private card=%q want empty", got)
+	}
+}
+
 func TestHomeDiscoveryDayStartUsesAgentTimezone(t *testing.T) {
 	now := time.Date(2026, 9, 3, 7, 45, 0, 0, time.FixedZone("SGT", 8*60*60))
 	location, err := time.LoadLocation("Asia/Singapore")

--- a/api/consolev2/home_handlers_postgres_test.go
+++ b/api/consolev2/home_handlers_postgres_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -125,6 +126,68 @@ func TestHomeHTTPContracts(t *testing.T) {
 		WHERE agent_id=?`, now, now, agentIDValue).Error; err != nil {
 		t.Fatal(err)
 	}
+	demandAgentID := agentIDValue + 1
+	publishAgentID := agentIDValue + 2
+	demandShortID, err := agentidentity.GenerateShortID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	publishShortID, err := agentidentity.GenerateShortID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO agents
+		(agent_id, short_id, email, email_kind, agent_name, bio, created_at, updated_at, identity_state)
+		VALUES (?, ?, ?, 'internal_alias', 'Demand Contract Agent', '', ?, ?, 'active'),
+		       (?, ?, ?, 'internal_alias', 'Publish Contract Agent', '', ?, ?, 'active')`,
+		demandAgentID, demandShortID, fmt.Sprintf("home-demand-%d@agent.eigenflux.internal", demandAgentID), now-int64(30*24*time.Hour/time.Millisecond), now,
+		publishAgentID, publishShortID, fmt.Sprintf("home-publish-%d@agent.eigenflux.internal", publishAgentID), now-int64(30*24*time.Hour/time.Millisecond), now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = db.Exec(`DELETE FROM agents WHERE agent_id IN (?, ?)`, demandAgentID, publishAgentID).Error
+	})
+
+	firstVoiceItemID := agentIDValue + 10
+	oldDemandItemID := agentIDValue + 11
+	newDemandItemID := agentIDValue + 12
+	newPublishItemID := agentIDValue + 13
+	if err := db.Exec(`INSERT INTO raw_items (item_id, author_agent_id, raw_content, created_at) VALUES
+		(?, ?, 'new Agent first voice', ?), (?, ?, 'older demand', ?),
+		(?, ?, 'newer demand', ?), (?, ?, 'newest general publish', ?)`,
+		firstVoiceItemID, agentIDValue, now-4000,
+		oldDemandItemID, demandAgentID, now-3000,
+		newDemandItemID, demandAgentID, now-2000,
+		newPublishItemID, publishAgentID, now-1000).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO processed_items
+		(item_id, status, summary, broadcast_type, quality_score, lang, updated_at,
+		 homepage_eligible, homepage_evaluation_version, homepage_real_world_relevant)
+		VALUES (?, 3, 'new Agent first voice', 'info', 0.70, 'en', ?, TRUE, ?, FALSE),
+		       (?, 3, 'older demand', 'demand', 0.95, 'en', ?, TRUE, ?, FALSE),
+		       (?, 3, 'newer demand', 'demand', 0.80, 'en', ?, TRUE, ?, FALSE),
+		       (?, 3, 'newest general publish', 'info', 0.99, 'en', ?, TRUE, ?, FALSE)`,
+		firstVoiceItemID, now, homepageEvaluationVersion,
+		oldDemandItemID, now, homepageEvaluationVersion,
+		newDemandItemID, now, homepageEvaluationVersion,
+		newPublishItemID, now, homepageEvaluationVersion).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO item_stats
+		(item_id, author_agent_id, score_1_count, score_2_count, created_at, updated_at)
+		VALUES (?, ?, 1, 0, ?, ?), (?, ?, 9, 0, ?, ?),
+		       (?, ?, 2, 0, ?, ?), (?, ?, 3, 0, ?, ?)`,
+		firstVoiceItemID, agentIDValue, now, now,
+		oldDemandItemID, demandAgentID, now, now,
+		newDemandItemID, demandAgentID, now, now,
+		newPublishItemID, publishAgentID, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = db.Exec(`DELETE FROM processed_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
+		_ = db.Exec(`DELETE FROM raw_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
+	})
 
 	generatedAt := time.Now().UnixMilli()
 	dayStart := homeDiscoveryDayStart(time.Now(), time.UTC)
@@ -155,7 +218,7 @@ func TestHomeHTTPContracts(t *testing.T) {
 		}
 	}
 	discoveryKey := homeDiscoveryCacheKey("UTC", dayStart)
-	worthKey := homeWorthWatchingCacheKey("UTC", dayStart)
+	worthKey := homeWorthWatchingCacheKey()
 	writeJSON(discoveryKey, discoveryCached)
 	writeJSON(homeActivityCacheKey, activityCached)
 	writeJSON(worthKey, worthCached)
@@ -191,6 +254,13 @@ func TestHomeHTTPContracts(t *testing.T) {
 			if !ok || len(rows) > limits[path] {
 				t.Fatalf("%s %s=%#v limit=%d", path, collection, data[collection], limits[path])
 			}
+			if path == "/api/v2/console/home/worth-watching" {
+				assertHomeWorthWatchingReasons(t, rows, map[string]string{
+					"new_real_world_demand":  strconv.FormatInt(newDemandItemID, 10),
+					"noteworthy_new_publish": strconv.FormatInt(newPublishItemID, 10),
+					"new_agent_first_voice":  strconv.FormatInt(firstVoiceItemID, 10),
+				})
+			}
 		}
 		for _, key := range []string{discoveryKey, homeActivityCacheKey, worthKey} {
 			raw, err := redisClient.Get(context.Background(), key).Bytes()
@@ -218,6 +288,29 @@ func TestHomeHTTPContracts(t *testing.T) {
 			}
 		}
 	})
+}
+
+func assertHomeWorthWatchingReasons(t *testing.T, rows []interface{}, want map[string]string) {
+	t.Helper()
+	got := make(map[string]string, len(want))
+	for _, raw := range rows {
+		row, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rule, _ := row["rule_key"].(string)
+		itemID, _ := row["item_id"].(string)
+		if _, tracked := want[rule]; tracked {
+			if _, exists := got[rule]; !exists {
+				got[rule] = itemID
+			}
+		}
+	}
+	for rule, itemID := range want {
+		if got[rule] != itemID {
+			t.Fatalf("worth-watching rule %s item=%q, want %q; all=%#v", rule, got[rule], itemID, rows)
+		}
+	}
 }
 
 func assertHomeCachedResponse(t *testing.T, h *server.Hertz, path, collection, idField, wantID string, cookie ut.Header) {

--- a/api/consolev2/home_handlers_postgres_test.go
+++ b/api/consolev2/home_handlers_postgres_test.go
@@ -1,0 +1,244 @@
+package consolev2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	redis "github.com/redis/go-redis/v9"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/config"
+)
+
+func TestHomeHTTPContracts(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for homepage PostgreSQL contracts")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UnixMilli()
+	agentIDValue := time.Now().UnixNano()
+	email := fmt.Sprintf("home-contract-%d@example.test", agentIDValue)
+	shortID, err := agentidentity.GenerateShortID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO agents
+		(agent_id, short_id, email, email_kind, agent_name, bio, created_at, updated_at, identity_state)
+		VALUES (?, ?, ?, 'v2_bound', 'Home Contract Agent', '', ?, ?, 'active')`,
+		agentIDValue, shortID, email, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Exec(`DELETE FROM agents WHERE agent_id = ?`, agentIDValue).Error })
+
+	var principalID int64
+	if err := db.Raw(`INSERT INTO agent_principals
+		(agent_id, key_type, key_fingerprint, public_key, key_version, status, created_at, last_seen_at)
+		VALUES (?, 'ed25519-v1', ?, decode(repeat('42', 32), 'hex'), 1, 'active', ?, ?)
+		RETURNING principal_id`, agentIDValue, fmt.Sprintf("home-contract-%d", agentIDValue), now, now).
+		Scan(&principalID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO agent_cards
+		(agent_id, public_card, private_card, schema_version, source_version, rebuild_fence,
+		 card_version, public_card_version, generated_at, public_card_generated_at)
+		VALUES (?, '{}'::jsonb, '{"timezone":"UTC"}'::jsonb, 1, 1, 0, 1, 1, ?, 0)`,
+		agentIDValue, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO agent_onboarding_v2
+		(agent_id, state, current_step, revision, created_at, updated_at)
+		VALUES (?, 'in_progress', 4, 1, ?, ?)`, agentIDValue, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	sessionID := fmt.Sprintf("home-contract-session-%d", agentIDValue)
+	sessionSecret := fmt.Sprintf("home-contract-secret-%d", agentIDValue)
+	if err := db.Exec(`INSERT INTO console_v2_sessions
+		(session_id, session_secret_hash, agent_id, principal_id, csrf_secret_hash, status, scopes,
+		 issued_at, idle_expires_at, absolute_expires_at, last_seen_at, auth_method)
+		VALUES (?, ?, ?, ?, ?, 'active', '{}'::text[], ?, ?, ?, ?, 'handoff')`,
+		sessionID, hashString(sessionSecret), agentIDValue, principalID, hashString("unused-csrf"),
+		now, now+int64(time.Hour/time.Millisecond), now+int64(2*time.Hour/time.Millisecond), now).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() { _ = redisClient.Close() })
+	svc, err := NewService(db, &fixedIDGenerator{id: agentIDValue + 100}, &config.Config{
+		ConsoleV2BootstrapSecret: "home-contract-secret",
+		ConsoleV2OTPPepper:       "home-contract-pepper",
+		ConsoleV2PublicURL:       "https://console.example.test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.redisClient = redisClient
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	svc.Register(h)
+
+	paths := []string{
+		"/api/v2/console/home/discovery",
+		"/api/v2/console/home/activity",
+		"/api/v2/console/home/worth-watching",
+	}
+	for _, path := range paths {
+		t.Run("unauthorized "+path, func(t *testing.T) {
+			status, payload, _ := performJSON(t, h, http.MethodGet, path, map[string]interface{}{})
+			if status != http.StatusUnauthorized || responseErrorCode(t, payload) != "CONSOLE_SESSION_REQUIRED" {
+				t.Fatalf("status=%d payload=%#v", status, payload)
+			}
+		})
+	}
+
+	cookie := ut.Header{Key: "Cookie", Value: consoleCookieName + "=" + sessionID + "." + sessionSecret}
+	for _, path := range paths {
+		t.Run("onboarding required "+path, func(t *testing.T) {
+			status, payload, _ := performJSON(t, h, http.MethodGet, path, map[string]interface{}{}, cookie)
+			if status != http.StatusConflict || responseErrorCode(t, payload) != "ONBOARDING_REQUIRED" {
+				t.Fatalf("status=%d payload=%#v", status, payload)
+			}
+		})
+	}
+
+	if err := db.Exec(`INSERT INTO agent_context_revisions
+		(agent_id, revision, compiled_context, schema_version, generated_at)
+		VALUES (?, 1, '{}'::jsonb, 1, ?)`, agentIDValue, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`UPDATE agent_onboarding_v2
+		SET state='completed', current_step=5, active_context_revision=1, completed_at=?, updated_at=?
+		WHERE agent_id=?`, now, now, agentIDValue).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	generatedAt := time.Now().UnixMilli()
+	dayStart := homeDiscoveryDayStart(time.Now(), time.UTC)
+	discoveryCached := homeDiscoveryResponse{
+		Items: []homeDiscoveryAgent{{RuleKey: "recognized", AgentID: "101", ShortID: "agent-101", AgentName: "Cached Discovery", JoinedAt: now,
+			Metric: homeDiscoveryMetric{Key: "recognition", Value: 3}}},
+		WindowStart: dayStart, WindowTimezone: "UTC", GeneratedAt: generatedAt,
+		CacheTTLSeconds: int64(homeDiscoveryCacheTTL / time.Second),
+	}
+	activityCached := homeActivityResponse{
+		Events:      []homeActivityEvent{{ID: "broadcast:201", Type: "broadcast", CreatedAt: now, ActorName: "Cached Activity", Private: false}},
+		GeneratedAt: generatedAt, CacheTTLSeconds: int64(homeActivityCacheTTL / time.Second),
+	}
+	worthCached := homeWorthWatchingResponse{
+		Items: []homeWorthWatchingItem{{RuleKey: "trending", ItemID: "301", Content: "cached worth watching", CreatedAt: now,
+			AgentID: "101", AgentShortID: "agent-101", AgentName: "Cached Worth", Metric: homeWorthWatchingMetric{Key: "engagement", Value: 5}}},
+		WindowStart: time.Now().Add(-7 * 24 * time.Hour).UnixMilli(), WindowTimezone: "UTC", GeneratedAt: generatedAt,
+		CacheTTLSeconds: int64(homeWorthWatchingCacheTTL / time.Second), EvaluationVersion: homepageEvaluationVersion,
+	}
+	writeJSON := func(key string, value interface{}) {
+		t.Helper()
+		raw, marshalErr := json.Marshal(value)
+		if marshalErr != nil {
+			t.Fatal(marshalErr)
+		}
+		if setErr := redisClient.Set(context.Background(), key, raw, time.Minute).Err(); setErr != nil {
+			t.Fatal(setErr)
+		}
+	}
+	discoveryKey := homeDiscoveryCacheKey("UTC", dayStart)
+	worthKey := homeWorthWatchingCacheKey("UTC", dayStart)
+	writeJSON(discoveryKey, discoveryCached)
+	writeJSON(homeActivityCacheKey, activityCached)
+	writeJSON(worthKey, worthCached)
+
+	t.Run("cache hit response envelopes and field types", func(t *testing.T) {
+		assertHomeCachedResponse(t, h, "/api/v2/console/home/discovery", "items", "agent_id", "101", cookie)
+		assertHomeCachedResponse(t, h, "/api/v2/console/home/activity", "events", "id", "broadcast:201", cookie)
+		assertHomeCachedResponse(t, h, "/api/v2/console/home/worth-watching", "items", "item_id", "301", cookie)
+	})
+
+	t.Run("corrupt cache falls back to SQL and rebuilds bounded responses", func(t *testing.T) {
+		for _, key := range []string{discoveryKey, homeActivityCacheKey, worthKey} {
+			if err := redisClient.Set(context.Background(), key, "{", time.Minute).Err(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		limits := map[string]int{
+			"/api/v2/console/home/discovery":      homeDiscoveryResultLimit,
+			"/api/v2/console/home/activity":       homeActivityLimit,
+			"/api/v2/console/home/worth-watching": 7 * homeWorthWatchingCandidateMax,
+		}
+		for _, path := range paths {
+			status, payload, _ := performJSON(t, h, http.MethodGet, path, map[string]interface{}{}, cookie)
+			if status != http.StatusOK {
+				t.Fatalf("%s status=%d payload=%#v", path, status, payload)
+			}
+			data := responseData(t, payload)
+			collection := "items"
+			if path == "/api/v2/console/home/activity" {
+				collection = "events"
+			}
+			rows, ok := data[collection].([]interface{})
+			if !ok || len(rows) > limits[path] {
+				t.Fatalf("%s %s=%#v limit=%d", path, collection, data[collection], limits[path])
+			}
+		}
+		for _, key := range []string{discoveryKey, homeActivityCacheKey, worthKey} {
+			raw, err := redisClient.Get(context.Background(), key).Bytes()
+			if err != nil || !json.Valid(raw) {
+				t.Fatalf("cache %s was not rebuilt: err=%v raw=%q", key, err, raw)
+			}
+		}
+	})
+
+	t.Run("redis outage degrades to SQL", func(t *testing.T) {
+		available := svc.redisClient
+		unavailable := redis.NewClient(&redis.Options{
+			Addr: "127.0.0.1:1", MaxRetries: 0,
+			DialTimeout: 10 * time.Millisecond, ReadTimeout: 10 * time.Millisecond, WriteTimeout: 10 * time.Millisecond,
+		})
+		svc.redisClient = unavailable
+		t.Cleanup(func() {
+			svc.redisClient = available
+			_ = unavailable.Close()
+		})
+		for _, path := range paths {
+			status, payload, _ := performJSON(t, h, http.MethodGet, path, map[string]interface{}{}, cookie)
+			if status != http.StatusOK {
+				t.Fatalf("%s status=%d payload=%#v", path, status, payload)
+			}
+		}
+	})
+}
+
+func assertHomeCachedResponse(t *testing.T, h *server.Hertz, path, collection, idField, wantID string, cookie ut.Header) {
+	t.Helper()
+	status, payload, _ := performJSON(t, h, http.MethodGet, path, map[string]interface{}{}, cookie)
+	if status != http.StatusOK {
+		t.Fatalf("%s status=%d payload=%#v", path, status, payload)
+	}
+	data := responseData(t, payload)
+	rows, ok := data[collection].([]interface{})
+	if !ok || len(rows) != 1 {
+		t.Fatalf("%s %s=%#v", path, collection, data[collection])
+	}
+	row, ok := rows[0].(map[string]interface{})
+	if !ok || row[idField] != wantID {
+		t.Fatalf("%s row=%#v, want %s=%q", path, rows[0], idField, wantID)
+	}
+	if _, ok := data["generated_at"].(float64); !ok {
+		t.Fatalf("%s generated_at has unexpected type: %#v", path, data["generated_at"])
+	}
+	if _, ok := data["cache_ttl_seconds"].(float64); !ok {
+		t.Fatalf("%s cache_ttl_seconds has unexpected type: %#v", path, data["cache_ttl_seconds"])
+	}
+}

--- a/api/consolev2/home_observability.go
+++ b/api/consolev2/home_observability.go
@@ -1,0 +1,21 @@
+package consolev2
+
+import (
+	"time"
+
+	"eigenflux_server/pkg/metrics"
+)
+
+const homeRefreshTimeout = 10 * time.Second
+
+func recordHomeCache(module, result string) {
+	metrics.ConsoleHomeCacheTotal.WithLabelValues(module, result).Inc()
+}
+
+func observeHomeRefresh(module string, started time.Time, err error) {
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	metrics.ConsoleHomeRefreshDuration.WithLabelValues(module, result).Observe(time.Since(started).Seconds())
+}

--- a/api/consolev2/home_worth_watching_handlers.go
+++ b/api/consolev2/home_worth_watching_handlers.go
@@ -16,8 +16,7 @@ import (
 const (
 	homeWorthWatchingCacheTTL     = 2 * time.Minute
 	homeWorthWatchingCandidateMax = 32
-	homeWorthWatchingResultMax    = 24
-	homeWorthWatchingCacheVersion = "weekly-v3"
+	homeWorthWatchingCacheVersion = "weekly-v4"
 	homepageEvaluationVersion     = "homepage-v2"
 )
 
@@ -270,6 +269,7 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 	}
 
 	rules := []homeWorthWatchingRule{
+		{Key: "real_world_signal", MetricKey: "quality_score_percent", Rows: realWorld},
 		{Key: "trending_now", MetricKey: "replies_last_hour", Rows: trending},
 		{Key: "most_agents_participating", MetricKey: "participating_agents_week", Rows: participated},
 		{Key: "most_agents_found_helpful", MetricKey: "helpful_agents_week", Rows: helpful},
@@ -277,11 +277,7 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		{Key: "noteworthy_new_publish", MetricKey: "quality_score_percent", Rows: newContent},
 		{Key: "new_agent_first_voice", MetricKey: "broadcast_number", Rows: firstVoice},
 	}
-	selected := selectPreferredHomeWorthWatching(
-		homeWorthWatchingRule{Key: "real_world_signal", MetricKey: "quality_score_percent", Rows: realWorld},
-		rules,
-		homeWorthWatchingResultMax,
-	)
+	selected := selectUniqueHomeWorthWatching(rules, homeWorthWatchingCandidateCount(rules))
 	items, err := s.hydrateHomeWorthWatching(selected)
 	if err != nil {
 		return homeWorthWatchingResponse{}, err
@@ -292,46 +288,12 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 	}, nil
 }
 
-func selectPreferredHomeWorthWatching(preferred homeWorthWatchingRule, rules []homeWorthWatchingRule, limit int) []homeWorthWatchingRule {
-	if limit <= 0 {
-		return []homeWorthWatchingRule{}
-	}
-	selected := make([]homeWorthWatchingRule, 0, limit)
-	usedItems := map[int64]struct{}{}
-	for _, row := range preferred.Rows {
-		if len(selected) >= limit {
-			return selected
-		}
-		if row.ItemID <= 0 || row.AgentID <= 0 {
-			continue
-		}
-		if _, exists := usedItems[row.ItemID]; exists {
-			continue
-		}
-		usedItems[row.ItemID] = struct{}{}
-		rule := preferred
-		rule.Rows = []homeWorthWatchingCandidate{row}
-		selected = append(selected, rule)
-	}
-	filteredRules := make([]homeWorthWatchingRule, 0, len(rules))
+func homeWorthWatchingCandidateCount(rules []homeWorthWatchingRule) int {
+	total := 0
 	for _, rule := range rules {
-		filtered := rule
-		filtered.Rows = make([]homeWorthWatchingCandidate, 0, len(rule.Rows))
-		for _, row := range rule.Rows {
-			if _, exists := usedItems[row.ItemID]; !exists {
-				filtered.Rows = append(filtered.Rows, row)
-			}
-		}
-		filteredRules = append(filteredRules, filtered)
+		total += len(rule.Rows)
 	}
-	for _, rule := range selectUniqueHomeWorthWatching(filteredRules, limit-len(selected)) {
-		if len(selected) >= limit {
-			break
-		}
-		usedItems[rule.Rows[0].ItemID] = struct{}{}
-		selected = append(selected, rule)
-	}
-	return selected
+	return total
 }
 
 func selectUniqueHomeWorthWatching(rules []homeWorthWatchingRule, limit int) []homeWorthWatchingRule {

--- a/api/consolev2/home_worth_watching_handlers.go
+++ b/api/consolev2/home_worth_watching_handlers.go
@@ -3,20 +3,21 @@ package consolev2
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/lib/pq"
+	redis "github.com/redis/go-redis/v9"
 )
 
 const (
 	homeWorthWatchingCacheTTL     = 2 * time.Minute
 	homeWorthWatchingCandidateMax = 32
-	homeWorthWatchingCacheVersion = "weekly-v4"
+	homeWorthWatchingCacheVersion = "weekly-v5"
 	homepageEvaluationVersion     = "homepage-v2"
 )
 
@@ -84,39 +85,34 @@ type homeWorthWatchingContentRow struct {
 	HelpfulCount    int64   `gorm:"column:helpful_count"`
 }
 
-func homeWorthWatchingCacheKey(timezone string, start int64) string {
-	return "console:v2:home:worth-watching:" + homeWorthWatchingCacheVersion + ":" + homepageEvaluationVersion + ":" +
-		strings.ReplaceAll(timezone, "/", "_") + ":" + strconv.FormatInt(start, 10)
+func homeWorthWatchingCacheKey() string {
+	return "console:v2:home:worth-watching:" + homeWorthWatchingCacheVersion + ":" + homepageEvaluationVersion
 }
 
 func (s *Service) getHomeWorthWatching(ctx context.Context, c *app.RequestContext) {
-	agentIDValue, _ := agentID(c)
-	var privateCard string
-	if err := s.db.Raw(`SELECT COALESCE(private_card, '{}'::jsonb)::text
-		FROM agent_cards WHERE agent_id = ?`, agentIDValue).Scan(&privateCard).Error; err != nil {
-		fail(c, http.StatusInternalServerError, "HOME_WORTH_WATCHING_FAILED", "failed to load homepage timezone", nil)
-		return
-	}
-
+	requestCtx, cancelRequest := context.WithTimeout(ctx, homeRefreshTimeout)
+	defer cancelRequest()
 	now := time.Now()
-	location, timezone := todayLocationFromPrivateCard(privateCard)
-	dayBucket := homeDiscoveryDayStart(now, location)
 	windowStart := now.Add(-7 * 24 * time.Hour).UnixMilli()
-	cacheKey := homeWorthWatchingCacheKey(timezone, dayBucket)
-	if cached, ok := s.readHomeWorthWatchingCache(ctx, cacheKey); ok {
+	cacheKey := homeWorthWatchingCacheKey()
+	if cached, ok := s.readHomeWorthWatchingCache(requestCtx, cacheKey); ok {
 		reply(c, http.StatusOK, cached)
 		return
 	}
 
 	value, err, _ := s.homeWorthWatchingRefresh.Do(cacheKey, func() (interface{}, error) {
-		if cached, ok := s.readHomeWorthWatchingCache(ctx, cacheKey); ok {
+		refreshCtx, cancel := context.WithTimeout(context.Background(), homeRefreshTimeout)
+		defer cancel()
+		if cached, ok := s.readHomeWorthWatchingCache(refreshCtx, cacheKey); ok {
 			return cached, nil
 		}
-		result, loadErr := s.loadHomeWorthWatching(windowStart, now.UnixMilli(), timezone)
+		started := time.Now()
+		result, loadErr := s.loadHomeWorthWatching(refreshCtx, windowStart, now.UnixMilli())
+		observeHomeRefresh("worth_watching", started, loadErr)
 		if loadErr != nil {
 			return homeWorthWatchingResponse{}, loadErr
 		}
-		s.writeHomeWorthWatchingCache(ctx, cacheKey, result)
+		s.writeHomeWorthWatchingCache(refreshCtx, cacheKey, result)
 		return result, nil
 	})
 	if err != nil {
@@ -128,16 +124,24 @@ func (s *Service) getHomeWorthWatching(ctx context.Context, c *app.RequestContex
 
 func (s *Service) readHomeWorthWatchingCache(ctx context.Context, key string) (homeWorthWatchingResponse, bool) {
 	if s.redisClient == nil {
+		recordHomeCache("worth_watching", "disabled")
 		return homeWorthWatchingResponse{}, false
 	}
 	raw, err := s.redisClient.Get(ctx, key).Bytes()
 	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			recordHomeCache("worth_watching", "miss")
+		} else {
+			recordHomeCache("worth_watching", "error")
+		}
 		return homeWorthWatchingResponse{}, false
 	}
 	var result homeWorthWatchingResponse
 	if json.Unmarshal(raw, &result) != nil || result.GeneratedAt <= 0 || result.EvaluationVersion != homepageEvaluationVersion {
+		recordHomeCache("worth_watching", "corrupt")
 		return homeWorthWatchingResponse{}, false
 	}
+	recordHomeCache("worth_watching", "hit")
 	return result, true
 }
 
@@ -145,24 +149,31 @@ func (s *Service) writeHomeWorthWatchingCache(ctx context.Context, key string, r
 	if s.redisClient == nil {
 		return
 	}
-	if raw, err := json.Marshal(result); err == nil {
-		_ = s.redisClient.Set(ctx, key, raw, homeWorthWatchingCacheTTL).Err()
+	raw, err := json.Marshal(result)
+	if err != nil {
+		recordHomeCache("worth_watching", "encode_error")
+		return
 	}
+	if err := s.redisClient.Set(ctx, key, raw, homeWorthWatchingCacheTTL).Err(); err != nil {
+		recordHomeCache("worth_watching", "write_error")
+		return
+	}
+	recordHomeCache("worth_watching", "write_success")
 }
 
-func (s *Service) rankedHomeWorthWatching(sql string, args ...interface{}) ([]homeWorthWatchingCandidate, error) {
+func (s *Service) rankedHomeWorthWatching(ctx context.Context, sql string, args ...interface{}) ([]homeWorthWatchingCandidate, error) {
 	rows := make([]homeWorthWatchingCandidate, 0, homeWorthWatchingCandidateMax)
-	if err := s.db.Raw(sql, args...).Scan(&rows).Error; err != nil {
+	if err := s.db.WithContext(ctx).Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (homeWorthWatchingResponse, error) {
+func (s *Service) loadHomeWorthWatching(ctx context.Context, start, now int64) (homeWorthWatchingResponse, error) {
 	eligible := `p.status=3 AND p.homepage_eligible=TRUE AND p.homepage_evaluation_version=?
 		AND a.short_id IS NOT NULL AND BTRIM(a.agent_name) <> ''`
 
-	realWorld, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
+	realWorld, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
 		SELECT r.item_id, r.author_agent_id AS agent_id,
 		       COALESCE(ROUND(p.quality_score * 100),0)::bigint AS primary_value,
 		       COALESCE(s.score_1_count+s.score_2_count,0) AS secondary_value
@@ -175,7 +186,7 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		return homeWorthWatchingResponse{}, err
 	}
 
-	trending, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
+	trending, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
 		SELECT r.item_id, r.author_agent_id AS agent_id,
 		       COUNT(*) FILTER (WHERE pm.created_at >= ?) AS primary_value,
 		       COUNT(DISTINCT pm.sender_id) FILTER (WHERE pm.sender_id <> r.author_agent_id) AS secondary_value
@@ -192,7 +203,7 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		return homeWorthWatchingResponse{}, err
 	}
 
-	participated, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
+	participated, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
 		SELECT r.item_id, r.author_agent_id AS agent_id,
 		       COUNT(DISTINCT pm.sender_id) FILTER (WHERE pm.sender_id <> r.author_agent_id) AS primary_value,
 		       COUNT(*) AS secondary_value
@@ -208,7 +219,7 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		return homeWorthWatchingResponse{}, err
 	}
 
-	helpful, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
+	helpful, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
 		SELECT r.item_id, r.author_agent_id AS agent_id,
 		       COUNT(DISTINCT f.agent_id) AS primary_value, COUNT(*) AS secondary_value
 		FROM raw_items r JOIN processed_items p ON p.item_id=r.item_id
@@ -221,24 +232,21 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		return homeWorthWatchingResponse{}, err
 	}
 
-	demand, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
+	demand, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
 		SELECT r.item_id, r.author_agent_id AS agent_id,
-		       COUNT(DISTINCT f.agent_id) FILTER (WHERE f.score > 0) AS primary_value,
-		       COUNT(DISTINCT pm.sender_id) FILTER (WHERE pm.sender_id <> r.author_agent_id) AS secondary_value
+		       COALESCE(s.score_1_count+s.score_2_count,0) AS primary_value,
+		       COALESCE(ROUND(p.quality_score * 100),0)::bigint AS secondary_value
 		FROM raw_items r JOIN processed_items p ON p.item_id=r.item_id
 		JOIN agents a ON a.agent_id=r.author_agent_id
-		LEFT JOIN feedback_logs f ON f.item_id=r.item_id AND f.feedback_at >= ?
-		LEFT JOIN conversations c ON c.origin_type='broadcast' AND c.origin_id=r.item_id
-		LEFT JOIN private_messages pm ON pm.conv_id=c.conv_id AND pm.created_at >= ?
+		LEFT JOIN item_stats s ON s.item_id=r.item_id
 		WHERE r.created_at >= ? AND p.broadcast_type='demand' AND %s
-		GROUP BY r.item_id, r.author_agent_id, p.quality_score
-		ORDER BY primary_value DESC, secondary_value DESC, p.quality_score DESC, r.created_at DESC LIMIT ?`, eligible),
-		start, start, start, homepageEvaluationVersion, homeWorthWatchingCandidateMax)
+		ORDER BY r.created_at DESC, p.quality_score DESC, primary_value DESC LIMIT ?`, eligible),
+		start, homepageEvaluationVersion, homeWorthWatchingCandidateMax)
 	if err != nil {
 		return homeWorthWatchingResponse{}, err
 	}
 
-	newContent, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
+	newContent, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
 		SELECT r.item_id, r.author_agent_id AS agent_id,
 		       COALESCE(ROUND(p.quality_score * 100),0)::bigint AS primary_value,
 		       COALESCE(s.score_1_count+s.score_2_count,0) AS secondary_value
@@ -251,17 +259,19 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		return homeWorthWatchingResponse{}, err
 	}
 
-	firstVoice, err := s.rankedHomeWorthWatching(fmt.Sprintf(`
-		WITH first_broadcasts AS (
-			SELECT r.item_id, r.author_agent_id, r.created_at,
-			       ROW_NUMBER() OVER (PARTITION BY r.author_agent_id ORDER BY r.created_at, r.item_id) AS broadcast_number
-			FROM raw_items r JOIN processed_items completed ON completed.item_id=r.item_id AND completed.status=3)
-		SELECT r.item_id, r.author_agent_id AS agent_id, fb.broadcast_number AS primary_value,
+	firstVoice, err := s.rankedHomeWorthWatching(ctx, fmt.Sprintf(`
+		SELECT r.item_id, r.author_agent_id AS agent_id, 1 AS primary_value,
 		       COALESCE(s.score_1_count+s.score_2_count,0) AS secondary_value
-		FROM first_broadcasts fb JOIN raw_items r ON r.item_id=fb.item_id
-		JOIN processed_items p ON p.item_id=r.item_id JOIN agents a ON a.agent_id=r.author_agent_id
+		FROM agents a JOIN LATERAL (
+			SELECT candidate.item_id, candidate.author_agent_id, candidate.created_at
+			FROM raw_items candidate
+			JOIN processed_items completed ON completed.item_id=candidate.item_id AND completed.status=3
+			WHERE candidate.author_agent_id=a.agent_id
+			ORDER BY candidate.created_at, candidate.item_id LIMIT 1
+		) r ON TRUE
+		JOIN processed_items p ON p.item_id=r.item_id
 		LEFT JOIN item_stats s ON s.item_id=r.item_id
-		WHERE fb.broadcast_number <= 3 AND a.created_at >= ? AND r.created_at >= ? AND %s
+		WHERE a.created_at >= ? AND r.created_at >= ? AND %s
 		ORDER BY secondary_value DESC, p.quality_score DESC, r.created_at DESC LIMIT ?`, eligible),
 		now-int64(14*24*time.Hour/time.Millisecond), start, homepageEvaluationVersion, homeWorthWatchingCandidateMax)
 	if err != nil {
@@ -273,17 +283,17 @@ func (s *Service) loadHomeWorthWatching(start, now int64, timezone string) (home
 		{Key: "trending_now", MetricKey: "replies_last_hour", Rows: trending},
 		{Key: "most_agents_participating", MetricKey: "participating_agents_week", Rows: participated},
 		{Key: "most_agents_found_helpful", MetricKey: "helpful_agents_week", Rows: helpful},
-		{Key: "new_real_world_demand", MetricKey: "helpful_agents_week", Rows: demand},
+		{Key: "new_real_world_demand", MetricKey: "helpful_count", Rows: demand},
 		{Key: "noteworthy_new_publish", MetricKey: "quality_score_percent", Rows: newContent},
 		{Key: "new_agent_first_voice", MetricKey: "broadcast_number", Rows: firstVoice},
 	}
 	selected := selectUniqueHomeWorthWatching(rules, homeWorthWatchingCandidateCount(rules))
-	items, err := s.hydrateHomeWorthWatching(selected)
+	items, err := s.hydrateHomeWorthWatching(ctx, selected)
 	if err != nil {
 		return homeWorthWatchingResponse{}, err
 	}
 	return homeWorthWatchingResponse{
-		Items: items, WindowStart: start, WindowTimezone: timezone, GeneratedAt: now,
+		Items: items, WindowStart: start, WindowTimezone: "UTC", GeneratedAt: now,
 		CacheTTLSeconds: int64(homeWorthWatchingCacheTTL / time.Second), EvaluationVersion: homepageEvaluationVersion,
 	}, nil
 }
@@ -346,7 +356,7 @@ func selectUniqueHomeWorthWatching(rules []homeWorthWatchingRule, limit int) []h
 	return selected
 }
 
-func (s *Service) hydrateHomeWorthWatching(selected []homeWorthWatchingRule) ([]homeWorthWatchingItem, error) {
+func (s *Service) hydrateHomeWorthWatching(ctx context.Context, selected []homeWorthWatchingRule) ([]homeWorthWatchingItem, error) {
 	if len(selected) == 0 {
 		return []homeWorthWatchingItem{}, nil
 	}
@@ -355,7 +365,7 @@ func (s *Service) hydrateHomeWorthWatching(selected []homeWorthWatchingRule) ([]
 		ids = append(ids, rule.Rows[0].ItemID)
 	}
 	var rows []homeWorthWatchingContentRow
-	if err := s.db.Raw(`SELECT r.item_id, r.author_agent_id AS agent_id, r.raw_content AS content,
+	if err := s.db.WithContext(ctx).Raw(`SELECT r.item_id, r.author_agent_id AS agent_id, r.raw_content AS content,
 		COALESCE(p.summary,'') AS summary, COALESCE(p.lang,'') AS language,
 		COALESCE(p.broadcast_type,'') AS broadcast_type, r.created_at,
 		COALESCE(a.short_id,'') AS short_id, a.agent_name, COALESCE(a.agent_name_en,'') AS agent_name_en,

--- a/api/consolev2/home_worth_watching_handlers_test.go
+++ b/api/consolev2/home_worth_watching_handlers_test.go
@@ -34,23 +34,21 @@ func TestSelectUniqueHomeWorthWatchingAllowsRepeatedAgentOnlyToFillRule(t *testi
 
 func TestHomeWorthWatchingCacheKeyIncludesPolicyAndDay(t *testing.T) {
 	got := homeWorthWatchingCacheKey("Asia/Singapore", 12345)
-	want := "console:v2:home:worth-watching:weekly-v3:homepage-v2:Asia_Singapore:12345"
+	want := "console:v2:home:worth-watching:weekly-v4:homepage-v2:Asia_Singapore:12345"
 	if got != want {
 		t.Fatalf("cache key = %q, want %q", got, want)
 	}
 }
 
-func TestSelectPreferredHomeWorthWatchingPutsAllRealWorldSignalsFirst(t *testing.T) {
-	preferred := homeWorthWatchingRule{Key: "real_world_signal", Rows: []homeWorthWatchingCandidate{
-		{ItemID: 101, AgentID: 1}, {ItemID: 102, AgentID: 2},
-	}}
+func TestSelectHomeWorthWatchingDispersesAllReasons(t *testing.T) {
 	rules := []homeWorthWatchingRule{
+		{Key: "real_world_signal", Rows: []homeWorthWatchingCandidate{{ItemID: 101, AgentID: 1}, {ItemID: 102, AgentID: 2}}},
 		{Key: "trending", Rows: []homeWorthWatchingCandidate{{ItemID: 101, AgentID: 1}, {ItemID: 201, AgentID: 3}}},
 		{Key: "helpful", Rows: []homeWorthWatchingCandidate{{ItemID: 202, AgentID: 4}}},
 	}
-	got := selectPreferredHomeWorthWatching(preferred, rules, 4)
-	wantItems := []int64{101, 102, 201, 202}
-	wantKeys := []string{"real_world_signal", "real_world_signal", "trending", "helpful"}
+	got := selectUniqueHomeWorthWatching(rules, homeWorthWatchingCandidateCount(rules))
+	wantItems := []int64{101, 201, 202, 102}
+	wantKeys := []string{"real_world_signal", "trending", "helpful", "real_world_signal"}
 	for i := range wantItems {
 		if got[i].Rows[0].ItemID != wantItems[i] || got[i].Key != wantKeys[i] {
 			t.Fatalf("selected[%d] = %#v, want key=%s item=%d", i, got[i], wantKeys[i], wantItems[i])

--- a/api/consolev2/home_worth_watching_handlers_test.go
+++ b/api/consolev2/home_worth_watching_handlers_test.go
@@ -32,9 +32,9 @@ func TestSelectUniqueHomeWorthWatchingAllowsRepeatedAgentOnlyToFillRule(t *testi
 	}
 }
 
-func TestHomeWorthWatchingCacheKeyIncludesPolicyAndDay(t *testing.T) {
-	got := homeWorthWatchingCacheKey("Asia/Singapore", 12345)
-	want := "console:v2:home:worth-watching:weekly-v4:homepage-v2:Asia_Singapore:12345"
+func TestHomeWorthWatchingCacheKeyIsGlobalAndVersioned(t *testing.T) {
+	got := homeWorthWatchingCacheKey()
+	want := "console:v2:home:worth-watching:weekly-v5:homepage-v2"
 	if got != want {
 		t.Fatalf("cache key = %q, want %q", got, want)
 	}

--- a/migrations/000099_console_home_query_indexes.sql
+++ b/migrations/000099_console_home_query_indexes.sql
@@ -1,0 +1,31 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_raw_items_author_created_item
+    ON raw_items(author_agent_id, created_at, item_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_private_messages_home_activity
+    ON private_messages(created_at DESC, msg_id DESC)
+    INCLUDE (conv_id, sender_id, receiver_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_relations_home_activity
+    ON user_relations(created_at DESC, id DESC)
+    INCLUDE (from_uid, to_uid)
+    WHERE rel_type = 1;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_cards_home_activity
+    ON agent_cards(public_card_generated_at DESC, agent_id)
+    WHERE public_card_version > 1;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_commands_home_activity
+    ON agent_commands(created_at DESC, command_id DESC)
+    INCLUDE (agent_id)
+    WHERE command_type = 'task_delegation';
+
+-- +goose Down
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_commands_home_activity;
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_cards_home_activity;
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_relations_home_activity;
+DROP INDEX CONCURRENTLY IF EXISTS idx_private_messages_home_activity;
+DROP INDEX CONCURRENTLY IF EXISTS idx_raw_items_author_created_item;

--- a/migrations/migrations_contract_test.go
+++ b/migrations/migrations_contract_test.go
@@ -360,3 +360,23 @@ func TestHomepageRealWorldRelevanceMigrationIsIndexed(t *testing.T) {
 		}
 	}
 }
+
+func TestConsoleHomeQueryIndexesCoverRecentActivityAndFirstVoice(t *testing.T) {
+	sql := migration(t, "000099_console_home_query_indexes.sql")
+	for _, required := range []string{
+		"idx_raw_items_author_created_item",
+		"raw_items(author_agent_id, created_at, item_id)",
+		"idx_private_messages_home_activity",
+		"private_messages(created_at DESC, msg_id DESC)",
+		"idx_user_relations_home_activity",
+		"WHERE rel_type = 1",
+		"idx_agent_cards_home_activity",
+		"public_card_generated_at DESC",
+		"idx_agent_commands_home_activity",
+		"WHERE command_type = 'task_delegation'",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("console home query-index migration missing %q", required)
+		}
+	}
+}

--- a/pipeline/cron/homepage_eligibility_backfill.go
+++ b/pipeline/cron/homepage_eligibility_backfill.go
@@ -21,6 +21,8 @@ const (
 	defaultHomepageEligibilityWorkers     = 1
 	defaultHomepageEligibilityMinInterval = 5 * time.Second
 	defaultHomepageEligibilityRetryDelay  = time.Hour
+	homepageEligibilityLockTTL            = 8 * time.Minute
+	homepageEligibilityItemTimeout        = 60 * time.Second
 )
 
 type homepageEligibilityBackfillItem struct {
@@ -44,7 +46,7 @@ func StartHomepageEligibilityBackfill(ctx context.Context, rdb *redis.Client, ll
 }
 
 func runHomepageEligibilityBackfill(ctx context.Context, rdb *redis.Client, llmClient *llm.Client) {
-	token, acquired, err := acquireLock(ctx, rdb, lockKeyHomepageEligibility, 8*time.Minute)
+	token, acquired, err := acquireLock(ctx, rdb, lockKeyHomepageEligibility, homepageEligibilityLockTTL)
 	if err != nil || !acquired {
 		if err != nil {
 			logger.Default().Warn("homepage eligibility backfill lock error", "err", err)
@@ -52,10 +54,21 @@ func runHomepageEligibilityBackfill(ctx context.Context, rdb *redis.Client, llmC
 		return
 	}
 	defer releaseLock(rdb, lockKeyHomepageEligibility, token)
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	stopRenewal, lockLost := startLockRenewal(runCtx, rdb, lockKeyHomepageEligibility, token, homepageEligibilityLockTTL)
+	defer stopRenewal()
+	go func() {
+		select {
+		case <-lockLost:
+			cancelRun()
+		case <-runCtx.Done():
+		}
+	}()
 
 	now := time.Now()
 	var items []homepageEligibilityBackfillItem
-	if err := db.DB.Table("processed_items AS p").
+	if err := db.DB.WithContext(runCtx).Table("processed_items AS p").
 		Select("p.item_id, r.raw_content, r.raw_notes").
 		Joins("JOIN raw_items r ON r.item_id=p.item_id").
 		Where(`p.status = ? AND r.created_at >= ?
@@ -82,14 +95,19 @@ func runHomepageEligibilityBackfill(ctx context.Context, rdb *redis.Client, llmC
 			defer wg.Done()
 			for item := range jobs {
 				select {
-				case <-ctx.Done():
+				case <-runCtx.Done():
 					return
 				case <-rateLimiter.C:
 				}
-				result, err := llmClient.ProcessItem(ctx, item.RawContent, item.RawNotes)
+				itemCtx, cancelItem := context.WithTimeout(runCtx, homepageEligibilityItemTimeout)
+				result, err := llmClient.ProcessItem(itemCtx, item.RawContent, item.RawNotes)
+				cancelItem()
+				if runCtx.Err() != nil {
+					return
+				}
 				if err != nil {
 					logger.Default().Warn("homepage eligibility backfill model error", "itemID", item.ItemID, "err", err)
-					if retryErr := itemDal.ScheduleHomepageEvaluationRetry(db.DB, item.ItemID, homepageEligibilityRetryAt(time.Now())); retryErr != nil {
+					if retryErr := itemDal.ScheduleHomepageEvaluationRetry(db.DB.WithContext(runCtx), item.ItemID, homepageEligibilityRetryAt(time.Now())); retryErr != nil {
 						logger.Default().Warn("homepage eligibility backfill retry schedule failed", "itemID", item.ItemID, "err", retryErr)
 					}
 					continue
@@ -102,12 +120,15 @@ func runHomepageEligibilityBackfill(ctx context.Context, rdb *redis.Client, llmC
 				llm.NormalizeHomepageEvaluation(result)
 				if result.HomepageEvaluationIncomplete {
 					logger.Default().Warn("homepage eligibility backfill received incomplete evaluation", "itemID", item.ItemID)
-					if retryErr := itemDal.ScheduleHomepageEvaluationRetry(db.DB, item.ItemID, homepageEligibilityRetryAt(time.Now())); retryErr != nil {
+					if retryErr := itemDal.ScheduleHomepageEvaluationRetry(db.DB.WithContext(runCtx), item.ItemID, homepageEligibilityRetryAt(time.Now())); retryErr != nil {
 						logger.Default().Warn("homepage eligibility backfill retry schedule failed", "itemID", item.ItemID, "err", retryErr)
 					}
 					continue
 				}
-				if err := itemDal.UpdateHomepageEvaluation(db.DB, item.ItemID, llm.HomepageEligibleValue(result), llm.HomepageRealWorldRelevantValue(result), result.HomepageRejectionReason, result.HomepageEvaluationVersion); err != nil {
+				if runCtx.Err() != nil {
+					return
+				}
+				if err := itemDal.UpdateHomepageEvaluation(db.DB.WithContext(runCtx), item.ItemID, llm.HomepageEligibleValue(result), llm.HomepageRealWorldRelevantValue(result), result.HomepageRejectionReason, result.HomepageEvaluationVersion); err != nil {
 					logger.Default().Warn("homepage eligibility backfill DB error", "itemID", item.ItemID, "err", err)
 				}
 			}
@@ -117,7 +138,7 @@ func runHomepageEligibilityBackfill(ctx context.Context, rdb *redis.Client, llmC
 enqueue:
 	for _, item := range items {
 		select {
-		case <-ctx.Done():
+		case <-runCtx.Done():
 			break enqueue
 		case jobs <- item:
 		}

--- a/pipeline/cron/homepage_eligibility_backfill_test.go
+++ b/pipeline/cron/homepage_eligibility_backfill_test.go
@@ -40,3 +40,9 @@ func TestHomepageEligibilityBackfillIsRateLimited(t *testing.T) {
 		t.Fatalf("minimum interval = %s, want at least 5s", defaultHomepageEligibilityMinInterval)
 	}
 }
+
+func TestHomepageEligibilityBackfillTimeoutFitsRenewableLease(t *testing.T) {
+	if homepageEligibilityItemTimeout <= 0 || homepageEligibilityItemTimeout >= homepageEligibilityLockTTL {
+		t.Fatalf("item timeout %s must be positive and shorter than lock TTL %s", homepageEligibilityItemTimeout, homepageEligibilityLockTTL)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,17 @@ var (
 		Name: "http_requests_in_flight",
 		Help: "Number of HTTP requests currently being processed.",
 	})
+
+	ConsoleHomeCacheTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "console_home_cache_total",
+		Help: "Console homepage cache operations by module and bounded result.",
+	}, []string{"module", "result"})
+
+	ConsoleHomeRefreshDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "console_home_refresh_duration_seconds",
+		Help:    "Console homepage shared cache refresh latency by module and result.",
+		Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	}, []string{"module", "result"})
 )
 
 // Public Agent identity rollout metrics. Labels are deliberately bounded;
@@ -217,6 +228,7 @@ var (
 func init() {
 	Registry.MustRegister(
 		HTTPRequestDuration, HTTPRequestsTotal, HTTPRequestsInFlight,
+		ConsoleHomeCacheTotal, ConsoleHomeRefreshDuration,
 		RPCRequestDuration, RPCRequestsTotal,
 		ConsumerMessagesTotal, ConsumerMessageDuration, ConsumerLag, ConsumerRetryTotal,
 		ItemPublishToProcessDuration,


### PR DESCRIPTION
## Summary
- source homepage Agent country from the canonical Agent Card geo field
- diversify worth-watching content across recommendation reasons and expand available results
- exclude the official EigenFlux assistant and expose canonical Runtime and public capabilities
- decorate homepage Agent results with per-viewer friend, pending request, self, and add-friend state after shared caching
- keep shared discovery ranking cache viewer-independent

## Frontend
- Companion PR: https://github.com/phronesis-io/eigenflux-website/pull/129

## Validation
- git diff --check passed
- 45 focused frontend integration tests and the full production build passed
- Go tests could not run locally because this environment has no Go toolchain; GitHub CI is the authoritative backend check