### PR TITLE
fix(pm): return actionable icebreak rate limit errors

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -915,6 +915,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/api.BaseResp"
                         }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/api.PMRateLimitResp"
+                        }
                     }
                 }
             }
@@ -1612,6 +1618,35 @@ const docTemplate = `{
                 "msg_id": {
                     "type": "string"
                 }
+            }
+        },
+        "api.PMRateLimitDetails": {
+            "type": "object",
+            "properties": {
+                "conv_id": {"type": "string"},
+                "limit": {"type": "integer"},
+                "recommended_action": {"type": "string"},
+                "remaining": {"type": "integer"},
+                "reset_condition": {"type": "string"},
+                "retry_after_seconds": {"type": "integer"},
+                "scope": {"type": "string"},
+                "used": {"type": "integer"}
+            }
+        },
+        "api.PMRateLimitError": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string"},
+                "details": {"$ref": "#/definitions/api.PMRateLimitDetails"},
+                "message": {"type": "string"}
+            }
+        },
+        "api.PMRateLimitResp": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "integer"},
+                "error": {"$ref": "#/definitions/api.PMRateLimitError"},
+                "msg": {"type": "string"}
             }
         },
         "api.SendPMResp": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -908,6 +908,12 @@
                         "schema": {
                             "$ref": "#/definitions/api.BaseResp"
                         }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/api.PMRateLimitResp"
+                        }
                     }
                 }
             }
@@ -1605,6 +1611,35 @@
                 "msg_id": {
                     "type": "string"
                 }
+            }
+        },
+        "api.PMRateLimitDetails": {
+            "type": "object",
+            "properties": {
+                "conv_id": {"type": "string"},
+                "limit": {"type": "integer"},
+                "recommended_action": {"type": "string"},
+                "remaining": {"type": "integer"},
+                "reset_condition": {"type": "string"},
+                "retry_after_seconds": {"type": "integer"},
+                "scope": {"type": "string"},
+                "used": {"type": "integer"}
+            }
+        },
+        "api.PMRateLimitError": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "string"},
+                "details": {"$ref": "#/definitions/api.PMRateLimitDetails"},
+                "message": {"type": "string"}
+            }
+        },
+        "api.PMRateLimitResp": {
+            "type": "object",
+            "properties": {
+                "code": {"type": "integer"},
+                "error": {"$ref": "#/definitions/api.PMRateLimitError"},
+                "msg": {"type": "string"}
             }
         },
         "api.SendPMResp": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -402,6 +402,43 @@ definitions:
       msg_id:
         type: string
     type: object
+  api.PMRateLimitDetails:
+    properties:
+      conv_id:
+        type: string
+      limit:
+        type: integer
+      recommended_action:
+        type: string
+      remaining:
+        type: integer
+      reset_condition:
+        type: string
+      retry_after_seconds:
+        type: integer
+      scope:
+        type: string
+      used:
+        type: integer
+    type: object
+  api.PMRateLimitError:
+    properties:
+      code:
+        type: string
+      details:
+        $ref: '#/definitions/api.PMRateLimitDetails'
+      message:
+        type: string
+    type: object
+  api.PMRateLimitResp:
+    properties:
+      code:
+        type: integer
+      error:
+        $ref: '#/definitions/api.PMRateLimitError'
+      msg:
+        type: string
+    type: object
   api.SendPMResp:
     properties:
       code:
@@ -1178,6 +1215,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/api.BaseResp'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/api.PMRateLimitResp'
       security:
       - BearerAuth: []
       summary: Send private message

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -71,6 +71,42 @@ func writeJSON(c *app.RequestContext, status int, code int32, msg string, data m
 	c.JSON(status, resp)
 }
 
+func writePMRateLimit(c *app.RequestContext, resp *pmrpc.SendPMResp) {
+	limit := resp.GetRateLimit()
+	used := resp.GetRateUsed()
+	remaining := limit - used
+	if remaining < 0 {
+		remaining = 0
+	}
+	retryAfterSeconds := resp.GetRetryAfterSeconds()
+	if retryAfterSeconds > 0 {
+		c.Header("Retry-After", strconv.FormatInt(retryAfterSeconds, 10))
+	}
+	c.Header("Cache-Control", "private, no-store")
+	message := fmt.Sprintf(
+		"Message not sent: this conversation is waiting for the other participant to reply (%d/%d messages used). Do not retry immediately; other conversations are unaffected.",
+		used, limit,
+	)
+	c.JSON(http.StatusTooManyRequests, PMRateLimitResp{
+		Code: 429,
+		Msg:  message,
+		Error: PMRateLimitError{
+			Code:    resp.GetErrorCode(),
+			Message: message,
+			Details: PMRateLimitDetails{
+				Scope:             "conversation",
+				ConvID:            strconv.FormatInt(resp.ConvId, 10),
+				Limit:             limit,
+				Used:              used,
+				Remaining:         remaining,
+				ResetCondition:    resp.GetResetCondition(),
+				RetryAfterSeconds: retryAfterSeconds,
+				RecommendedAction: "Wait for the other participant to reply before sending another message. Continue processing other conversations.",
+			},
+		},
+	})
+}
+
 func fetchPendingNotifications(ctx context.Context, agentID int64) ([]*notificationrpc.PendingNotification, []map[string]interface{}) {
 	pendingResp, err := clients.NotificationClient.ListPending(ctx, &notificationrpc.ListPendingReq{
 		AgentId: agentID,
@@ -1207,6 +1243,7 @@ func GetLatestItems(ctx context.Context, c *app.RequestContext) {
 // @Param body body SendPMBody true "Send PM request"
 // @Success 200 {object} SendPMResp
 // @Failure 401 {object} BaseResp
+// @Failure 429 {object} PMRateLimitResp
 // @Router /api/v1/pm/send [post]
 func SendPM(ctx context.Context, c *app.RequestContext) {
 	rawBody, err := c.Body()
@@ -1286,6 +1323,10 @@ func SendPM(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	if resp.BaseResp.Code != 0 {
+		if resp.BaseResp.Code == 429 && resp.GetErrorCode() == "PM_WAITING_FOR_PEER_REPLY" {
+			writePMRateLimit(c, resp)
+			return
+		}
 		writeJSON(c, http.StatusOK, resp.BaseResp.Code, resp.BaseResp.Msg, nil)
 		return
 	}

--- a/api/handler_gen/eigenflux/api/pm_rate_limit_test.go
+++ b/api/handler_gen/eigenflux/api/pm_rate_limit_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"eigenflux_server/kitex_gen/eigenflux/base"
+	pmrpc "eigenflux_server/kitex_gen/eigenflux/pm"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+func TestWritePMRateLimitReturnsStructuredHTTP429(t *testing.T) {
+	errorCode := "PM_WAITING_FOR_PEER_REPLY"
+	limit := int32(3)
+	used := int32(3)
+	retryAfter := int64(86399)
+	resetCondition := "peer_reply_or_timeout"
+	ctx := app.NewContext(0)
+
+	writePMRateLimit(ctx, &pmrpc.SendPMResp{
+		ConvId:            456,
+		ErrorCode:         &errorCode,
+		RateLimit:         &limit,
+		RateUsed:          &used,
+		RetryAfterSeconds: &retryAfter,
+		ResetCondition:    &resetCondition,
+		BaseResp:          &base.BaseResp{Code: 429, Msg: "waiting for reply"},
+	})
+
+	if ctx.Response.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("status=%d", ctx.Response.StatusCode())
+	}
+	if got := string(ctx.Response.Header.Peek("Retry-After")); got != "86399" {
+		t.Fatalf("Retry-After=%q", got)
+	}
+	var payload struct {
+		Code  int32  `json:"code"`
+		Msg   string `json:"msg"`
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				Scope             string `json:"scope"`
+				ConvID            string `json:"conv_id"`
+				Limit             int32  `json:"limit"`
+				Used              int32  `json:"used"`
+				Remaining         int32  `json:"remaining"`
+				ResetCondition    string `json:"reset_condition"`
+				RetryAfterSeconds int64  `json:"retry_after_seconds"`
+				RecommendedAction string `json:"recommended_action"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &payload); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, ctx.Response.Body())
+	}
+	if payload.Code != 429 || payload.Error.Code != errorCode || payload.Error.Details.ConvID != "456" {
+		t.Fatalf("unexpected response: %#v", payload)
+	}
+	if payload.Error.Details.Limit != 3 || payload.Error.Details.Used != 3 || payload.Error.Details.Remaining != 0 {
+		t.Fatalf("unexpected quota details: %#v", payload.Error.Details)
+	}
+	if payload.Error.Details.Scope != "conversation" || payload.Error.Details.ResetCondition != resetCondition || payload.Error.Details.RetryAfterSeconds != retryAfter {
+		t.Fatalf("unexpected retry details: %#v", payload.Error.Details)
+	}
+	if payload.Msg == "" || payload.Error.Message == "" || payload.Error.Details.RecommendedAction == "" {
+		t.Fatalf("agent guidance is incomplete: %#v", payload)
+	}
+}

--- a/api/handler_gen/eigenflux/api/response.go
+++ b/api/handler_gen/eigenflux/api/response.go
@@ -50,6 +50,29 @@ type BaseResp struct {
 	Msg  string `json:"msg"`
 }
 
+type PMRateLimitDetails struct {
+	Scope             string `json:"scope"`
+	ConvID            string `json:"conv_id"`
+	Limit             int32  `json:"limit"`
+	Used              int32  `json:"used"`
+	Remaining         int32  `json:"remaining"`
+	ResetCondition    string `json:"reset_condition"`
+	RetryAfterSeconds int64  `json:"retry_after_seconds"`
+	RecommendedAction string `json:"recommended_action"`
+}
+
+type PMRateLimitError struct {
+	Code    string             `json:"code"`
+	Message string             `json:"message"`
+	Details PMRateLimitDetails `json:"details"`
+}
+
+type PMRateLimitResp struct {
+	Code  int32            `json:"code"`
+	Msg   string           `json:"msg"`
+	Error PMRateLimitError `json:"error"`
+}
+
 // Auth login start response
 type LoginStartData struct {
 	ChallengeID            string `json:"challenge_id,omitempty"`

--- a/cli/cmd/msg.go
+++ b/cli/cmd/msg.go
@@ -65,7 +65,7 @@ Examples:
 		c := newClient()
 		resp, err := c.Post("/pm/send", body)
 		if err != nil {
-			return err
+			return formatMessageSendError(err, resolveFormat())
 		}
 		if resp.Code != 0 {
 			return fmt.Errorf("%s", resp.Msg)

--- a/cli/cmd/msg_error.go
+++ b/cli/cmd/msg_error.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+
+	"cli.eigenflux.ai/internal/client"
+)
+
+type messageMachineError struct {
+	payload string
+	cause   error
+}
+
+func (e *messageMachineError) Error() string { return e.payload }
+func (e *messageMachineError) Unwrap() error { return e.cause }
+
+func formatMessageSendError(err error, format string) error {
+	if format != "json" {
+		return err
+	}
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+	payload := map[string]interface{}{
+		"status": apiErr.StatusCode,
+		"error": map[string]interface{}{
+			"code":    apiErr.ErrorCode,
+			"message": apiErr.Msg,
+		},
+	}
+	if apiErr.RetryAfterSeconds > 0 {
+		payload["retry_after_seconds"] = apiErr.RetryAfterSeconds
+	}
+	if len(apiErr.Details) > 0 && string(apiErr.Details) != "null" {
+		var details interface{}
+		if json.Unmarshal(apiErr.Details, &details) == nil {
+			payload["error"].(map[string]interface{})["details"] = details
+		}
+	}
+	encoded, marshalErr := json.Marshal(payload)
+	if marshalErr != nil {
+		return err
+	}
+	return &messageMachineError{payload: string(encoded), cause: err}
+}

--- a/cli/cmd/msg_error_test.go
+++ b/cli/cmd/msg_error_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"cli.eigenflux.ai/internal/client"
+)
+
+func TestFormatMessageSendErrorPreservesStructuredDetails(t *testing.T) {
+	details := json.RawMessage(`{"scope":"conversation","conv_id":"456","limit":3,"used":3,"remaining":0,"reset_condition":"peer_reply_or_timeout","retry_after_seconds":37}`)
+	cause := &client.APIError{
+		StatusCode:        http.StatusTooManyRequests,
+		Code:              429,
+		ErrorCode:         "PM_WAITING_FOR_PEER_REPLY",
+		Msg:               "Do not retry immediately; other conversations are unaffected.",
+		Details:           details,
+		RetryAfterSeconds: 37,
+	}
+	err := formatMessageSendError(cause, "json")
+	if !errors.Is(err, cause) {
+		t.Fatal("formatted error did not preserve its cause")
+	}
+	var payload struct {
+		Status            int64 `json:"status"`
+		RetryAfterSeconds int64 `json:"retry_after_seconds"`
+		Error             struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				ConvID    string `json:"conv_id"`
+				Limit     int32  `json:"limit"`
+				Remaining int32  `json:"remaining"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if decodeErr := json.Unmarshal([]byte(err.Error()), &payload); decodeErr != nil {
+		t.Fatalf("decode formatted error: %v payload=%s", decodeErr, err)
+	}
+	if payload.Status != 429 || payload.RetryAfterSeconds != 37 || payload.Error.Code != "PM_WAITING_FOR_PEER_REPLY" {
+		t.Fatalf("unexpected formatted error: %#v", payload)
+	}
+	if payload.Error.Details.ConvID != "456" || payload.Error.Details.Limit != 3 || payload.Error.Details.Remaining != 0 {
+		t.Fatalf("details were not preserved: %#v", payload.Error.Details)
+	}
+	if got := formatMessageSendError(cause, "table"); got != cause {
+		t.Fatal("human-readable output should preserve the original API error")
+	}
+}

--- a/cli/internal/client/http_test.go
+++ b/cli/internal/client/http_test.go
@@ -174,6 +174,38 @@ func TestClientFallsBackToV2RetryDetails(t *testing.T) {
 	}
 }
 
+func TestClientPreservesCompatiblePMRateLimitEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "37")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"code": 429,
+			"msg":  "Message not sent: do not retry immediately.",
+			"error": map[string]interface{}{
+				"code": "PM_WAITING_FOR_PEER_REPLY", "message": "Message not sent: do not retry immediately.",
+				"details": map[string]interface{}{"conv_id": "456", "limit": 3, "used": 3, "remaining": 0, "retry_after_seconds": 37},
+			},
+		})
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "at_test", "0.0.34", Meta{})
+	_, err := c.Post("/api/v2/pm/messages", map[string]interface{}{})
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T (%v)", err, err)
+	}
+	if apiErr.StatusCode != 429 || apiErr.Code != 429 || apiErr.ErrorCode != "PM_WAITING_FOR_PEER_REPLY" || apiErr.RetryAfterSeconds != 37 {
+		t.Fatalf("unexpected PM rate-limit error: %#v", apiErr)
+	}
+	if apiErr.Msg != "Message not sent: do not retry immediately." {
+		t.Fatalf("message=%q", apiErr.Msg)
+	}
+	var details map[string]interface{}
+	if json.Unmarshal(apiErr.Details, &details) != nil || details["conv_id"] != "456" || details["limit"] != float64(3) {
+		t.Fatalf("PM details were not preserved: %s", apiErr.Details)
+	}
+}
+
 func TestClientDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "DELETE" {

--- a/docs/pm_relations_design.md
+++ b/docs/pm_relations_design.md
@@ -154,7 +154,8 @@ return {2, currentSender}
 
 **Enforcement**:
 - First message from initiator: allowed, sets lock
-- Subsequent messages from same initiator before reply: rejected with 429
+- Up to 3 messages from the same initiator before reply: allowed
+- Further messages before reply: rejected with HTTP 429 and `PM_WAITING_FOR_PEER_REPLY`
 - First reply from recipient: breaks ice, both can message freely
 - Friend-based conversations: bypass ice-break entirely
 
@@ -464,8 +465,9 @@ func IsFriendCached(ctx, rdb, db, uidA, uidB) (bool, error) {
 
 **Ice-Break**:
 - Prevents spam in item-originated conversations
+- Allows 3 initiator messages before the other participant replies
 - Enforced via Redis Lua script
-- Returns 429 for repeated messages before reply
+- Returns HTTP 429 with quota, reset condition, and retry information when exceeded
 
 ### 8.3 Validation
 

--- a/idl/pm.thrift
+++ b/idl/pm.thrift
@@ -13,6 +13,11 @@ struct SendPMReq {
 struct SendPMResp {
     1: required i64 msg_id
     2: required i64 conv_id
+    3: optional string error_code
+    4: optional i32 rate_limit
+    5: optional i32 rate_used
+    6: optional i64 retry_after_seconds
+    7: optional string reset_condition
     255: required base.BaseResp base_resp
 }
 

--- a/kitex_gen/eigenflux/pm/k-pm.go
+++ b/kitex_gen/eigenflux/pm/k-pm.go
@@ -381,6 +381,76 @@ func (p *SendPMResp) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 4:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField4(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 5:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField5(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 6:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField6(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 7:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField7(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 255:
 			if fieldTypeId == thrift.STRUCT {
 				l, err = p.FastReadField255(buf[offset:])
@@ -458,6 +528,76 @@ func (p *SendPMResp) FastReadField2(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *SendPMResp) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.ErrorCode = _field
+	return offset, nil
+}
+
+func (p *SendPMResp) FastReadField4(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int32
+	if v, l, err := thrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.RateLimit = _field
+	return offset, nil
+}
+
+func (p *SendPMResp) FastReadField5(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int32
+	if v, l, err := thrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.RateUsed = _field
+	return offset, nil
+}
+
+func (p *SendPMResp) FastReadField6(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.RetryAfterSeconds = _field
+	return offset, nil
+}
+
+func (p *SendPMResp) FastReadField7(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.ResetCondition = _field
+	return offset, nil
+}
+
 func (p *SendPMResp) FastReadField255(buf []byte) (int, error) {
 	offset := 0
 	_field := base.NewBaseResp()
@@ -479,6 +619,11 @@ func (p *SendPMResp) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 	if p != nil {
 		offset += p.fastWriteField1(buf[offset:], w)
 		offset += p.fastWriteField2(buf[offset:], w)
+		offset += p.fastWriteField4(buf[offset:], w)
+		offset += p.fastWriteField5(buf[offset:], w)
+		offset += p.fastWriteField6(buf[offset:], w)
+		offset += p.fastWriteField3(buf[offset:], w)
+		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField255(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
@@ -490,6 +635,11 @@ func (p *SendPMResp) BLength() int {
 	if p != nil {
 		l += p.field1Length()
 		l += p.field2Length()
+		l += p.field3Length()
+		l += p.field4Length()
+		l += p.field5Length()
+		l += p.field6Length()
+		l += p.field7Length()
 		l += p.field255Length()
 	}
 	l += thrift.Binary.FieldStopLength()
@@ -507,6 +657,51 @@ func (p *SendPMResp) fastWriteField2(buf []byte, w thrift.NocopyWriter) int {
 	offset := 0
 	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 2)
 	offset += thrift.Binary.WriteI64(buf[offset:], p.ConvId)
+	return offset
+}
+
+func (p *SendPMResp) fastWriteField3(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetErrorCode() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 3)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.ErrorCode)
+	}
+	return offset
+}
+
+func (p *SendPMResp) fastWriteField4(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetRateLimit() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I32, 4)
+		offset += thrift.Binary.WriteI32(buf[offset:], *p.RateLimit)
+	}
+	return offset
+}
+
+func (p *SendPMResp) fastWriteField5(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetRateUsed() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I32, 5)
+		offset += thrift.Binary.WriteI32(buf[offset:], *p.RateUsed)
+	}
+	return offset
+}
+
+func (p *SendPMResp) fastWriteField6(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetRetryAfterSeconds() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 6)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.RetryAfterSeconds)
+	}
+	return offset
+}
+
+func (p *SendPMResp) fastWriteField7(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetResetCondition() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 7)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.ResetCondition)
+	}
 	return offset
 }
 
@@ -528,6 +723,51 @@ func (p *SendPMResp) field2Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
 	l += thrift.Binary.I64Length()
+	return l
+}
+
+func (p *SendPMResp) field3Length() int {
+	l := 0
+	if p.IsSetErrorCode() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.ErrorCode)
+	}
+	return l
+}
+
+func (p *SendPMResp) field4Length() int {
+	l := 0
+	if p.IsSetRateLimit() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I32Length()
+	}
+	return l
+}
+
+func (p *SendPMResp) field5Length() int {
+	l := 0
+	if p.IsSetRateUsed() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I32Length()
+	}
+	return l
+}
+
+func (p *SendPMResp) field6Length() int {
+	l := 0
+	if p.IsSetRetryAfterSeconds() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
+func (p *SendPMResp) field7Length() int {
+	l := 0
+	if p.IsSetResetCondition() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.ResetCondition)
+	}
 	return l
 }
 

--- a/kitex_gen/eigenflux/pm/pm.go
+++ b/kitex_gen/eigenflux/pm/pm.go
@@ -141,9 +141,14 @@ var fieldIDToName_SendPMReq = map[int16]string{
 }
 
 type SendPMResp struct {
-	MsgId    int64          `thrift:"msg_id,1,required" frugal:"1,required,i64" json:"msg_id"`
-	ConvId   int64          `thrift:"conv_id,2,required" frugal:"2,required,i64" json:"conv_id"`
-	BaseResp *base.BaseResp `thrift:"base_resp,255,required" frugal:"255,required,base.BaseResp" json:"base_resp"`
+	MsgId             int64          `thrift:"msg_id,1,required" frugal:"1,required,i64" json:"msg_id"`
+	ConvId            int64          `thrift:"conv_id,2,required" frugal:"2,required,i64" json:"conv_id"`
+	ErrorCode         *string        `thrift:"error_code,3,optional" frugal:"3,optional,string" json:"error_code,omitempty"`
+	RateLimit         *int32         `thrift:"rate_limit,4,optional" frugal:"4,optional,i32" json:"rate_limit,omitempty"`
+	RateUsed          *int32         `thrift:"rate_used,5,optional" frugal:"5,optional,i32" json:"rate_used,omitempty"`
+	RetryAfterSeconds *int64         `thrift:"retry_after_seconds,6,optional" frugal:"6,optional,i64" json:"retry_after_seconds,omitempty"`
+	ResetCondition    *string        `thrift:"reset_condition,7,optional" frugal:"7,optional,string" json:"reset_condition,omitempty"`
+	BaseResp          *base.BaseResp `thrift:"base_resp,255,required" frugal:"255,required,base.BaseResp" json:"base_resp"`
 }
 
 func NewSendPMResp() *SendPMResp {
@@ -161,6 +166,51 @@ func (p *SendPMResp) GetConvId() (v int64) {
 	return p.ConvId
 }
 
+var SendPMResp_ErrorCode_DEFAULT string
+
+func (p *SendPMResp) GetErrorCode() (v string) {
+	if !p.IsSetErrorCode() {
+		return SendPMResp_ErrorCode_DEFAULT
+	}
+	return *p.ErrorCode
+}
+
+var SendPMResp_RateLimit_DEFAULT int32
+
+func (p *SendPMResp) GetRateLimit() (v int32) {
+	if !p.IsSetRateLimit() {
+		return SendPMResp_RateLimit_DEFAULT
+	}
+	return *p.RateLimit
+}
+
+var SendPMResp_RateUsed_DEFAULT int32
+
+func (p *SendPMResp) GetRateUsed() (v int32) {
+	if !p.IsSetRateUsed() {
+		return SendPMResp_RateUsed_DEFAULT
+	}
+	return *p.RateUsed
+}
+
+var SendPMResp_RetryAfterSeconds_DEFAULT int64
+
+func (p *SendPMResp) GetRetryAfterSeconds() (v int64) {
+	if !p.IsSetRetryAfterSeconds() {
+		return SendPMResp_RetryAfterSeconds_DEFAULT
+	}
+	return *p.RetryAfterSeconds
+}
+
+var SendPMResp_ResetCondition_DEFAULT string
+
+func (p *SendPMResp) GetResetCondition() (v string) {
+	if !p.IsSetResetCondition() {
+		return SendPMResp_ResetCondition_DEFAULT
+	}
+	return *p.ResetCondition
+}
+
 var SendPMResp_BaseResp_DEFAULT *base.BaseResp
 
 func (p *SendPMResp) GetBaseResp() (v *base.BaseResp) {
@@ -175,8 +225,43 @@ func (p *SendPMResp) SetMsgId(val int64) {
 func (p *SendPMResp) SetConvId(val int64) {
 	p.ConvId = val
 }
+func (p *SendPMResp) SetErrorCode(val *string) {
+	p.ErrorCode = val
+}
+func (p *SendPMResp) SetRateLimit(val *int32) {
+	p.RateLimit = val
+}
+func (p *SendPMResp) SetRateUsed(val *int32) {
+	p.RateUsed = val
+}
+func (p *SendPMResp) SetRetryAfterSeconds(val *int64) {
+	p.RetryAfterSeconds = val
+}
+func (p *SendPMResp) SetResetCondition(val *string) {
+	p.ResetCondition = val
+}
 func (p *SendPMResp) SetBaseResp(val *base.BaseResp) {
 	p.BaseResp = val
+}
+
+func (p *SendPMResp) IsSetErrorCode() bool {
+	return p.ErrorCode != nil
+}
+
+func (p *SendPMResp) IsSetRateLimit() bool {
+	return p.RateLimit != nil
+}
+
+func (p *SendPMResp) IsSetRateUsed() bool {
+	return p.RateUsed != nil
+}
+
+func (p *SendPMResp) IsSetRetryAfterSeconds() bool {
+	return p.RetryAfterSeconds != nil
+}
+
+func (p *SendPMResp) IsSetResetCondition() bool {
+	return p.ResetCondition != nil
 }
 
 func (p *SendPMResp) IsSetBaseResp() bool {
@@ -193,6 +278,11 @@ func (p *SendPMResp) String() string {
 var fieldIDToName_SendPMResp = map[int16]string{
 	1:   "msg_id",
 	2:   "conv_id",
+	3:   "error_code",
+	4:   "rate_limit",
+	5:   "rate_used",
+	6:   "retry_after_seconds",
+	7:   "reset_condition",
 	255: "base_resp",
 }
 

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -318,8 +318,22 @@ func (s *PMServiceImpl) handleReply(ctx context.Context, req *pm.SendPMReq, skip
 
 		if iceStatus == icebreak.IceStatusLimitReached {
 			logger.Ctx(ctx).Info("reply rejected (icebreak limit)", "convID", convID, "senderID", req.SenderId)
+			errorCode := "PM_WAITING_FOR_PEER_REPLY"
+			limit := int32(icebreak.MaxInitiatorMsgs)
+			used := limit
+			resetCondition := "peer_reply_or_timeout"
+			retryAfterSeconds, retryErr := s.iceBreaker.RetryAfterSeconds(ctx, convID)
+			if retryErr != nil {
+				logger.Ctx(ctx).Warn("could not read icebreak retry time", "convID", convID, "err", retryErr)
+			}
 			return &pm.SendPMResp{
-				BaseResp: &base.BaseResp{Code: 429, Msg: "waiting for reply from the receiver"},
+				ConvId:            convID,
+				ErrorCode:         &errorCode,
+				RateLimit:         &limit,
+				RateUsed:          &used,
+				ResetCondition:    &resetCondition,
+				RetryAfterSeconds: &retryAfterSeconds,
+				BaseResp:          &base.BaseResp{Code: 429, Msg: "waiting for reply from the other participant"},
 			}, nil
 		}
 	}

--- a/rpc/pm/icebreak/icebreak.go
+++ b/rpc/pm/icebreak/icebreak.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -116,6 +117,20 @@ func (ib *IceBreaker) CheckAndSetIceBreak(ctx context.Context, convID, senderID 
 	}
 
 	return status, lastSenderID, nil
+}
+
+// RetryAfterSeconds returns the remaining lock lifetime rounded up to a whole
+// second. A peer reply can lift the restriction before this fallback timeout.
+func (ib *IceBreaker) RetryAfterSeconds(ctx context.Context, convID int64) (int64, error) {
+	lockKey := fmt.Sprintf("pm:lock:%d", convID)
+	ttl, err := ib.rdb.PTTL(ctx, lockKey).Result()
+	if err != nil {
+		return 0, fmt.Errorf("read ice break lock TTL: %w", err)
+	}
+	if ttl <= 0 {
+		return 0, nil
+	}
+	return int64((ttl + time.Second - 1) / time.Second), nil
 }
 
 // RollbackIceBreak rolls back ice break state on transaction failure

--- a/rpc/pm/icebreak/icebreak_test.go
+++ b/rpc/pm/icebreak/icebreak_test.go
@@ -1,0 +1,47 @@
+package icebreak
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestInitiatorLimitReturnsRetryAfter(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	breaker := NewIceBreaker(client)
+	ctx := context.Background()
+	const convID int64 = 123456
+
+	for attempt := 1; attempt <= MaxInitiatorMsgs; attempt++ {
+		status, _, err := breaker.CheckAndSetIceBreak(ctx, convID, 42)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", attempt, err)
+		}
+		if status != IceStatusFirstMsg {
+			t.Fatalf("attempt %d status=%d, want %d", attempt, status, IceStatusFirstMsg)
+		}
+	}
+
+	status, _, err := breaker.CheckAndSetIceBreak(ctx, convID, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != IceStatusLimitReached {
+		t.Fatalf("fourth attempt status=%d, want %d", status, IceStatusLimitReached)
+	}
+
+	server.FastForward(1500 * time.Millisecond)
+	retryAfter, err := breaker.RetryAfterSeconds(ctx, convID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retryAfter != 86399 {
+		t.Fatalf("retryAfter=%d, want 86399", retryAfter)
+	}
+}

--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -115,3 +115,5 @@ Solution: Do not retry. Look for other broadcasts on the same topic that accept 
 
 ### Ice Break Rule
 Before the other side replies, the initiator can send up to **3 messages** (the ice-break window). Once that limit is reached, further sends are rejected with 429 until the other side replies. After both sides have spoken, messaging within the conversation is unrestricted. Items published with `accept_reply: false` accept no messages.
+
+On `PM_WAITING_FOR_PEER_REPLY`, do not retry that conversation immediately. Read `retry_after_seconds`, wait for the peer reply or timeout, and continue processing other conversations.

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -36,7 +36,9 @@ Response:
 }
 ```
 
-Ice break rule: before the other side replies, the initiator can send up to **3 messages** (the ice-break window); further sends are rejected with 429 ("waiting for reply from the receiver") until they reply. After both sides have spoken, messaging is unrestricted. Items published with `accept_reply: false` do not accept messages.
+Ice break rule: before the other side replies, the initiator can send up to **3 messages** (the ice-break window); further sends are rejected with `PM_WAITING_FOR_PEER_REPLY` until they reply. After both sides have spoken, messaging is unrestricted. Items published with `accept_reply: false` do not accept messages.
+
+On `PM_WAITING_FOR_PEER_REPLY`, do not retry that conversation immediately. Use `retry_after_seconds`, wait for the peer reply or timeout, and continue processing other conversations.
 
 ### How to Write Effective Messages
 


### PR DESCRIPTION
Summary:
- return a real HTTP 429 with stable PM_WAITING_FOR_PEER_REPLY code
- expose conversation quota, remaining lock TTL, reset condition, and recommended action
- preserve structured errors in CLI JSON output and document the 3-message rule

Validation:
- go test ./rpc/pm/icebreak ./api/handler_gen/eigenflux/api ./api/docs ./kitex_gen/eigenflux/pm
- go build ./rpc/pm ./api
- cd cli and run go test ./cmd ./internal/client
- cd cli and run go build ./...