### PR TITLE
fix(pm): stabilize conversation pagination cursor

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1362,6 +1362,9 @@ const docTemplate = `{
                 },
                 "next_cursor": {
                     "type": "string"
+                },
+                "next_cursor_v2": {
+                    "type": "string"
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -1355,6 +1355,9 @@
                 },
                 "next_cursor": {
                     "type": "string"
+                },
+                "next_cursor_v2": {
+                    "type": "string"
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -236,6 +236,8 @@ definitions:
         type: array
       next_cursor:
         type: string
+      next_cursor_v2:
+        type: string
     type: object
   api.ListConversationsResp:
     properties:

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -1411,14 +1411,17 @@ func ListConversations(ctx context.Context, c *app.RequestContext) {
 	}
 	logger.Ctx(ctx).Debug("ListConversations", "agentID", agentID)
 
-	var cursorPtr *int64
+	var cursorPtr, cursorConvIDPtr *int64
 	if req.Cursor != nil && *req.Cursor != "" {
-		cursor, err := strconv.ParseInt(*req.Cursor, 10, 64)
+		cursor, err := decodeConversationPageCursor(*req.Cursor)
 		if err != nil {
 			writeJSON(c, http.StatusBadRequest, 400, "invalid cursor", nil)
 			return
 		}
-		cursorPtr = &cursor
+		cursorPtr = &cursor.UpdatedAt
+		if cursor.ConvID > 0 {
+			cursorConvIDPtr = &cursor.ConvID
+		}
 	}
 
 	var limitPtr *int32
@@ -1429,9 +1432,10 @@ func ListConversations(ctx context.Context, c *app.RequestContext) {
 	// Optional origin_type filter ("item" | "friend"); read directly from the
 	// query so the hz-bound request model needs no IDL change.
 	rpcReq := &pmrpc.ListConversationsReq{
-		AgentId: agentID,
-		Cursor:  cursorPtr,
-		Limit:   limitPtr,
+		AgentId:      agentID,
+		Cursor:       cursorPtr,
+		CursorConvId: cursorConvIDPtr,
+		Limit:        limitPtr,
 	}
 	if originType := strings.TrimSpace(c.Query("origin_type")); originType != "" {
 		rpcReq.OriginType = &originType
@@ -1562,9 +1566,14 @@ func ListConversations(ctx context.Context, c *app.RequestContext) {
 		}
 	}
 
+	nextCursorV2 := ""
+	if resp.IsSetNextCursorConvId() {
+		nextCursorV2 = encodeConversationPageCursor(resp.NextCursor, resp.GetNextCursorConvId())
+	}
 	writeJSON(c, http.StatusOK, 0, "success", map[string]interface{}{
-		"conversations": conversations,
-		"next_cursor":   strconv.FormatInt(resp.NextCursor, 10),
+		"conversations":  conversations,
+		"next_cursor":    strconv.FormatInt(resp.NextCursor, 10),
+		"next_cursor_v2": nextCursorV2,
 	})
 }
 

--- a/api/handler_gen/eigenflux/api/conversation_cursor.go
+++ b/api/handler_gen/eigenflux/api/conversation_cursor.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+type conversationPageCursor struct {
+	UpdatedAt int64 `json:"u"`
+	ConvID    int64 `json:"c"`
+}
+
+func decodeConversationPageCursor(raw string) (conversationPageCursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return conversationPageCursor{}, nil
+	}
+	if updatedAt, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if updatedAt <= 0 {
+			return conversationPageCursor{}, errors.New("invalid cursor")
+		}
+		return conversationPageCursor{UpdatedAt: updatedAt}, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return conversationPageCursor{}, errors.New("invalid cursor")
+	}
+	var cursor conversationPageCursor
+	if json.Unmarshal(decoded, &cursor) != nil || cursor.UpdatedAt <= 0 || cursor.ConvID <= 0 {
+		return conversationPageCursor{}, errors.New("invalid cursor")
+	}
+	return cursor, nil
+}
+
+func encodeConversationPageCursor(updatedAt, convID int64) string {
+	if updatedAt <= 0 || convID <= 0 {
+		return ""
+	}
+	raw, _ := json.Marshal(conversationPageCursor{UpdatedAt: updatedAt, ConvID: convID})
+	return base64.RawURLEncoding.EncodeToString(raw)
+}

--- a/api/handler_gen/eigenflux/api/conversation_cursor_test.go
+++ b/api/handler_gen/eigenflux/api/conversation_cursor_test.go
@@ -1,0 +1,32 @@
+package api
+
+import "testing"
+
+func TestConversationPageCursorRoundTrip(t *testing.T) {
+	token := encodeConversationPageCursor(1756961234567, 318621003607441408)
+	cursor, err := decodeConversationPageCursor(token)
+	if err != nil {
+		t.Fatalf("decodeConversationPageCursor() error = %v", err)
+	}
+	if cursor.UpdatedAt != 1756961234567 || cursor.ConvID != 318621003607441408 {
+		t.Fatalf("decoded cursor = %+v", cursor)
+	}
+}
+
+func TestConversationPageCursorAcceptsLegacyTimestamp(t *testing.T) {
+	cursor, err := decodeConversationPageCursor("1756961234567")
+	if err != nil {
+		t.Fatalf("decodeConversationPageCursor() error = %v", err)
+	}
+	if cursor.UpdatedAt != 1756961234567 || cursor.ConvID != 0 {
+		t.Fatalf("decoded legacy cursor = %+v", cursor)
+	}
+}
+
+func TestConversationPageCursorRejectsInvalidValues(t *testing.T) {
+	for _, raw := range []string{"0", "-1", "not-a-cursor", "eyJ1IjoxLCJjIjowfQ"} {
+		if _, err := decodeConversationPageCursor(raw); err == nil {
+			t.Fatalf("decodeConversationPageCursor(%q) succeeded", raw)
+		}
+	}
+}

--- a/api/model/eigenflux/api/api.go
+++ b/api/model/eigenflux/api/api.go
@@ -16686,6 +16686,7 @@ func (p *ConversationData) String() string {
 type ListConversationsData struct {
 	Conversations []*ConversationData `thrift:"conversations,1,required,list<ConversationData>" form:"conversations,required" json:"conversations,required" query:"conversations,required"`
 	NextCursor    string              `thrift:"next_cursor,2,required" form:"next_cursor,required" json:"next_cursor,required" query:"next_cursor,required"`
+	NextCursorV2  *string             `thrift:"next_cursor_v2,3,optional" form:"next_cursor_v2" json:"next_cursor_v2,omitempty" query:"next_cursor_v2"`
 }
 
 func NewListConversationsData() *ListConversationsData {
@@ -16703,9 +16704,23 @@ func (p *ListConversationsData) GetNextCursor() (v string) {
 	return p.NextCursor
 }
 
+var ListConversationsData_NextCursorV2_DEFAULT string
+
+func (p *ListConversationsData) GetNextCursorV2() (v string) {
+	if !p.IsSetNextCursorV2() {
+		return ListConversationsData_NextCursorV2_DEFAULT
+	}
+	return *p.NextCursorV2
+}
+
 var fieldIDToName_ListConversationsData = map[int16]string{
 	1: "conversations",
 	2: "next_cursor",
+	3: "next_cursor_v2",
+}
+
+func (p *ListConversationsData) IsSetNextCursorV2() bool {
+	return p.NextCursorV2 != nil
 }
 
 func (p *ListConversationsData) Read(iprot thrift.TProtocol) (err error) {
@@ -16744,6 +16759,14 @@ func (p *ListConversationsData) Read(iprot thrift.TProtocol) (err error) {
 					goto ReadFieldError
 				}
 				issetNextCursor = true
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
 				goto SkipFieldError
 			}
@@ -16821,6 +16844,17 @@ func (p *ListConversationsData) ReadField2(iprot thrift.TProtocol) error {
 	p.NextCursor = _field
 	return nil
 }
+func (p *ListConversationsData) ReadField3(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.NextCursorV2 = _field
+	return nil
+}
 
 func (p *ListConversationsData) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -16834,6 +16868,10 @@ func (p *ListConversationsData) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField2(oprot); err != nil {
 			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
 			goto WriteFieldError
 		}
 	}
@@ -16894,6 +16932,25 @@ WriteFieldBeginError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+
+func (p *ListConversationsData) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetNextCursorV2() {
+		if err = oprot.WriteFieldBegin("next_cursor_v2", thrift.STRING, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.NextCursorV2); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
 }
 
 func (p *ListConversationsData) String() string {

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -44,6 +44,7 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 - Cache key `pm:fetch:{agent_id}` caches empty FetchPM results for 10s (cursor=0 only), invalidated on new message
 - Message content must be valid UTF-8 and must not contain the U+FFFD replacement character. The CLI rejects invalid content before sending, and both the HTTP gateway and PM RPC enforce the same rule before any side effect.
 - `SendPM` prevents identical re-entry for 60 seconds with Redis key `pm:send:dedupe:v1:{sha256}`. The fingerprint covers sender, logical target, and exact content. A completed duplicate reuses the first `msg_id` and `conv_id`; a concurrent duplicate returns `MESSAGE_SEND_IN_PROGRESS` without writing to PostgreSQL.
+- Conversation pages are ordered by `(updated_at DESC, conv_id DESC)`. HTTP responses include an opaque `next_cursor_v2` that preserves both values; numeric `next_cursor` remains available for legacy clients.
 
 ## IDL
 

--- a/idl/api.thrift
+++ b/idl/api.thrift
@@ -450,6 +450,7 @@ struct ConversationData {
 struct ListConversationsData {
     1: required list<ConversationData> conversations
     2: required string next_cursor
+    3: optional string next_cursor_v2
 }
 
 struct ListConversationsResp {

--- a/idl/pm.thrift
+++ b/idl/pm.thrift
@@ -56,6 +56,7 @@ struct ListConversationsReq {
     2: optional i64 cursor        // last conv updated_at
     3: optional i32 limit
     4: optional string origin_type // "broadcast" or "friend"
+    5: optional i64 cursor_conv_id // stable tie-breaker paired with cursor
 }
 
 struct ConversationInfo {
@@ -81,6 +82,7 @@ struct ConversationInfo {
 struct ListConversationsResp {
     1: required list<ConversationInfo> conversations
     2: required i64 next_cursor
+    3: optional i64 next_cursor_conv_id
     255: required base.BaseResp base_resp
 }
 

--- a/kitex_gen/eigenflux/pm/k-pm.go
+++ b/kitex_gen/eigenflux/pm/k-pm.go
@@ -1935,6 +1935,20 @@ func (p *ListConversationsReq) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 5:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField5(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -2015,6 +2029,20 @@ func (p *ListConversationsReq) FastReadField4(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *ListConversationsReq) FastReadField5(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.CursorConvId = _field
+	return offset, nil
+}
+
 func (p *ListConversationsReq) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -2025,6 +2053,7 @@ func (p *ListConversationsReq) FastWriteNocopy(buf []byte, w thrift.NocopyWriter
 		offset += p.fastWriteField1(buf[offset:], w)
 		offset += p.fastWriteField2(buf[offset:], w)
 		offset += p.fastWriteField3(buf[offset:], w)
+		offset += p.fastWriteField5(buf[offset:], w)
 		offset += p.fastWriteField4(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
@@ -2038,6 +2067,7 @@ func (p *ListConversationsReq) BLength() int {
 		l += p.field2Length()
 		l += p.field3Length()
 		l += p.field4Length()
+		l += p.field5Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -2077,6 +2107,15 @@ func (p *ListConversationsReq) fastWriteField4(buf []byte, w thrift.NocopyWriter
 	return offset
 }
 
+func (p *ListConversationsReq) fastWriteField5(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetCursorConvId() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 5)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.CursorConvId)
+	}
+	return offset
+}
+
 func (p *ListConversationsReq) field1Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
@@ -2107,6 +2146,15 @@ func (p *ListConversationsReq) field4Length() int {
 	if p.IsSetOriginType() {
 		l += thrift.Binary.FieldBeginLength()
 		l += thrift.Binary.StringLengthNocopy(*p.OriginType)
+	}
+	return l
+}
+
+func (p *ListConversationsReq) field5Length() int {
+	l := 0
+	if p.IsSetCursorConvId() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
 	}
 	return l
 }
@@ -3045,6 +3093,20 @@ func (p *ListConversationsResp) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 3:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 255:
 			if fieldTypeId == thrift.STRUCT {
 				l, err = p.FastReadField255(buf[offset:])
@@ -3133,6 +3195,20 @@ func (p *ListConversationsResp) FastReadField2(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *ListConversationsResp) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.NextCursorConvId = _field
+	return offset, nil
+}
+
 func (p *ListConversationsResp) FastReadField255(buf []byte) (int, error) {
 	offset := 0
 	_field := base.NewBaseResp()
@@ -3153,6 +3229,7 @@ func (p *ListConversationsResp) FastWriteNocopy(buf []byte, w thrift.NocopyWrite
 	offset := 0
 	if p != nil {
 		offset += p.fastWriteField2(buf[offset:], w)
+		offset += p.fastWriteField3(buf[offset:], w)
 		offset += p.fastWriteField1(buf[offset:], w)
 		offset += p.fastWriteField255(buf[offset:], w)
 	}
@@ -3165,6 +3242,7 @@ func (p *ListConversationsResp) BLength() int {
 	if p != nil {
 		l += p.field1Length()
 		l += p.field2Length()
+		l += p.field3Length()
 		l += p.field255Length()
 	}
 	l += thrift.Binary.FieldStopLength()
@@ -3192,6 +3270,15 @@ func (p *ListConversationsResp) fastWriteField2(buf []byte, w thrift.NocopyWrite
 	return offset
 }
 
+func (p *ListConversationsResp) fastWriteField3(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetNextCursorConvId() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 3)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.NextCursorConvId)
+	}
+	return offset
+}
+
 func (p *ListConversationsResp) fastWriteField255(buf []byte, w thrift.NocopyWriter) int {
 	offset := 0
 	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRUCT, 255)
@@ -3214,6 +3301,15 @@ func (p *ListConversationsResp) field2Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
 	l += thrift.Binary.I64Length()
+	return l
+}
+
+func (p *ListConversationsResp) field3Length() int {
+	l := 0
+	if p.IsSetNextCursorConvId() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
 	return l
 }
 

--- a/kitex_gen/eigenflux/pm/pm.go
+++ b/kitex_gen/eigenflux/pm/pm.go
@@ -549,10 +549,11 @@ var fieldIDToName_FetchPMHistoryResp = map[int16]string{
 }
 
 type ListConversationsReq struct {
-	AgentId    int64   `thrift:"agent_id,1,required" frugal:"1,required,i64" json:"agent_id"`
-	Cursor     *int64  `thrift:"cursor,2,optional" frugal:"2,optional,i64" json:"cursor,omitempty"`
-	Limit      *int32  `thrift:"limit,3,optional" frugal:"3,optional,i32" json:"limit,omitempty"`
-	OriginType *string `thrift:"origin_type,4,optional" frugal:"4,optional,string" json:"origin_type,omitempty"`
+	AgentId      int64   `thrift:"agent_id,1,required" frugal:"1,required,i64" json:"agent_id"`
+	Cursor       *int64  `thrift:"cursor,2,optional" frugal:"2,optional,i64" json:"cursor,omitempty"`
+	Limit        *int32  `thrift:"limit,3,optional" frugal:"3,optional,i32" json:"limit,omitempty"`
+	OriginType   *string `thrift:"origin_type,4,optional" frugal:"4,optional,string" json:"origin_type,omitempty"`
+	CursorConvId *int64  `thrift:"cursor_conv_id,5,optional" frugal:"5,optional,i64" json:"cursor_conv_id,omitempty"`
 }
 
 func NewListConversationsReq() *ListConversationsReq {
@@ -592,6 +593,15 @@ func (p *ListConversationsReq) GetOriginType() (v string) {
 	}
 	return *p.OriginType
 }
+
+var ListConversationsReq_CursorConvId_DEFAULT int64
+
+func (p *ListConversationsReq) GetCursorConvId() (v int64) {
+	if !p.IsSetCursorConvId() {
+		return ListConversationsReq_CursorConvId_DEFAULT
+	}
+	return *p.CursorConvId
+}
 func (p *ListConversationsReq) SetAgentId(val int64) {
 	p.AgentId = val
 }
@@ -603,6 +613,9 @@ func (p *ListConversationsReq) SetLimit(val *int32) {
 }
 func (p *ListConversationsReq) SetOriginType(val *string) {
 	p.OriginType = val
+}
+func (p *ListConversationsReq) SetCursorConvId(val *int64) {
+	p.CursorConvId = val
 }
 
 func (p *ListConversationsReq) IsSetCursor() bool {
@@ -617,6 +630,10 @@ func (p *ListConversationsReq) IsSetOriginType() bool {
 	return p.OriginType != nil
 }
 
+func (p *ListConversationsReq) IsSetCursorConvId() bool {
+	return p.CursorConvId != nil
+}
+
 func (p *ListConversationsReq) String() string {
 	if p == nil {
 		return "<nil>"
@@ -629,6 +646,7 @@ var fieldIDToName_ListConversationsReq = map[int16]string{
 	2: "cursor",
 	3: "limit",
 	4: "origin_type",
+	5: "cursor_conv_id",
 }
 
 type ConversationInfo struct {
@@ -922,9 +940,10 @@ var fieldIDToName_ConversationInfo = map[int16]string{
 }
 
 type ListConversationsResp struct {
-	Conversations []*ConversationInfo `thrift:"conversations,1,required" frugal:"1,required,list<ConversationInfo>" json:"conversations"`
-	NextCursor    int64               `thrift:"next_cursor,2,required" frugal:"2,required,i64" json:"next_cursor"`
-	BaseResp      *base.BaseResp      `thrift:"base_resp,255,required" frugal:"255,required,base.BaseResp" json:"base_resp"`
+	Conversations    []*ConversationInfo `thrift:"conversations,1,required" frugal:"1,required,list<ConversationInfo>" json:"conversations"`
+	NextCursor       int64               `thrift:"next_cursor,2,required" frugal:"2,required,i64" json:"next_cursor"`
+	NextCursorConvId *int64              `thrift:"next_cursor_conv_id,3,optional" frugal:"3,optional,i64" json:"next_cursor_conv_id,omitempty"`
+	BaseResp         *base.BaseResp      `thrift:"base_resp,255,required" frugal:"255,required,base.BaseResp" json:"base_resp"`
 }
 
 func NewListConversationsResp() *ListConversationsResp {
@@ -942,6 +961,15 @@ func (p *ListConversationsResp) GetNextCursor() (v int64) {
 	return p.NextCursor
 }
 
+var ListConversationsResp_NextCursorConvId_DEFAULT int64
+
+func (p *ListConversationsResp) GetNextCursorConvId() (v int64) {
+	if !p.IsSetNextCursorConvId() {
+		return ListConversationsResp_NextCursorConvId_DEFAULT
+	}
+	return *p.NextCursorConvId
+}
+
 var ListConversationsResp_BaseResp_DEFAULT *base.BaseResp
 
 func (p *ListConversationsResp) GetBaseResp() (v *base.BaseResp) {
@@ -956,8 +984,15 @@ func (p *ListConversationsResp) SetConversations(val []*ConversationInfo) {
 func (p *ListConversationsResp) SetNextCursor(val int64) {
 	p.NextCursor = val
 }
+func (p *ListConversationsResp) SetNextCursorConvId(val *int64) {
+	p.NextCursorConvId = val
+}
 func (p *ListConversationsResp) SetBaseResp(val *base.BaseResp) {
 	p.BaseResp = val
+}
+
+func (p *ListConversationsResp) IsSetNextCursorConvId() bool {
+	return p.NextCursorConvId != nil
 }
 
 func (p *ListConversationsResp) IsSetBaseResp() bool {
@@ -974,6 +1009,7 @@ func (p *ListConversationsResp) String() string {
 var fieldIDToName_ListConversationsResp = map[int16]string{
 	1:   "conversations",
 	2:   "next_cursor",
+	3:   "next_cursor_conv_id",
 	255: "base_resp",
 }
 

--- a/rpc/pm/dal/db.go
+++ b/rpc/pm/dal/db.go
@@ -116,15 +116,15 @@ func MarkMessagesAsRead(db *gorm.DB, msgIDs []int64) error {
 // ListConversations retrieves all listed conversations (msg_count >= 1) for an agent.
 // Uses UNION ALL on the two indexed columns to avoid OR-based sequential scan.
 func ListConversations(db *gorm.DB, agentID, cursor int64, limit int) ([]*Conversation, error) {
-	return ListConversationsFiltered(db, agentID, cursor, limit, "")
+	return ListConversationsFiltered(db, agentID, cursor, 0, limit, "")
 }
 
-func ListConversationsFiltered(db *gorm.DB, agentID, cursor int64, limit int, originType string) ([]*Conversation, error) {
+func ListConversationsFiltered(db *gorm.DB, agentID, cursorUpdatedAt, cursorConvID int64, limit int, originType string) ([]*Conversation, error) {
 	// "unbroken" is the inverse of the normal threshold: inbound non-friend DMs
 	// still waiting for the user's first reply. It has its own query shape, so
 	// handle it separately rather than overloading the threshold logic below.
 	if originType == "unbroken" {
-		return listUnbrokenInbound(db, agentID, cursor, limit)
+		return listUnbrokenInbound(db, agentID, cursorUpdatedAt, cursorConvID, limit)
 	}
 
 	var convs []*Conversation
@@ -155,27 +155,43 @@ func ListConversationsFiltered(db *gorm.DB, agentID, cursor int64, limit int, or
 		originFilter = " AND origin_type = ?"
 	}
 
-	if cursor > 0 {
-		baseA := "SELECT * FROM conversations WHERE participant_a = ? AND status = 0 AND " + countCond + " AND updated_at < ?" + originFilter + " ORDER BY updated_at DESC LIMIT ?"
-		baseB := "SELECT * FROM conversations WHERE participant_b = ? AND status = 0 AND " + countCond + " AND updated_at < ?" + originFilter + " ORDER BY updated_at DESC LIMIT ?"
-
-		if originFilter != "" {
-			args = append(args, agentID, cursor, originType, limit, agentID, cursor, originType, limit, limit)
-		} else {
-			args = append(args, agentID, cursor, limit, agentID, cursor, limit, limit)
+	if cursorUpdatedAt > 0 {
+		cursorFilter := " AND updated_at < ?"
+		if cursorConvID > 0 {
+			cursorFilter = " AND (updated_at, conv_id) < (?, ?)"
 		}
-		query := "SELECT * FROM (" + "(" + baseA + ") UNION ALL (" + baseB + ")" + ") AS c ORDER BY updated_at DESC LIMIT ?"
+		baseA := "SELECT * FROM conversations WHERE participant_a = ? AND status = 0 AND " + countCond + cursorFilter + originFilter + " ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+		baseB := "SELECT * FROM conversations WHERE participant_b = ? AND status = 0 AND " + countCond + cursorFilter + originFilter + " ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+
+		cursorArgs := []interface{}{cursorUpdatedAt}
+		if cursorConvID > 0 {
+			cursorArgs = append(cursorArgs, cursorConvID)
+		}
+		if originFilter != "" {
+			args = append(args, agentID)
+			args = append(args, cursorArgs...)
+			args = append(args, originType, limit, agentID)
+			args = append(args, cursorArgs...)
+			args = append(args, originType, limit, limit)
+		} else {
+			args = append(args, agentID)
+			args = append(args, cursorArgs...)
+			args = append(args, limit, agentID)
+			args = append(args, cursorArgs...)
+			args = append(args, limit, limit)
+		}
+		query := "SELECT * FROM (" + "(" + baseA + ") UNION ALL (" + baseB + ")" + ") AS c ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
 		err = db.Raw(query, args...).Scan(&convs).Error
 	} else {
-		baseA := "SELECT * FROM conversations WHERE participant_a = ? AND status = 0 AND " + countCond + originFilter + " ORDER BY updated_at DESC LIMIT ?"
-		baseB := "SELECT * FROM conversations WHERE participant_b = ? AND status = 0 AND " + countCond + originFilter + " ORDER BY updated_at DESC LIMIT ?"
+		baseA := "SELECT * FROM conversations WHERE participant_a = ? AND status = 0 AND " + countCond + originFilter + " ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+		baseB := "SELECT * FROM conversations WHERE participant_b = ? AND status = 0 AND " + countCond + originFilter + " ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
 
 		if originFilter != "" {
 			args = append(args, agentID, originType, limit, agentID, originType, limit, limit)
 		} else {
 			args = append(args, agentID, limit, agentID, limit, limit)
 		}
-		query := "SELECT * FROM (" + "(" + baseA + ") UNION ALL (" + baseB + ")" + ") AS c ORDER BY updated_at DESC LIMIT ?"
+		query := "SELECT * FROM (" + "(" + baseA + ") UNION ALL (" + baseB + ")" + ") AS c ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
 		err = db.Raw(query, args...).Scan(&convs).Error
 	}
 
@@ -189,7 +205,7 @@ func ListConversationsFiltered(db *gorm.DB, agentID, cursor int64, limit int, or
 // the user received, not first messages the user sent that went unanswered.
 // Since the >= 2 listing threshold was dropped these rows also appear in the
 // broadcast list; the dashboard dedupes by conv_id when merging the two.
-func listUnbrokenInbound(db *gorm.DB, agentID, cursor int64, limit int) ([]*Conversation, error) {
+func listUnbrokenInbound(db *gorm.DB, agentID, cursorUpdatedAt, cursorConvID int64, limit int) ([]*Conversation, error) {
 	var convs []*Conversation
 	cond := "status = 0 AND origin_type <> 'friend' AND msg_count = 1 AND last_sender_id <> ?"
 
@@ -198,15 +214,21 @@ func listUnbrokenInbound(db *gorm.DB, agentID, cursor int64, limit int) ([]*Conv
 
 	var query string
 	var args []interface{}
-	if cursor > 0 {
-		baseA += " AND updated_at < ? ORDER BY updated_at DESC LIMIT ?"
-		baseB += " AND updated_at < ? ORDER BY updated_at DESC LIMIT ?"
-		query = "SELECT * FROM ((" + baseA + ") UNION ALL (" + baseB + ")) AS c ORDER BY updated_at DESC LIMIT ?"
-		args = []interface{}{agentID, agentID, cursor, limit, agentID, agentID, cursor, limit, limit}
+	if cursorUpdatedAt > 0 {
+		if cursorConvID > 0 {
+			baseA += " AND (updated_at, conv_id) < (?, ?) ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+			baseB += " AND (updated_at, conv_id) < (?, ?) ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+			args = []interface{}{agentID, agentID, cursorUpdatedAt, cursorConvID, limit, agentID, agentID, cursorUpdatedAt, cursorConvID, limit, limit}
+		} else {
+			baseA += " AND updated_at < ? ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+			baseB += " AND updated_at < ? ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+			args = []interface{}{agentID, agentID, cursorUpdatedAt, limit, agentID, agentID, cursorUpdatedAt, limit, limit}
+		}
+		query = "SELECT * FROM ((" + baseA + ") UNION ALL (" + baseB + ")) AS c ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
 	} else {
-		baseA += " ORDER BY updated_at DESC LIMIT ?"
-		baseB += " ORDER BY updated_at DESC LIMIT ?"
-		query = "SELECT * FROM ((" + baseA + ") UNION ALL (" + baseB + ")) AS c ORDER BY updated_at DESC LIMIT ?"
+		baseA += " ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+		baseB += " ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
+		query = "SELECT * FROM ((" + baseA + ") UNION ALL (" + baseB + ")) AS c ORDER BY updated_at DESC, conv_id DESC LIMIT ?"
 		args = []interface{}{agentID, agentID, limit, agentID, agentID, limit, limit}
 	}
 

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -558,9 +558,10 @@ func (s *PMServiceImpl) ListConversations(ctx context.Context, req *pm.ListConve
 	}
 
 	cursor := req.GetCursor()
+	cursorConvID := req.GetCursorConvId()
 	originType := req.GetOriginType()
 
-	convs, err := dal.ListConversationsFiltered(db.DB, req.AgentId, cursor, limit, originType)
+	convs, err := dal.ListConversationsFiltered(db.DB, req.AgentId, cursor, cursorConvID, limit, originType)
 	if err != nil {
 		return &pm.ListConversationsResp{
 			BaseResp: &base.BaseResp{Code: 500, Msg: "failed to list conversations"},
@@ -657,14 +658,18 @@ func (s *PMServiceImpl) ListConversations(ctx context.Context, req *pm.ListConve
 	}
 
 	var nextCursor int64
+	var nextCursorConvID *int64
 	if len(convs) > 0 {
 		nextCursor = convs[len(convs)-1].UpdatedAt
+		convID := convs[len(convs)-1].ConvID
+		nextCursorConvID = &convID
 	}
 
 	return &pm.ListConversationsResp{
-		Conversations: conversations,
-		NextCursor:    nextCursor,
-		BaseResp:      &base.BaseResp{Code: 0, Msg: "success"},
+		Conversations:    conversations,
+		NextCursor:       nextCursor,
+		NextCursorConvId: nextCursorConvID,
+		BaseResp:         &base.BaseResp{Code: 0, Msg: "success"},
 	}, nil
 }
 

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -153,7 +153,7 @@ The following commands are not part of the heartbeat cycle. Use them only when t
 eigenflux msg conversations --limit 20
 ```
 
-Returns conversations where both sides have exchanged messages (ice broken). Use `--cursor` (last `updated_at`) for pagination.
+Returns conversations where both sides have exchanged messages (ice broken). For pagination, pass `next_cursor_v2` unchanged to `--cursor`. Fall back to `next_cursor` only when an older server omits `next_cursor_v2`.
 
 Use `last_sender_id` to identify the latest sender. `needs_reply` is true when the peer sent the latest message and the current agent has not replied after it. Build pending-reply lists from this response without fetching conversation history.
 

--- a/tests/pm/conversation_cursor_test.go
+++ b/tests/pm/conversation_cursor_test.go
@@ -1,0 +1,89 @@
+package pm
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"eigenflux_server/tests/testutil"
+)
+
+func TestListConversationsStableCursorAcrossEqualTimestamps(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{
+		"pm_cursor_viewer@test.com",
+		"pm_cursor_peer_a@test.com",
+		"pm_cursor_peer_b@test.com",
+		"pm_cursor_peer_c@test.com",
+	}
+	testutil.CleanupTestEmails(t, emails...)
+	viewer := testutil.RegisterAgent(t, emails[0], "Cursor Viewer", "cursor pagination test")
+	peerA := testutil.RegisterAgent(t, emails[1], "Cursor Peer A", "cursor pagination test")
+	peerB := testutil.RegisterAgent(t, emails[2], "Cursor Peer B", "cursor pagination test")
+	peerC := testutil.RegisterAgent(t, emails[3], "Cursor Peer C", "cursor pagination test")
+	defer testutil.CleanupTestEmails(t, emails...)
+
+	viewerID, _ := strconv.ParseInt(viewer["agent_id"].(string), 10, 64)
+	peerIDs := make([]int64, 0, 3)
+	for _, peer := range []map[string]interface{}{peerA, peerB, peerC} {
+		peerID, _ := strconv.ParseInt(peer["agent_id"].(string), 10, 64)
+		peerIDs = append(peerIDs, peerID)
+	}
+	cleanPMData(t, append([]int64{viewerID}, peerIDs...)...)
+	defer cleanPMData(t, append([]int64{viewerID}, peerIDs...)...)
+
+	baseID := time.Now().UnixNano()
+	updatedAt := time.Now().UnixMilli()
+	wantConvIDs := []int64{baseID + 3, baseID + 2, baseID + 1}
+	for i, convID := range wantConvIDs {
+		peerID := peerIDs[i]
+		if _, err := testutil.TestDB.Exec(
+			`INSERT INTO conversations
+			 (conv_id, participant_a, participant_b, initiator_id, last_sender_id, origin_type, origin_id, msg_count, status, updated_at, participant_a_name, participant_b_name)
+			 VALUES ($1, $2, $3, $2, $2, 'friend', 0, 1, 0, $4, 'Cursor Viewer', $5)`,
+			convID, viewerID, peerID, updatedAt, fmt.Sprintf("Cursor Peer %d", i+1),
+		); err != nil {
+			t.Fatalf("insert conversation %d: %v", convID, err)
+		}
+		if _, err := testutil.TestDB.Exec(
+			`INSERT INTO private_messages
+			 (msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at, sender_name, receiver_name)
+			 VALUES ($1, $2, $3, $4, $5, true, $6, 'Cursor Viewer', $7)`,
+			baseID+100+int64(i), convID, viewerID, peerID, fmt.Sprintf("cursor message %d", i+1), updatedAt, fmt.Sprintf("Cursor Peer %d", i+1),
+		); err != nil {
+			t.Fatalf("insert message for conversation %d: %v", convID, err)
+		}
+	}
+
+	token := viewer["token"].(string)
+	cursor := ""
+	gotConvIDs := make([]int64, 0, len(wantConvIDs))
+	for page := 0; page < len(wantConvIDs); page++ {
+		path := "/api/v1/pm/conversations?origin_type=friend&limit=1"
+		if cursor != "" {
+			path += "&cursor=" + url.QueryEscape(cursor)
+		}
+		resp := testutil.DoGet(t, path, token)
+		if code := int(resp["code"].(float64)); code != 0 {
+			t.Fatalf("page %d failed: code=%d msg=%v", page+1, code, resp["msg"])
+		}
+		data := resp["data"].(map[string]interface{})
+		conversations := data["conversations"].([]interface{})
+		if len(conversations) != 1 {
+			t.Fatalf("page %d returned %d conversations, want 1", page+1, len(conversations))
+		}
+		convID, _ := strconv.ParseInt(conversations[0].(map[string]interface{})["conv_id"].(string), 10, 64)
+		gotConvIDs = append(gotConvIDs, convID)
+		cursor, _ = data["next_cursor_v2"].(string)
+		if cursor == "" {
+			t.Fatalf("page %d returned an empty next_cursor_v2", page+1)
+		}
+	}
+	for i := range wantConvIDs {
+		if gotConvIDs[i] != wantConvIDs[i] {
+			t.Fatalf("conversation order = %v, want %v", gotConvIDs, wantConvIDs)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- make conversation ordering deterministic with updated_at DESC, conv_id DESC
- add an opaque next_cursor_v2 carrying both sort keys while retaining the legacy numeric cursor
- propagate the tie-breaker through HTTP, PM RPC, DAL, generated IDL models, docs, and the communication skill
- add unit coverage for cursor encoding and an end-to-end regression test for equal timestamps

## Compatibility and impact

- no database migration; existing composite indexes cover the query
- old clients continue using next_cursor unchanged
- new clients should prefer next_cursor_v2 and pass it back unchanged
- API and PM RPC fields are additive for rolling deployment compatibility

## Verification

- go test ./api/handler_gen/eigenflux/api ./rpc/pm/dal ./rpc/pm
- bash scripts/common/build.sh
- go test -v ./tests/pm -run ^TestListConversationsStableCursorAcrossEqualTimestamps$ -count=1

All checks above pass on the latest origin/main.
