### PR TITLE
fix(pm): reject corrupt text and dedupe sends

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"gorm.io/gorm"
 
@@ -45,6 +46,7 @@ import (
 	"eigenflux_server/pkg/runtimeidentity"
 	"eigenflux_server/pkg/stats"
 	"eigenflux_server/pkg/tagnorm"
+	"eigenflux_server/pkg/textguard"
 	"eigenflux_server/pkg/validator"
 	itemdal "eigenflux_server/rpc/item/dal"
 	profiledal "eigenflux_server/rpc/profile/dal"
@@ -1197,8 +1199,30 @@ func GetLatestItems(ctx context.Context, c *app.RequestContext) {
 // @Failure 401 {object} BaseResp
 // @Router /api/v1/pm/send [post]
 func SendPM(ctx context.Context, c *app.RequestContext) {
+	rawBody, err := c.Body()
+	if err != nil {
+		writeJSON(c, http.StatusBadRequest, 400, "invalid request body", nil)
+		return
+	}
+	if !utf8.Valid(rawBody) {
+		writeJSON(c, http.StatusBadRequest, 400, textguard.ErrInvalidUTF8.Error(), nil)
+		return
+	}
+	var contentProbe struct {
+		Content string `json:"content"`
+	}
+	if json.Unmarshal(rawBody, &contentProbe) == nil {
+		if err := textguard.ValidateMessageContent(contentProbe.Content); err != nil {
+			writeJSON(c, http.StatusBadRequest, 400, err.Error(), nil)
+			return
+		}
+	}
 	var req apimodel.SendPMReq
 	if !bindOrBadRequest(c, &req) {
+		return
+	}
+	if err := textguard.ValidateMessageContent(req.Content); err != nil {
+		writeJSON(c, http.StatusBadRequest, 400, err.Error(), nil)
 		return
 	}
 	agentID, ok := currentAgentID(c)

--- a/api/handler_gen/eigenflux/api/send_pm_encoding_test.go
+++ b/api/handler_gen/eigenflux/api/send_pm_encoding_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+func TestSendPMRejectsInvalidUTF8Body(t *testing.T) {
+	var requestContext app.RequestContext
+	requestContext.Request.SetBody([]byte{'{', '"', 'c', 'o', 'n', 't', 'e', 'n', 't', '"', ':', '"', 0xff, '"', '}'})
+
+	SendPM(context.Background(), &requestContext)
+
+	if requestContext.Response.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", requestContext.Response.StatusCode(), http.StatusBadRequest)
+	}
+	if body := string(requestContext.Response.Body()); !strings.Contains(body, "INVALID_TEXT_ENCODING") || !strings.Contains(body, "valid UTF-8") {
+		t.Fatalf("unexpected response body: %s", body)
+	}
+}
+
+func TestSendPMRejectsReplacementCharacter(t *testing.T) {
+	var requestContext app.RequestContext
+	requestContext.Request.Header.SetContentTypeBytes([]byte("application/json"))
+	requestContext.Request.SetBodyString(`{"content":"损坏�内容","item_id":"1"}`)
+
+	SendPM(context.Background(), &requestContext)
+
+	if requestContext.Response.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", requestContext.Response.StatusCode(), http.StatusBadRequest)
+	}
+	if body := string(requestContext.Response.Body()); !strings.Contains(body, "INVALID_TEXT_ENCODING") || !strings.Contains(body, "U+FFFD") {
+		t.Fatalf("unexpected response body: %s", body)
+	}
+}

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,7 +3,7 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.41
+CLI_VERSION=0.0.42
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients

--- a/cli/cmd/msg.go
+++ b/cli/cmd/msg.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"unicode/utf8"
 
 	"cli.eigenflux.ai/internal/cache"
 	"cli.eigenflux.ai/internal/output"
@@ -40,6 +42,9 @@ Examples:
 		withContext, _ := cmd.Flags().GetBool("with-context")
 		if content == "" {
 			return fmt.Errorf("--content is required")
+		}
+		if err := validateMessageContent(content); err != nil {
+			return err
 		}
 		if itemID == "" && convID == "" && receiverID == "" {
 			return fmt.Errorf("one of --item-id, --conv-id, or --receiver-id is required")
@@ -88,6 +93,16 @@ Examples:
 		}
 		return nil
 	},
+}
+
+func validateMessageContent(content string) error {
+	if !utf8.ValidString(content) {
+		return fmt.Errorf("INVALID_TEXT_ENCODING: message content is not valid UTF-8; regenerate it as UTF-8 before sending")
+	}
+	if strings.ContainsRune(content, utf8.RuneError) {
+		return fmt.Errorf("INVALID_TEXT_ENCODING: message content contains U+FFFD; regenerate the original text before sending")
+	}
+	return nil
 }
 
 var msgFetchCmd = &cobra.Command{

--- a/cli/cmd/msg_test.go
+++ b/cli/cmd/msg_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMessageContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantReason string
+	}{
+		{name: "valid", content: "你好, EigenFlux — hello"},
+		{name: "invalid UTF-8", content: string([]byte{0xff}), wantReason: "not valid UTF-8"},
+		{name: "replacement character", content: "损坏�内容", wantReason: "contains U+FFFD"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMessageContent(tt.content)
+			if tt.wantReason == "" && err != nil {
+				t.Fatalf("valid content rejected: %v", err)
+			}
+			if tt.wantReason != "" && (err == nil || !strings.Contains(err.Error(), tt.wantReason)) {
+				t.Fatalf("error = %v, want reason %q", err, tt.wantReason)
+			}
+		})
+	}
+}

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -42,6 +42,8 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 - Friend request notifications stored in Redis `pm:notify:{agent_id}` (HASH, 7-day TTL), read/deleted by notification service. New friend requests also publish to `pm:push:{receiverID}` for real-time WebSocket delivery
 - Auto-accept (mutual pending requests) writes a `friend_accepted` notification to `pm:notify:{originalRequesterID}` and publishes `friend_accepted:{friendUID}` to `pm:push:{originalRequesterID}` for real-time WebSocket delivery
 - Cache key `pm:fetch:{agent_id}` caches empty FetchPM results for 10s (cursor=0 only), invalidated on new message
+- Message content must be valid UTF-8 and must not contain the U+FFFD replacement character. The CLI rejects invalid content before sending, and both the HTTP gateway and PM RPC enforce the same rule before any side effect.
+- `SendPM` prevents identical re-entry for 60 seconds with Redis key `pm:send:dedupe:v1:{sha256}`. The fingerprint covers sender, logical target, and exact content. A completed duplicate reuses the first `msg_id` and `conv_id`; a concurrent duplicate returns `MESSAGE_SEND_IN_PROGRESS` without writing to PostgreSQL.
 
 ## IDL
 

--- a/pkg/textguard/message.go
+++ b/pkg/textguard/message.go
@@ -1,0 +1,22 @@
+package textguard
+
+import (
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	ErrInvalidUTF8          = errors.New("INVALID_TEXT_ENCODING: message content is not valid UTF-8; regenerate it as UTF-8 before sending")
+	ErrReplacementCharacter = errors.New("INVALID_TEXT_ENCODING: message content contains U+FFFD; regenerate the original text before sending")
+)
+
+func ValidateMessageContent(content string) error {
+	if !utf8.ValidString(content) {
+		return ErrInvalidUTF8
+	}
+	if strings.ContainsRune(content, utf8.RuneError) {
+		return ErrReplacementCharacter
+	}
+	return nil
+}

--- a/pkg/textguard/message_test.go
+++ b/pkg/textguard/message_test.go
@@ -1,0 +1,27 @@
+package textguard
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateMessageContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr error
+	}{
+		{name: "valid multilingual text", content: "你好, EigenFlux — hello"},
+		{name: "invalid UTF-8", content: string([]byte{0xff}), wantErr: ErrInvalidUTF8},
+		{name: "replacement character", content: "损坏�内容", wantErr: ErrReplacementCharacter},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMessageContent(tt.content)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ValidateMessageContent() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -17,11 +17,13 @@ import (
 	"eigenflux_server/pkg/db"
 	"eigenflux_server/pkg/logger"
 	"eigenflux_server/pkg/metrics"
+	"eigenflux_server/pkg/textguard"
 	"eigenflux_server/rpc/pm/dal"
 	"eigenflux_server/rpc/pm/icebreak"
 	"eigenflux_server/rpc/pm/notifyutil"
 	"eigenflux_server/rpc/pm/ratelimit"
 	"eigenflux_server/rpc/pm/relations"
+	"eigenflux_server/rpc/pm/sendguard"
 	"eigenflux_server/rpc/pm/validator"
 
 	"gorm.io/gorm"
@@ -51,6 +53,7 @@ type PMServiceImpl struct {
 	iceBreaker          *icebreak.IceBreaker
 	validator           *validator.Validator
 	friendRequestLimits *ratelimit.Config
+	sendGuard           *sendguard.Guard
 }
 
 func publicIdentityForNotification(ctx context.Context, agentID int64) (agentidentity.PublicIdentity, bool) {
@@ -86,6 +89,48 @@ func publishFriendResponseEvent(ctx context.Context, recipientID, peerID int64, 
 
 func (s *PMServiceImpl) SendPM(ctx context.Context, req *pm.SendPMReq) (*pm.SendPMResp, error) {
 	logger.Ctx(ctx).Info("SendPM", "senderID", req.SenderId, "receiverID", req.ReceiverId, "itemID", req.ItemId, "convID", req.ConvId)
+	if err := textguard.ValidateMessageContent(req.Content); err != nil {
+		return &pm.SendPMResp{BaseResp: &base.BaseResp{Code: 400, Msg: err.Error()}}, nil
+	}
+
+	targetKind, targetID := sendTarget(req)
+	lease, replay, err := s.sendGuard.Acquire(ctx, sendguard.Fingerprint(req.SenderId, targetKind, targetID, req.Content))
+	if errors.Is(err, sendguard.ErrInProgress) {
+		return &pm.SendPMResp{BaseResp: &base.BaseResp{Code: 409, Msg: err.Error()}}, nil
+	}
+	if err != nil {
+		logger.Ctx(ctx).Error("message send guard unavailable", "senderID", req.SenderId, "err", err)
+		return &pm.SendPMResp{BaseResp: &base.BaseResp{Code: 503, Msg: "MESSAGE_SEND_GUARD_UNAVAILABLE: duplicate protection is unavailable; message was not sent"}}, nil
+	}
+	if replay != nil {
+		logger.Ctx(ctx).Info("duplicate message send replayed", "senderID", req.SenderId, "msgID", replay.MsgID, "convID", replay.ConvID)
+		return &pm.SendPMResp{MsgId: replay.MsgID, ConvId: replay.ConvID, BaseResp: &base.BaseResp{Code: 0, Msg: "success"}}, nil
+	}
+
+	resp, sendErr := s.sendPM(ctx, req)
+	if sendErr != nil || resp == nil || resp.BaseResp == nil || resp.BaseResp.Code != 0 {
+		if releaseErr := s.sendGuard.Release(ctx, lease); releaseErr != nil {
+			logger.Ctx(ctx).Error("failed to release message send guard", "senderID", req.SenderId, "err", releaseErr)
+		}
+		return resp, sendErr
+	}
+	if err := s.sendGuard.Complete(ctx, lease, sendguard.Result{MsgID: resp.MsgId, ConvID: resp.ConvId}); err != nil {
+		logger.Ctx(ctx).Error("failed to complete message send guard", "senderID", req.SenderId, "msgID", resp.MsgId, "convID", resp.ConvId, "err", err)
+	}
+	return resp, nil
+}
+
+func sendTarget(req *pm.SendPMReq) (string, int64) {
+	if req.ItemId != nil && *req.ItemId > 0 {
+		return "item", *req.ItemId
+	}
+	if req.ConvId != nil && *req.ConvId > 0 {
+		return "conversation", *req.ConvId
+	}
+	return "friend", req.ReceiverId
+}
+
+func (s *PMServiceImpl) sendPM(ctx context.Context, req *pm.SendPMReq) (*pm.SendPMResp, error) {
 	// Case 1: New conversation (item_id provided)
 	if req.ItemId != nil && *req.ItemId > 0 {
 		return s.handleNewConversation(ctx, req)

--- a/rpc/pm/handler_encoding_test.go
+++ b/rpc/pm/handler_encoding_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"eigenflux_server/kitex_gen/eigenflux/pm"
+)
+
+func TestSendPMRejectsInvalidMessageEncodingBeforeRedis(t *testing.T) {
+	service := &PMServiceImpl{}
+	tests := []struct {
+		name       string
+		content    string
+		wantReason string
+	}{
+		{name: "invalid UTF-8", content: string([]byte{0xff}), wantReason: "valid UTF-8"},
+		{name: "replacement character", content: "损坏�内容", wantReason: "U+FFFD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := service.SendPM(context.Background(), &pm.SendPMReq{SenderId: 1, ReceiverId: 2, Content: tt.content})
+			if err != nil {
+				t.Fatalf("SendPM error: %v", err)
+			}
+			if resp.BaseResp.Code != 400 || !strings.Contains(resp.BaseResp.Msg, tt.wantReason) {
+				t.Fatalf("response = %+v, want code 400 containing %q", resp.BaseResp, tt.wantReason)
+			}
+		})
+	}
+}

--- a/rpc/pm/main.go
+++ b/rpc/pm/main.go
@@ -21,6 +21,7 @@ import (
 	"eigenflux_server/pkg/telemetry"
 	"eigenflux_server/rpc/pm/icebreak"
 	"eigenflux_server/rpc/pm/ratelimit"
+	"eigenflux_server/rpc/pm/sendguard"
 	"eigenflux_server/rpc/pm/validator"
 )
 
@@ -131,6 +132,7 @@ func main() {
 			iceBreaker:          iceBreaker,
 			validator:           pmValidator,
 			friendRequestLimits: friendRequestLimits,
+			sendGuard:           sendguard.New(db.RDB),
 		},
 		rpcx.ServerOptions(addr, registry, "PMService", metrics.KitexServerMW())...,
 	)

--- a/rpc/pm/sendguard/guard.go
+++ b/rpc/pm/sendguard/guard.go
@@ -1,0 +1,132 @@
+package sendguard
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	duplicateWindow = time.Minute
+	pendingTTL      = duplicateWindow
+	keyPrefix       = "pm:send:dedupe:v1:"
+)
+
+var ErrInProgress = errors.New("MESSAGE_SEND_IN_PROGRESS: an identical message is already being sent; wait before retrying")
+
+type Result struct {
+	MsgID  int64
+	ConvID int64
+}
+
+type Lease struct {
+	key   string
+	token string
+}
+
+type Guard struct {
+	rdb *redis.Client
+}
+
+func New(rdb *redis.Client) *Guard {
+	return &Guard{rdb: rdb}
+}
+
+func Fingerprint(senderID int64, targetKind string, targetID int64, content string) string {
+	hash := sha256.New()
+	fmt.Fprintf(hash, "%d\n%s\n%d\n%d\n", senderID, targetKind, targetID, len(content))
+	hash.Write([]byte(content))
+	return keyPrefix + hex.EncodeToString(hash.Sum(nil))
+}
+
+func (g *Guard) Acquire(ctx context.Context, key string) (*Lease, *Result, error) {
+	if g == nil || g.rdb == nil {
+		return nil, nil, errors.New("message send guard is unavailable")
+	}
+	tokenBytes := make([]byte, 16)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return nil, nil, fmt.Errorf("generate message send token: %w", err)
+	}
+	token := hex.EncodeToString(tokenBytes)
+	pendingValue := "pending:" + token
+
+	for attempt := 0; attempt < 2; attempt++ {
+		acquired, err := g.rdb.SetNX(ctx, key, pendingValue, pendingTTL).Result()
+		if err != nil {
+			return nil, nil, fmt.Errorf("acquire message send guard: %w", err)
+		}
+		if acquired {
+			return &Lease{key: key, token: token}, nil, nil
+		}
+
+		value, err := g.rdb.Get(ctx, key).Result()
+		if errors.Is(err, redis.Nil) {
+			continue
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("read message send guard: %w", err)
+		}
+		if strings.HasPrefix(value, "pending:") {
+			return nil, nil, ErrInProgress
+		}
+		result, err := parseDone(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, result, nil
+	}
+
+	return nil, nil, ErrInProgress
+}
+
+func (g *Guard) Complete(ctx context.Context, lease *Lease, result Result) error {
+	if g == nil || g.rdb == nil || lease == nil {
+		return errors.New("message send guard completion is unavailable")
+	}
+	const script = `if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("SET", KEYS[1], ARGV[2], "PX", ARGV[3]) else return false end`
+	pendingValue := "pending:" + lease.token
+	doneValue := fmt.Sprintf("done:%d:%d", result.MsgID, result.ConvID)
+	completed, err := g.rdb.Eval(ctx, script, []string{lease.key}, pendingValue, doneValue, duplicateWindow.Milliseconds()).Result()
+	if err != nil {
+		return fmt.Errorf("complete message send guard: %w", err)
+	}
+	if completed == nil {
+		return errors.New("message send guard lease expired before completion")
+	}
+	return nil
+}
+
+func (g *Guard) Release(ctx context.Context, lease *Lease) error {
+	if g == nil || g.rdb == nil || lease == nil {
+		return nil
+	}
+	const script = `if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end`
+	if err := g.rdb.Eval(ctx, script, []string{lease.key}, "pending:"+lease.token).Err(); err != nil {
+		return fmt.Errorf("release message send guard: %w", err)
+	}
+	return nil
+}
+
+func parseDone(value string) (*Result, error) {
+	parts := strings.Split(value, ":")
+	if len(parts) != 3 || parts[0] != "done" {
+		return nil, errors.New("invalid message send guard state")
+	}
+	msgID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, errors.New("invalid message send guard msg_id")
+	}
+	convID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return nil, errors.New("invalid message send guard conv_id")
+	}
+	return &Result{MsgID: msgID, ConvID: convID}, nil
+}

--- a/rpc/pm/sendguard/guard_test.go
+++ b/rpc/pm/sendguard/guard_test.go
@@ -1,0 +1,92 @@
+package sendguard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestGuard(t *testing.T) (*Guard, *miniredis.Miniredis) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return New(client), server
+}
+
+func TestGuardReplaysCompletedSend(t *testing.T) {
+	guard, _ := newTestGuard(t)
+	ctx := context.Background()
+	key := Fingerprint(1, "item", 2, "完全相同")
+
+	lease, replay, err := guard.Acquire(ctx, key)
+	if err != nil || lease == nil || replay != nil {
+		t.Fatalf("first acquire = lease %v replay %v err %v", lease, replay, err)
+	}
+	if err := guard.Complete(ctx, lease, Result{MsgID: 11, ConvID: 22}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	lease, replay, err = guard.Acquire(ctx, key)
+	if err != nil || lease != nil || replay == nil {
+		t.Fatalf("second acquire = lease %v replay %v err %v", lease, replay, err)
+	}
+	if replay.MsgID != 11 || replay.ConvID != 22 {
+		t.Fatalf("replayed result = %+v", replay)
+	}
+}
+
+func TestGuardRejectsConcurrentIdenticalSend(t *testing.T) {
+	guard, _ := newTestGuard(t)
+	ctx := context.Background()
+	key := Fingerprint(1, "conversation", 2, "same")
+
+	lease, _, err := guard.Acquire(ctx, key)
+	if err != nil || lease == nil {
+		t.Fatalf("first acquire: lease %v err %v", lease, err)
+	}
+	if _, _, err := guard.Acquire(ctx, key); !errors.Is(err, ErrInProgress) {
+		t.Fatalf("second acquire error = %v, want %v", err, ErrInProgress)
+	}
+	if err := guard.Release(ctx, lease); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if lease, _, err := guard.Acquire(ctx, key); err != nil || lease == nil {
+		t.Fatalf("acquire after release: lease %v err %v", lease, err)
+	}
+}
+
+func TestGuardAllowsSendAfterDuplicateWindow(t *testing.T) {
+	guard, server := newTestGuard(t)
+	ctx := context.Background()
+	key := Fingerprint(1, "friend", 2, "same")
+	lease, _, err := guard.Acquire(ctx, key)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := guard.Complete(ctx, lease, Result{MsgID: 11, ConvID: 22}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	server.FastForward(time.Minute + time.Second)
+	if lease, replay, err := guard.Acquire(ctx, key); err != nil || lease == nil || replay != nil {
+		t.Fatalf("acquire after window = lease %v replay %v err %v", lease, replay, err)
+	}
+}
+
+func TestFingerprintSeparatesTargetsAndSenders(t *testing.T) {
+	base := Fingerprint(1, "item", 2, "same")
+	for _, other := range []string{
+		Fingerprint(2, "item", 2, "same"),
+		Fingerprint(1, "item", 3, "same"),
+		Fingerprint(1, "conversation", 2, "same"),
+		Fingerprint(1, "item", 2, "different"),
+	} {
+		if other == base {
+			t.Fatal("fingerprint collision between distinct sends")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- reject invalid UTF-8 and U+FFFD in the CLI, HTTP gateway, and PM RPC
- prevent identical PM re-entry for 60 seconds with Redis and replay completed results
- release CLI v0.0.42 without changing skills

## Tests
- go test ./pkg/textguard ./rpc/pm/sendguard ./rpc/pm ./api/handler_gen/eigenflux/api -count=1
- cd cli && go test ./cmd -count=1
- bash scripts/common/build.sh pm api
- go build -o ../build/eigenflux-cli .