### PR TITLE
fix: use agent card regions throughout console

### DIFF
--- a/api/consolev2/attention_response_handlers.go
+++ b/api/consolev2/attention_response_handlers.go
@@ -346,6 +346,7 @@ func (s *Service) getAttentionSource(_ context.Context, c *app.RequestContext) {
 			Summary       string `gorm:"column:summary"`
 			URL           string `gorm:"column:url"`
 			AuthorID      int64  `gorm:"column:author_id"`
+			CountryCode   string `gorm:"column:country_code"`
 			UpdatedAt     int64  `gorm:"column:updated_at"`
 			ConsumedCount int64  `gorm:"column:consumed_count"`
 			HelpfulCount  int64  `gorm:"column:helpful_count"`
@@ -353,6 +354,7 @@ func (s *Service) getAttentionSource(_ context.Context, c *app.RequestContext) {
 		}
 		result := s.db.Raw(`SELECT raw.raw_content AS content, processed.summary, raw.raw_url AS url,
 			raw.author_agent_id AS author_id, processed.updated_at,
+			COALESCE(card.private_card->>'geo', '') AS country_code,
 			COALESCE(stats.consumed_count, 0) AS consumed_count,
 			COALESCE(stats.score_1_count, 0) + COALESCE(stats.score_2_count, 0) AS helpful_count,
 			COALESCE(stats.total_score, 0) AS total_score
@@ -360,12 +362,14 @@ func (s *Service) getAttentionSource(_ context.Context, c *app.RequestContext) {
 			JOIN raw_items raw ON raw.item_id = exposure.source_id
 			JOIN processed_items processed ON processed.item_id = exposure.source_id
 			LEFT JOIN item_stats stats ON stats.item_id = exposure.source_id
+			LEFT JOIN agent_cards card ON card.agent_id = raw.author_agent_id
 			WHERE exposure.agent_id = ? AND exposure.source_type = 'broadcast' AND exposure.source_id = ?`, agentIDValue, sourceID).Scan(&row)
 		err = result.Error
 		found = result.RowsAffected == 1 && row.AuthorID > 0
 		detail = map[string]interface{}{
 			"content": row.Content, "summary": row.Summary, "url": row.URL,
 			"author_agent_id": fmt.Sprintf("%d", row.AuthorID), "updated_at": row.UpdatedAt,
+			"country_code": todayCountryCode(row.CountryCode),
 			"interaction": map[string]interface{}{
 				"consumed_count": row.ConsumedCount, "helpful_count": row.HelpfulCount, "total_score": row.TotalScore,
 			},

--- a/api/consolev2/communication_handlers.go
+++ b/api/consolev2/communication_handlers.go
@@ -34,6 +34,7 @@ type communicationCardSummary struct {
 }
 
 type communicationAgentContext struct {
+	CountryCode       string                   `json:"country_code,omitempty"`
 	IdentityAssertion identityAssertion        `json:"identity_assertion"`
 	CardSummary       communicationCardSummary `json:"card_summary"`
 	PublicCardVersion int64                    `json:"public_card_version"`
@@ -279,6 +280,7 @@ func (s *Service) loadCommunicationContexts(viewerID int64, peerIDs []int64, rel
 			if decodeErr != nil {
 				contextValue.ProfileStatus = "unavailable"
 			} else {
+				contextValue.CountryCode = todayCountryCode(card.CountryCode)
 				contextValue.CardSummary = summary
 				contextValue.PublicCardVersion = card.PublicCardVersion
 				contextValue.CardGeneratedAt = card.PublicCardGeneratedAt

--- a/api/consolev2/home_activity_handlers.go
+++ b/api/consolev2/home_activity_handlers.go
@@ -129,43 +129,43 @@ func (s *Service) loadHomeActivity(ctx context.Context, now int64) (homeActivity
 	query := `WITH bounds AS (SELECT ?::bigint AS cutoff), events AS (
 		SELECT 'broadcast:' || r.item_id AS event_id, 'broadcast' AS event_type, r.created_at,
 		       a.agent_name AS actor_name, COALESCE(a.short_id,'') AS actor_short_id,
-		       COALESCE(ap.country,'') AS actor_country, '' AS counterpart_name,
+		       COALESCE(ap.private_card->>'geo','') AS actor_country, '' AS counterpart_name,
 		       '' AS counterpart_country, r.item_id AS broadcast_id,
 		       LEFT(r.raw_content, 4001) AS broadcast_content, false AS is_private
 		FROM raw_items r JOIN processed_items p ON p.item_id=r.item_id AND p.status=3
-		JOIN agents a ON a.agent_id=r.author_agent_id LEFT JOIN agent_profiles ap ON ap.agent_id=a.agent_id
+		JOIN agents a ON a.agent_id=r.author_agent_id LEFT JOIN agent_cards ap ON ap.agent_id=a.agent_id
 		WHERE r.created_at >= (SELECT cutoff FROM bounds) AND a.short_id IS NOT NULL
 		  AND COALESCE(a.email,'') NOT LIKE '%@pgc.eigenflux.one' AND COALESCE(a.email,'') NOT LIKE '%@bot.eigenflux.one'
 		UNION ALL
 		SELECT 'profile:' || c.agent_id || ':' || c.public_card_generated_at, 'profile', c.public_card_generated_at,
-		       a.agent_name, COALESCE(a.short_id,''), COALESCE(ap.country,''), '', '', 0, '', false
-		FROM agent_cards c JOIN agents a ON a.agent_id=c.agent_id LEFT JOIN agent_profiles ap ON ap.agent_id=a.agent_id
+		       a.agent_name, COALESCE(a.short_id,''), COALESCE(c.private_card->>'geo',''), '', '', 0, '', false
+		FROM agent_cards c JOIN agents a ON a.agent_id=c.agent_id
 		WHERE c.public_card_generated_at >= (SELECT cutoff FROM bounds) AND c.public_card_version > 1 AND a.short_id IS NOT NULL
 		UNION ALL
-		SELECT 'relation:' || r.id, 'relation', r.created_at, a.agent_name, '', COALESCE(ap.country,''),
-		       b.agent_name, COALESCE(bp.country,''), 0, '', true
+		SELECT 'relation:' || r.id, 'relation', r.created_at, a.agent_name, '', COALESCE(ap.private_card->>'geo',''),
+		       b.agent_name, COALESCE(bp.private_card->>'geo',''), 0, '', true
 		FROM user_relations r JOIN agents a ON a.agent_id=r.from_uid JOIN agents b ON b.agent_id=r.to_uid
-		LEFT JOIN agent_profiles ap ON ap.agent_id=a.agent_id LEFT JOIN agent_profiles bp ON bp.agent_id=b.agent_id
+		LEFT JOIN agent_cards ap ON ap.agent_id=a.agent_id LEFT JOIN agent_cards bp ON bp.agent_id=b.agent_id
 		WHERE r.created_at >= (SELECT cutoff FROM bounds) AND r.rel_type=1 AND r.from_uid < r.to_uid
 		UNION ALL
-		SELECT 'message:' || pm.msg_id, 'message', pm.created_at, sender.agent_name, '', COALESCE(sp.country,''),
-		       receiver.agent_name, COALESCE(rp.country,''), 0, '', true
+		SELECT 'message:' || pm.msg_id, 'message', pm.created_at, sender.agent_name, '', COALESCE(sp.private_card->>'geo',''),
+		       receiver.agent_name, COALESCE(rp.private_card->>'geo',''), 0, '', true
 		FROM private_messages pm JOIN conversations c ON c.conv_id=pm.conv_id
 		JOIN agents sender ON sender.agent_id=pm.sender_id JOIN agents receiver ON receiver.agent_id=pm.receiver_id
-		LEFT JOIN agent_profiles sp ON sp.agent_id=sender.agent_id LEFT JOIN agent_profiles rp ON rp.agent_id=receiver.agent_id
+		LEFT JOIN agent_cards sp ON sp.agent_id=sender.agent_id LEFT JOIN agent_cards rp ON rp.agent_id=receiver.agent_id
 		WHERE pm.created_at >= (SELECT cutoff FROM bounds) AND COALESCE(c.origin_type,'') <> 'broadcast'
 		UNION ALL
 		SELECT 'reply:' || pm.msg_id, 'reply', pm.created_at, sender.agent_name, COALESCE(sender.short_id,''),
-		       COALESCE(sp.country,''), '', '', r.item_id, LEFT(r.raw_content,4001), false
+		       COALESCE(sp.private_card->>'geo',''), '', '', r.item_id, LEFT(r.raw_content,4001), false
 		FROM private_messages pm JOIN conversations c ON c.conv_id=pm.conv_id AND c.origin_type='broadcast'
 		JOIN raw_items r ON r.item_id=c.origin_id JOIN processed_items p ON p.item_id=r.item_id AND p.status=3
-		JOIN agents sender ON sender.agent_id=pm.sender_id LEFT JOIN agent_profiles sp ON sp.agent_id=sender.agent_id
+		JOIN agents sender ON sender.agent_id=pm.sender_id LEFT JOIN agent_cards sp ON sp.agent_id=sender.agent_id
 		WHERE pm.created_at >= (SELECT cutoff FROM bounds) AND sender.short_id IS NOT NULL
 		UNION ALL
-		SELECT 'delegation:' || command_id, 'delegation', command.created_at, a.agent_name, '', COALESCE(ap.country,''),
+		SELECT 'delegation:' || command_id, 'delegation', command.created_at, a.agent_name, '', COALESCE(ap.private_card->>'geo',''),
 		       '', '', 0, '', true
 		FROM agent_commands command JOIN agents a ON a.agent_id=command.agent_id
-		LEFT JOIN agent_profiles ap ON ap.agent_id=a.agent_id
+		LEFT JOIN agent_cards ap ON ap.agent_id=a.agent_id
 		WHERE command.created_at >= (SELECT cutoff FROM bounds) AND command.command_type='task_delegation'
 	)
 	SELECT * FROM events ORDER BY created_at DESC, event_id DESC LIMIT ?`

--- a/api/consolev2/home_handlers_postgres_test.go
+++ b/api/consolev2/home_handlers_postgres_test.go
@@ -89,6 +89,7 @@ func TestHomeHTTPContracts(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc.redisClient = redisClient
+	svc.enableAttentionV1 = true
 	h := server.New(server.WithHostPorts("127.0.0.1:0"))
 	svc.Register(h)
 
@@ -187,6 +188,10 @@ func TestHomeHTTPContracts(t *testing.T) {
 	t.Cleanup(func() {
 		_ = db.Exec(`DELETE FROM processed_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
 		_ = db.Exec(`DELETE FROM raw_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
+	})
+
+	t.Run("country sources agree across Console", func(t *testing.T) {
+		testConsoleCountrySources(t, db, svc, h, cookie, agentIDValue, demandAgentID, publishAgentID, firstVoiceItemID, newPublishItemID, now)
 	})
 
 	generatedAt := time.Now().UnixMilli()
@@ -333,5 +338,120 @@ func assertHomeCachedResponse(t *testing.T, h *server.Hertz, path, collection, i
 	}
 	if _, ok := data["cache_ttl_seconds"].(float64); !ok {
 		t.Fatalf("%s cache_ttl_seconds has unexpected type: %#v", path, data["cache_ttl_seconds"])
+	}
+}
+
+func testConsoleCountrySources(t *testing.T, db *gorm.DB, svc *Service, h *server.Hertz, cookie ut.Header,
+	actorID, peerID, missingCardID, itemID, missingCardItemID, now int64) {
+	t.Helper()
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	originalDB := svc.db
+	svc.db = tx
+	t.Cleanup(func() { svc.db = originalDB; tx.Rollback() })
+	exec := func(sql string, args ...interface{}) {
+		t.Helper()
+		if err := tx.Exec(sql, args...).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The canonical card deliberately disagrees with both legacy profile fields.
+	exec(`INSERT INTO agent_profiles (agent_id, country, profile_data, updated_at)
+  VALUES (?, '', '{"geo":"US"}', ?), (?, 'US', '{"geo":"US"}', ?)`, actorID, now, missingCardID, now)
+	exec(`UPDATE agent_cards SET private_card='{"geo":" CN ","timezone":"UTC"}',
+  public_card_version=2, public_card_generated_at=? WHERE agent_id=?`, now, actorID)
+	// A card-only peer proves that no legacy profile row is required.
+	exec(`INSERT INTO agent_cards (agent_id, public_card, private_card, schema_version, source_version,
+  rebuild_fence, card_version, public_card_version, generated_at, public_card_generated_at)
+  VALUES (?, '{}', '{"geo":"Singapore"}', 1, 1, 0, 1, 1, ?, 0)`, peerID, now)
+	convID, replyConvID := actorID+30, actorID+31
+	exec(`INSERT INTO conversations (conv_id, participant_a, participant_b, initiator_id, last_sender_id,
+  origin_type, origin_id, updated_at) VALUES (?, ?, ?, ?, ?, 'direct', 0, ?), (?, ?, ?, ?, ?, 'broadcast', ?, ?)`,
+		convID, actorID, peerID, actorID, actorID, now, replyConvID, actorID, peerID, actorID, actorID, itemID, now)
+	exec(`INSERT INTO private_messages (msg_id, conv_id, sender_id, receiver_id, content, created_at)
+  VALUES (?, ?, ?, ?, 'direct message', ?), (?, ?, ?, ?, 'broadcast reply', ?)`,
+		actorID+32, convID, actorID, peerID, now, actorID+33, replyConvID, actorID, peerID, now)
+	exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, created_at) VALUES (?, ?, 1, ?)`, actorID, peerID, now)
+	exec(`INSERT INTO agent_commands (agent_id, command_type, payload_hash, idempotency_key, created_at)
+  VALUES (?, 'task_delegation', 'country-test', 'country-test', ?)`, actorID, now)
+	activity, err := svc.loadHomeActivity(context.Background(), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, event := range activity.Events {
+		if event.ActorName != "Home Contract Agent" && event.ActorName != "H***" {
+			continue
+		}
+		seen[event.Type] = true
+		if event.ActorCountryCode != "CN" {
+			t.Fatalf("%s actor country=%q", event.Type, event.ActorCountryCode)
+		}
+		if (event.Type == "relation" || event.Type == "message") && event.CounterpartCountry != "SG" {
+			t.Fatalf("%s counterpart country=%q", event.Type, event.CounterpartCountry)
+		}
+	}
+	for _, kind := range []string{"broadcast", "profile", "relation", "message", "reply", "delegation"} {
+		if !seen[kind] {
+			t.Fatalf("missing activity type %s", kind)
+		}
+	}
+	selected := []homeWorthWatchingRule{
+		{Key: "test", Rows: []homeWorthWatchingCandidate{{ItemID: itemID}}},
+		{Key: "missing", Rows: []homeWorthWatchingCandidate{{ItemID: missingCardItemID}}},
+	}
+	worth, err := svc.hydrateHomeWorthWatching(context.Background(), selected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worth) != 2 || worth[0].AgentCountryCode != "CN" || worth[1].AgentCountryCode != "" {
+		t.Fatalf("worth watching countries=%#v", worth)
+	}
+	status, payload, _ := performJSON(t, h, http.MethodGet, "/api/v2/console/today", map[string]interface{}{}, cookie)
+	if status != http.StatusOK {
+		t.Fatalf("Today status=%d payload=%#v", status, payload)
+	}
+	data := responseData(t, payload)
+	encounters, ok := data["encounters"].([]interface{})
+	if !ok || len(encounters) != 1 || encounters[0].(map[string]interface{})["country_code"] != "SG" {
+		t.Fatalf("Today encounters=%#v", data["encounters"])
+	}
+	contexts := data["agent_contexts"].(map[string]interface{})
+	if contexts[strconv.FormatInt(peerID, 10)].(map[string]interface{})["country_code"] != "SG" {
+		t.Fatalf("Today contexts=%#v", contexts)
+	}
+
+	exec(`INSERT INTO agent_feed_exposures (agent_id, source_type, source_id, content_class,
+  author_agent_id, first_seen_at, last_seen_at) VALUES (?, 'broadcast', ?, 'ugc', ?, ?, ?)`, actorID, itemID, actorID, now, now)
+	attentionID := actorID + 40
+	exec(`INSERT INTO agent_attention_items (attention_id, agent_id, title, source_type, source_id,
+  created_at, expires_at, producer, protocol_version, client_item_id, payload_hash, source_ref,
+  actions_snapshot, generated_at, updated_at)
+  VALUES (?, ?, 'country source', 'broadcast', ?, ?, ?, 'agent', 'agent_attention.v1', 'country-source',
+  'country-source', jsonb_build_object('type', 'broadcast', 'id', ?::text), '[{"action_key":"open"}]', ?, ?)`,
+		attentionID, actorID, itemID, now, now+3600000, strconv.FormatInt(itemID, 10), now, now)
+	status, sourcePayload, _ := performJSON(t, h, http.MethodGet,
+		fmt.Sprintf("/api/v2/console/attention-items/%d/source", attentionID), map[string]interface{}{}, cookie)
+	if status != http.StatusOK {
+		t.Fatalf("source status=%d payload=%#v", status, sourcePayload)
+	}
+	if responseData(t, sourcePayload)["detail"].(map[string]interface{})["country_code"] != "CN" {
+		t.Fatalf("broadcast source country=%#v", sourcePayload)
+	}
+	// Clearing the canonical value must not resurrect an obsolete country.
+	exec(`UPDATE agent_cards SET private_card='{}' WHERE agent_id=?`, actorID)
+	worth, err = svc.hydrateHomeWorthWatching(context.Background(), selected[:1])
+	if err != nil || len(worth) != 1 || worth[0].AgentCountryCode != "" {
+		t.Fatalf("cleared country: items=%#v err=%v", worth, err)
+	}
+	exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, created_at) VALUES (?, ?, 2, ?)`, actorID, peerID, now)
+	blocked, err := svc.loadCommunicationContexts(actorID, []int64{peerID}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked[strconv.FormatInt(peerID, 10)].CountryCode != "" {
+		t.Fatalf("blocked peer exposes country: %#v", blocked)
 	}
 }

--- a/api/consolev2/home_worth_watching_handlers.go
+++ b/api/consolev2/home_worth_watching_handlers.go
@@ -369,13 +369,12 @@ func (s *Service) hydrateHomeWorthWatching(ctx context.Context, selected []homeW
 		COALESCE(p.summary,'') AS summary, COALESCE(p.lang,'') AS language,
 		COALESCE(p.broadcast_type,'') AS broadcast_type, r.created_at,
 		COALESCE(a.short_id,'') AS short_id, a.agent_name, COALESCE(a.agent_name_en,'') AS agent_name_en,
-		COALESCE(ap.country,'') AS country, COALESCE(ac.public_card,'{}'::jsonb)::text AS public_card,
+		COALESCE(ac.private_card->>'geo','') AS country, COALESCE(ac.public_card,'{}'::jsonb)::text AS public_card,
 		COALESCE(p.quality_score,0) AS homepage_quality,
 		(SELECT COUNT(DISTINCT f.agent_id) FROM feedback_logs f
 		 WHERE f.item_id=r.item_id AND f.score > 0) AS helpful_count
 		FROM raw_items r JOIN processed_items p ON p.item_id=r.item_id
 		JOIN agents a ON a.agent_id=r.author_agent_id
-		LEFT JOIN agent_profiles ap ON ap.agent_id=a.agent_id
 		LEFT JOIN agent_cards ac ON ac.agent_id=a.agent_id
 		WHERE r.item_id = ANY(?)`, pq.Array(ids)).Scan(&rows).Error; err != nil {
 		return nil, err

--- a/api/consolev2/today_handlers.go
+++ b/api/consolev2/today_handlers.go
@@ -468,11 +468,10 @@ func (s *Service) getToday(_ context.Context, c *app.RequestContext) {
 			FROM recent WHERE peer_agent_id <> ? GROUP BY peer_agent_id
 		)
 		SELECT grouped.peer_agent_id, grouped.last_interaction_at, grouped.interaction_count,
-			COALESCE(NULLIF(BTRIM(profile.profile_data->>'geo'), ''),
-				NULLIF(BTRIM(profile.country), '')) AS country_code,
+			COALESCE(card.private_card->>'geo', '') AS country_code,
 			COUNT(*) OVER() AS total_count
 		FROM grouped
-		LEFT JOIN agent_profiles profile ON profile.agent_id = grouped.peer_agent_id
+		LEFT JOIN agent_cards card ON card.agent_id = grouped.peer_agent_id
 		ORDER BY grouped.last_interaction_at DESC, grouped.peer_agent_id DESC LIMIT ?`,
 		agentIDValue, todayStart, agentIDValue, todayStart,
 		agentIDValue, todayStart,

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -166,6 +166,12 @@ day boundary, and the evaluation version. Results use a two-minute Redis cache
 with process-local singleflight and PostgreSQL fallback. Homepage requests
 never invoke the LLM.
 
+Console country codes in Home discovery, activity, worth-watching, Today encounters,
+broadcast source drawers, and communication Agent summaries come from `agent_cards.private_card.geo`.
+Legacy `agent_profiles.country` and `profile_data.geo` are not display fallbacks.
+Missing or cleared Card regions remain unknown. Communication summaries expose
+only the normalized country code; blocked and deleted peers omit it.
+
 ## Console V2 Today Model Brief
 
 CLI account switching uses `GET /api/v2/console/account-switch` to inspect the

--- a/rpc/profile/dal/card.go
+++ b/rpc/profile/dal/card.go
@@ -285,6 +285,7 @@ type AgentCard struct {
 	AgentID               int64  `gorm:"column:agent_id;primaryKey"`
 	PublicCard            string `gorm:"column:public_card"`
 	PrivateCard           string `gorm:"column:private_card"`
+	CountryCode           string `gorm:"column:country_code;->"`
 	SchemaVersion         int32  `gorm:"column:schema_version"`
 	SourceVersion         int64  `gorm:"column:source_version"`
 	RebuildFence          int64  `gorm:"column:rebuild_fence"`
@@ -300,7 +301,7 @@ func (AgentCard) TableName() string { return "agent_cards" }
 func GetAgentCard(db *gorm.DB, agentID int64) (*AgentCard, error) {
 	var card AgentCard
 	err := db.Raw(`SELECT agent_id, public_card::text as public_card,
-			private_card::text as private_card, schema_version,
+			private_card::text as private_card, COALESCE(private_card->>'geo', '') AS country_code, schema_version,
 			source_version, rebuild_fence, card_version, public_card_version,
 			generated_at, public_card_generated_at
 		FROM agent_cards WHERE agent_id = ?`, agentID).Scan(&card).Error
@@ -313,7 +314,7 @@ func GetAgentCard(db *gorm.DB, agentID int64) (*AgentCard, error) {
 	return &card, nil
 }
 
-// GetAgentCards loads the already-built public projection for a bounded set of
+// GetAgentCards loads the already-built public projection and country code for a bounded set of
 // agents in one query. Missing cards are intentionally absent from the result:
 // list endpoints must not synchronously rebuild one card per peer.
 func GetAgentCards(db *gorm.DB, agentIDs []int64) (map[int64]*AgentCard, error) {
@@ -340,7 +341,8 @@ func GetAgentCards(db *gorm.DB, agentIDs []int64) (map[int64]*AgentCard, error) 
 
 	var cards []*AgentCard
 	err := db.Raw(`SELECT agent_id, public_card::text as public_card,
-			schema_version, public_card_version, public_card_generated_at
+			schema_version, public_card_version, public_card_generated_at,
+			COALESCE(private_card->>'geo', '') AS country_code
 		FROM agent_cards
 		WHERE agent_id IN ?`, deduplicated).Scan(&cards).Error
 	if err != nil {


### PR DESCRIPTION
Console activity could show a globe for an Agent whose discovery card already showed a country flag because the surfaces read different profile fields. Home activity, worth-watching broadcasts, Today encounters, broadcast source drawers, and communication summaries now read the canonical `agent_cards.private_card.geo` and normalize it consistently. Missing or cleared regions stay unknown; blocked communication peers omit the country code.

The batch card reader selects only the country code alongside the public projection. No production data repair or migration is required.

Validation: PostgreSQL-backed `go test ./api/consolev2 ./rpc/profile/dal -count=1` and `go build -o build/api ./api` passed. Added HTTP/database coverage for all six activity types, card-only peers, conflicting legacy fields, missing/cleared cards, Today encounters and summaries, broadcast source drawers, and blocked peers.
