### PR TITLE
fix(skills): prevent signed manifest sequence reuse

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -17,6 +17,14 @@ on:
     paths:
       - 'skills/**'                    # the skills source of truth
       - 'cli/internal/skills/types.go' # ProdAllowlist — which skills get packaged
+      - 'cli/scripts/release-skills.sh'
+      - 'cli/scripts/skills-release-state.py'
+      - 'cli/cmd/manifestcheck/**'
+      - 'cli/cmd/releaseverify/**'
+      - 'cli/internal/skills/release.go'
+      - 'tests/cli_release/**'
+      - 'cli/tests/skills_release_test.go'
+      - '.github/workflows/release-skills.yml'
       - 'cli/.cli.config'              # SKILLS_MIN_CLI_VERSION / SKILLS_REVISION
   workflow_dispatch:                   # manual "Run workflow" button
 
@@ -32,10 +40,13 @@ concurrency:
 
 jobs:
   release-skills:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -51,8 +62,15 @@ jobs:
         run: |
           gtar --version | head -1
           aws --version
+          aws s3api put-object --generate-cli-skeleton input | python3 -c 'import json,sys; assert "IfNoneMatch" in json.load(sys.stdin)'
           shasum -a 256 /dev/null >/dev/null && echo "shasum: ok"
           go version
+
+      - name: Test signed release and upgrade safeguards
+        run: |
+          python3 -m unittest discover -s tests/cli_release -p 'test_*.py'
+          cd cli
+          go test ./internal/skills ./cmd/manifestcheck ./cmd/releaseverify ./tests
 
       - name: Publish skills to R2
         env:

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -10,8 +10,8 @@ CLI_VERSION=0.0.42
 # actually compare, this is just a human-facing label.)
 SKILLS_REVISION=18
 
-# Monotonic signed release sequence. Every published manifest must increment it;
-# clients reject rollback and sequence reuse with different content.
+# Local build sequence only. Production releases allocate max(signed R2 history)+1
+# inside the serialized Release Skills workflow; this value never selects a release.
 SKILLS_SEQUENCE=8
 
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a

--- a/cli/cmd/manifestcheck/main.go
+++ b/cli/cmd/manifestcheck/main.go
@@ -1,0 +1,31 @@
+// manifestcheck verifies release records using the same trust root as skills sync.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"cli.eigenflux.ai/internal/skills"
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 1 {
+		log.Fatal("usage: manifestcheck manifest.json")
+	}
+	data, err := os.ReadFile(flag.Arg(0))
+	if err != nil {
+		log.Fatal(err)
+	}
+	var manifest skills.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		log.Fatal(err)
+	}
+	if err := skills.ValidateSignedRelease(&manifest); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(manifest.Sequence)
+}

--- a/cli/cmd/releaseverify/main.go
+++ b/cli/cmd/releaseverify/main.go
@@ -1,0 +1,105 @@
+// releaseverify exercises the real sync path in a disposable directory.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"time"
+
+	"cli.eigenflux.ai/internal/skills"
+)
+
+func main() {
+	manifestPath := flag.String("manifest", "", "expected signed manifest")
+	cdn := flag.String("cdn", skills.CDNDefault, "published CDN base")
+	bundle := flag.String("bundle", "", "verify a staged bundle before upload")
+	flag.Parse()
+	if *bundle != "" {
+		mux := http.NewServeMux()
+		for _, prefix := range []string{"/skills/latest", "/cli/latest"} {
+			mux.Handle(prefix+"/", http.StripPrefix(prefix, http.FileServer(http.Dir(*bundle))))
+		}
+		server := httptest.NewServer(mux)
+		defer server.Close()
+		*cdn = server.URL
+	}
+	if err := verify(*manifestPath, *cdn); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func verify(manifestPath, cdn string) error {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	var expected skills.Manifest
+	if err := json.Unmarshal(data, &expected); err != nil {
+		return err
+	}
+	if err := skills.ValidateSignedRelease(&expected); err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	for _, prefix := range []string{"skills/latest", "cli/latest"} {
+		resp, err := client.Get(cdn + "/" + prefix + "/manifest.json")
+		if err != nil {
+			return err
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		resp.Body.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("%s: HTTP %d", prefix, resp.StatusCode)
+		}
+		var live skills.Manifest
+		if err := json.Unmarshal(body, &live); err != nil {
+			return err
+		}
+		if err := skills.ValidateSignedRelease(&live); err != nil {
+			return err
+		}
+		if live.Sequence != expected.Sequence || live.Signature != expected.Signature {
+			return fmt.Errorf("%s: CDN does not serve the expected signed release", prefix)
+		}
+	}
+	root, err := os.MkdirTemp("", "eigenflux-release-verify-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(root)
+	opts := skills.SyncOptions{Into: filepath.Join(root, "skills"), CLIVersion: expected.CLIVersion, CDNBase: cdn, HTTPClient: client}
+	result, err := skills.Sync(opts)
+	if err != nil {
+		return err
+	}
+	if !result.VerifiedManifest || !result.Atomic || result.Source != "skills/latest" || len(result.Preserved) != 0 {
+		return fmt.Errorf("atomic installation failed: %+v", result)
+	}
+	installed, err := skills.ReadLocalManifest(opts.Into)
+	if err != nil {
+		return err
+	}
+	if installed.Sequence != expected.Sequence || installed.Signature != expected.Signature {
+		return fmt.Errorf("installed release differs from expected manifest")
+	}
+	fmt.Printf("verified atomic CDN installation: sequence=%d revision=%s\n", installed.Sequence, installed.Revision)
+	result, err = skills.Sync(opts)
+	if err != nil {
+		return err
+	}
+	if !result.VerifiedManifest || result.Atomic || result.Source != "local" {
+		return fmt.Errorf("repeat sync is not a verified no-op: %+v", result)
+	}
+	fmt.Println("verified repeat sync: source=local verified_manifest=true atomic=false")
+	return nil
+}

--- a/cli/internal/skills/release.go
+++ b/cli/internal/skills/release.go
@@ -1,0 +1,21 @@
+package skills
+
+import "fmt"
+
+// ValidateSignedRelease uses the client trust root and also checks that the
+// content revision is derived from the signed skill hashes.
+func ValidateSignedRelease(m *Manifest) error {
+	if m == nil {
+		return fmt.Errorf("nil release manifest")
+	}
+	if err := validateRemoteManifest(m); err != nil {
+		return err
+	}
+	if err := verifyManifestSignature(m); err != nil {
+		return err
+	}
+	if m.Revision != computeRevision(m.Skills) {
+		return fmt.Errorf("release revision does not match skill hashes")
+	}
+	return nil
+}

--- a/cli/scripts/publish.sh
+++ b/cli/scripts/publish.sh
@@ -27,6 +27,13 @@ if [[ -z "$R2_ACCESS_KEY_ID" || -z "$R2_SECRET_ACCESS_KEY" ]]; then
   exit 1
 fi
 
+# Route the legacy emergency entry point through the serialized Skills publisher.
+# Unset the switch after dispatch so this invocation only uploads CLI binaries.
+if [[ "${EIGENFLUX_PUBLISH_SKILLS_WITH_CLI:-false}" == "true" ]]; then
+  bash "$SCRIPT_DIR/release-skills.sh"
+  EIGENFLUX_PUBLISH_SKILLS_WITH_CLI=false
+fi
+
 export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
 

--- a/cli/scripts/release-skills.sh
+++ b/cli/scripts/release-skills.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # ============================================================
 # release-skills.sh — ship a skills change WITHOUT a CLI release.
@@ -18,12 +18,21 @@ CLI_DIR="$(cd "$SCRIPT_DIR/.."; pwd)"
 PROJECT_ROOT="$(cd "$CLI_DIR/.."; pwd)"
 BUILD_DIR="$PROJECT_ROOT/build/cli"
 
+# Local/manual recovery uses the same serialized publisher as automatic releases.
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  exec gh workflow run release-skills.yml --repo phronesis-io/eigenflux --ref main
+fi
+if [[ "${GITHUB_WORKFLOW_REF:-}" != "phronesis-io/eigenflux/.github/workflows/release-skills.yml@refs/heads/main" ]]; then
+  echo "Skills publishing requires the Release Skills workflow on main" >&2
+  exit 1
+fi
+
 source "$CLI_DIR/.cli.config"
 [[ -f "$CLI_DIR/.cli.env" ]] && source "$CLI_DIR/.cli.env"
 
 GREEN='\033[0;32m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
 
-if [[ -z "$R2_ACCESS_KEY_ID" || -z "$R2_SECRET_ACCESS_KEY" ]]; then
+if [[ -z "${R2_ACCESS_KEY_ID:-}" || -z "${R2_SECRET_ACCESS_KEY:-}" ]]; then
   echo -e "${RED}R2 credentials missing in .cli.env${NC}"; exit 1
 fi
 if [[ -z "${EIGENFLUX_SKILLS_SIGNING_KEY_FILE:-}" || -z "${EIGENFLUX_SKILLS_VERIFY_PUBLIC_KEY:-}" ]]; then
@@ -45,6 +54,13 @@ DERIVED_SKILLS_PUBLIC_KEY=$(cd "$CLI_DIR" && "${GO_CMD[@]}" run ./cmd/manifestge
 SKILLS_SRC="$PROJECT_ROOT/skills"
 SKILLS_STAGE="$BUILD_DIR/skills-stage"
 mkdir -p "$BUILD_DIR"
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+( cd "$CLI_DIR" && "${GO_CMD[@]}" build \
+    -ldflags "-X cli.eigenflux.ai/internal/skills.VerifyPublicKeyBase64=${EIGENFLUX_SKILLS_VERIFY_PUBLIC_KEY}" \
+    -o "$BUILD_DIR/manifestcheck" ./cmd/manifestcheck )
+SKILLS_SEQUENCE=$(python3 "$SCRIPT_DIR/skills-release-state.py" prepare --build "$BUILD_DIR")
+echo "Allocated signed Skills sequence $SKILLS_SEQUENCE from R2 release history"
 
 # Discover every distributable official ef-* Skill from the source tree.
 SKILLS_ALLOWLIST=()
@@ -78,11 +94,17 @@ echo -e "${CYAN}Built skills bundle (${REVISION}); publishing to R2 skills/lates
 export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
 S3_ARGS="--endpoint-url $R2_ENDPOINT"
+# Exercise the exact signed archive through Sync before any publication write.
+( cd "$CLI_DIR" && "${GO_CMD[@]}" run \
+    -ldflags "-X cli.eigenflux.ai/internal/skills.VerifyPublicKeyBase64=${EIGENFLUX_SKILLS_VERIFY_PUBLIC_KEY}" \
+    ./cmd/releaseverify --manifest "$BUILD_DIR/manifest.json" --bundle "$BUILD_DIR" )
+python3 "$SCRIPT_DIR/skills-release-state.py" reserve --build "$BUILD_DIR"
 for f in skills.tar.gz skills.tar.gz.sha256 manifest.json; do
   aws s3 cp "$BUILD_DIR/$f" "s3://$R2_BUCKET/skills/latest/$f" $S3_ARGS --quiet
   aws s3 cp "$BUILD_DIR/$f" "s3://$R2_BUCKET/cli/latest/$f"    $S3_ARGS --quiet
   echo -e "${GREEN}  $f → skills/latest + cli/latest${NC}"
 done
+python3 "$SCRIPT_DIR/skills-release-state.py" verify --build "$BUILD_DIR"
 # Post-publish verification: fetch the tarball through the CDN with the SAME
 # cache-busting key clients will use (?rev=<revision>). This both pre-warms the
 # edge AFTER R2 is consistent and catches the race where an edge caches the OLD
@@ -94,7 +116,7 @@ CDN_BASE="${EIGENFLUX_CDN:-https://cdn.eigenflux.ai}"
 sleep 5
 VERIFY_OK=false
 for i in 1 2 3; do
-  GOT_SHA=$(curl -fsSL "$CDN_BASE/skills/latest/skills.tar.gz?rev=$REV_KEY" 2>/dev/null | shasum -a 256 | awk '{print $1}')
+  GOT_SHA=$(curl -fsSL "$CDN_BASE/skills/latest/skills.tar.gz?rev=$REV_KEY" 2>/dev/null | shasum -a 256 | awk '{print $1}' || true)
   if [[ -n "$WANT_SHA" && "$GOT_SHA" == "$WANT_SHA" ]]; then VERIFY_OK=true; break; fi
   echo -e "${CYAN}CDN not consistent yet (try $i): got ${GOT_SHA:0:16}, want ${WANT_SHA:0:16}; retrying in 10s...${NC}"
   sleep 10
@@ -108,4 +130,8 @@ if [[ "$VERIFY_OK" != "true" ]]; then
 fi
 echo -e "${GREEN}CDN verified: rev-keyed tarball matches (rev $REV_KEY).${NC}"
 
+# Check the actual client path through both CDN aliases, including atomic install.
+( cd "$CLI_DIR" && "${GO_CMD[@]}" run \
+    -ldflags "-X cli.eigenflux.ai/internal/skills.VerifyPublicKeyBase64=${EIGENFLUX_SKILLS_VERIFY_PUBLIC_KEY}" \
+    ./cmd/releaseverify --manifest "$BUILD_DIR/manifest.json" --cdn "$CDN_BASE" )
 echo -e "${GREEN}Done. Skills are live on R2 — clients pick them up on next sync. No CLI release.${NC}"

--- a/cli/scripts/skills-release-state.py
+++ b/cli/scripts/skills-release-state.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Allocate and reserve signed Skills releases against R2, never CDN cache."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+
+LATEST = ("skills/latest", "cli/latest")
+ARCHIVE = "skills/releases/"
+
+
+def aws(*args):
+    try:
+        result = subprocess.run(
+            ["aws", "--endpoint-url", os.environ["R2_ENDPOINT"], "--region", "auto", "s3api", *args,
+             "--bucket", os.environ["R2_BUCKET"], "--output", "json"],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(f"R2 {args[0]} failed: {error.stderr.strip()}") from error
+    return json.loads(result.stdout or "{}")
+
+
+def verified(path, checker):
+    subprocess.run([str(checker), str(path)], check=True, stdout=subprocess.DEVNULL)
+    return json.loads(path.read_text())
+
+
+def archive_head():
+    # AWS CLI pagination is enabled: failed/partial releases also consume a number.
+    listing = aws("list-objects-v2", "--prefix", ARCHIVE)
+    numbers = []
+    for item in listing.get("Contents", []):
+        match = re.fullmatch(r"skills/releases/([1-9][0-9]*)/manifest.json", item["Key"])
+        if match:
+            numbers.append(int(match.group(1)))
+    return max(numbers, default=0)
+
+
+def snapshot(state, checker):
+    records = []
+    for index, prefix in enumerate(LATEST):
+        path = state / f"previous-{index}.json"
+        aws("get-object", "--key", f"{prefix}/manifest.json", str(path))
+        records.append(verified(path, checker))
+    head = archive_head()
+    if head:
+        path = state / "archive-head.json"
+        aws("get-object", "--key", f"{ARCHIVE}{head}/manifest.json", str(path))
+        record = verified(path, checker)
+        if record["sequence"] != head:
+            raise RuntimeError("archive key and signed sequence disagree")
+        records.append(record)
+    return records
+
+
+def next_sequence(records):
+    highest = max(record["sequence"] for record in records)
+    if highest >= 2**64 - 1:
+        raise RuntimeError("Skills sequence exhausted")
+    return highest + 1
+
+
+def require_transition(candidate, records, planned):
+    if candidate["sequence"] != planned or planned <= max(r["sequence"] for r in records):
+        raise RuntimeError("release sequence is stale or already used; start a new workflow run")
+
+
+def put_new(path, key):
+    # R2 enforces uniqueness atomically. A collision fails before latest is touched.
+    aws("put-object", "--key", key, "--body", str(path), "--if-none-match", "*")
+
+
+def prepare(state, checker):
+    state.mkdir(parents=True, exist_ok=True)
+    records = snapshot(state, checker)
+    sequence = next_sequence(records)
+    (state / "plan.json").write_text(json.dumps({"sequence": sequence, "records": records}))
+    print(sequence)
+
+
+def reserve(state, checker, build):
+    plan = json.loads((state / "plan.json").read_text())
+    candidate = verified(build / "manifest.json", checker)
+    # Recheck the origin immediately before reserving a sequence and publishing.
+    current = snapshot(state, checker)
+    require_transition(candidate, current, plan["sequence"])
+    if current != plan["records"]:
+        raise RuntimeError("R2 release state changed during build; refusing to publish")
+    digest = hashlib.sha256((build / "skills.tar.gz").read_bytes()).hexdigest()
+    if digest != candidate["tar_sha256"] or digest != (build / "skills.tar.gz.sha256").read_text().strip():
+        raise RuntimeError("built archive does not match signed manifest and sidecar")
+    prefix = f'{ARCHIVE}{candidate["sequence"]}'
+    # Reserve first: interruption must never make the same signed sequence reusable.
+    put_new(build / "manifest.json", f"{prefix}/manifest.json")
+    for name in ("skills.tar.gz", "skills.tar.gz.sha256"):
+        put_new(build / name, f"{prefix}/{name}")
+    print(f'reserved signed sequence {candidate["sequence"]}', flush=True)
+
+
+def verify_live(state, checker, build):
+    expected = verified(build / "manifest.json", checker)
+    for index, prefix in enumerate(LATEST):
+        path = state / f"live-{index}.json"
+        aws("get-object", "--key", f"{prefix}/manifest.json", str(path))
+        if verified(path, checker) != expected:
+            raise RuntimeError(f"{prefix} differs from the reserved signed release")
+    print(f'verified origin sequence {expected["sequence"]}', flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("prepare", "reserve", "verify"))
+    parser.add_argument("--build", type=Path, required=True)
+    args = parser.parse_args()
+    state = args.build / "release-state"
+    checker = args.build / "manifestcheck"
+    if args.action == "prepare":
+        prepare(state, checker)
+    elif args.action == "reserve":
+        reserve(state, checker, args.build)
+    else:
+        verify_live(state, checker, args.build)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/tests/skills_release_test.go
+++ b/cli/tests/skills_release_test.go
@@ -1,0 +1,154 @@
+package tests
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cli.eigenflux.ai/internal/skills"
+)
+
+func signedRelease(t *testing.T, key ed25519.PrivateKey, sequence uint64, content string) (*skills.Manifest, []byte) {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "ef-profile"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ef-profile", "SKILL.md"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := skills.GenerateManifest(root, "0.0.42", "0.0.39", []string{"ef-profile"}, 1700000000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gz)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: "ef-profile/SKILL.md", Mode: 0600, Size: int64(len(content))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	manifest.TarSHA256 = hex.EncodeToString(sum[:])
+	manifest.Sequence = sequence
+	if err := skills.SignManifest(manifest, key); err != nil {
+		t.Fatal(err)
+	}
+	return manifest, buf.Bytes()
+}
+
+func TestSignedSequenceConflictAndAtomicRecovery(t *testing.T) {
+	publicKey, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousKey := skills.VerifyPublicKeyBase64
+	skills.VerifyPublicKeyBase64 = base64.StdEncoding.EncodeToString(publicKey)
+	t.Cleanup(func() { skills.VerifyPublicKeyBase64 = previousKey })
+	old, oldTar := signedRelease(t, key, 8, "old official content")
+	conflict, conflictTar := signedRelease(t, key, 8, "new official content")
+	recovered, recoveredTar := signedRelease(t, key, 9, "new official content")
+	serve := func(manifest *skills.Manifest, archive []byte) *httptest.Server {
+		data, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/skills/latest/manifest.json", "/cli/latest/manifest.json":
+				_, _ = w.Write(data)
+			case "/skills/latest/skills.tar.gz", "/cli/latest/skills.tar.gz":
+				_, _ = w.Write(archive)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+	oldServer := serve(old, oldTar)
+	conflictServer := serve(conflict, conflictTar)
+	recoveryServer := serve(recovered, recoveredTar)
+	target := filepath.Join(t.TempDir(), "skills")
+	opts := skills.SyncOptions{Into: target, CLIVersion: "0.0.42", CDNBase: oldServer.URL}
+	if _, err := skills.Sync(opts); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(target, "user-skill"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	userFile := filepath.Join(target, "user-skill", "SKILL.md")
+	if err := os.WriteFile(userFile, []byte("user content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	opts.CDNBase = conflictServer.URL
+	result, err := skills.Sync(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != "local" || result.Atomic || result.VerifiedManifest {
+		t.Fatalf("conflict accepted: %+v", result)
+	}
+	got, err := os.ReadFile(filepath.Join(target, "ef-profile", "SKILL.md"))
+	if err != nil || string(got) != "old official content" {
+		t.Fatalf("conflict changed local content: %q %v", got, err)
+	}
+	opts.CDNBase = recoveryServer.URL
+	result, err = skills.Sync(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != "skills/latest" || !result.Atomic || !result.VerifiedManifest || len(result.Preserved) != 0 {
+		t.Fatalf("recovery failed: %+v", result)
+	}
+	got, err = os.ReadFile(filepath.Join(target, "ef-profile", "SKILL.md"))
+	if err != nil || string(got) != "new official content" {
+		t.Fatalf("recovery content: %q %v", got, err)
+	}
+	got, err = os.ReadFile(userFile)
+	if err != nil || string(got) != "user content" {
+		t.Fatalf("user skill changed: %q %v", got, err)
+	}
+	installed, err := skills.ReadLocalManifest(target)
+	if err != nil || installed.Sequence != 9 {
+		t.Fatalf("sequence not persisted: %+v %v", installed, err)
+	}
+	// Once 9 is accepted, even a valid old signature cannot roll it back.
+	opts.CDNBase = oldServer.URL
+	result, err = skills.Sync(opts)
+	if err != nil || result.Source != "local" || result.Atomic {
+		t.Fatalf("rollback accepted: %+v %v", result, err)
+	}
+	if err := skills.ValidateSignedRelease(recovered); err != nil {
+		t.Fatal(err)
+	}
+	recovered.Revision = "0000000000000000"
+	if err := skills.ValidateSignedRelease(recovered); err == nil {
+		t.Fatal("tampering accepted")
+	}
+	if err := skills.SignManifest(recovered, key); err != nil {
+		t.Fatal(err)
+	}
+	if err := skills.ValidateSignedRelease(recovered); err == nil {
+		t.Fatal("signed inconsistent revision accepted")
+	}
+}

--- a/docs/dev/skills_releases.md
+++ b/docs/dev/skills_releases.md
@@ -1,0 +1,50 @@
+# Signed Skills releases
+
+Official Skills are published from `main` by `.github/workflows/release-skills.yml`.
+Automatic pushes and manual dispatches share the `release-skills` concurrency group.
+`bash cli/scripts/release-skills.sh` outside Actions dispatches that workflow on
+`main`; it requires GitHub workflow permission and does not load local R2 keys.
+The legacy `EIGENFLUX_PUBLISH_SKILLS_WITH_CLI=true` switch dispatches the same
+workflow, while CLI binary publication remains independent.
+
+## Sequence ownership
+
+The release script reads and verifies both R2 latest manifests and the highest
+archived signed manifest using the client's Ed25519 trust root. It allocates one
+more than the highest accepted sequence. Read, listing, and signature failures
+stop publication. `cli/.cli.config`'s `SKILLS_SEQUENCE` is only for local build
+artifacts and does not select a production release number.
+
+Before writing latest, the publisher rechecks R2, verifies the signed archive
+through a disposable `skills sync`, and reserves
+`skills/releases/<sequence>/manifest.json` with `If-None-Match: *`. The archive
+and sidecar are also written conditionally under that prefix. Existing release
+objects cannot be overwritten by this publisher. Incomplete releases consume
+their sequence; the next workflow invocation allocates a larger number. A
+workflow rerun is a new release, rather than a rebuild under the old sequence.
+Do not delete archived manifests, which retain the release high-water mark.
+
+After the reservation, the publisher uploads archives before manifests to
+`skills/latest/` and `cli/latest/`. It verifies both origin manifests and both
+CDN manifests, performs a real atomic installation in a disposable directory,
+and checks that a repeated sync is a verified no-op. The CDN tarball check uses
+the same revision query as clients. No agent credentials or active Skills
+folders are involved in this verification.
+
+## Recovery and acceptance
+
+Different contents were previously published with sequence 8. A newly allocated
+sequence greater than 8 permits affected clients to accept the current bundle
+without deleting local metadata or weakening rollback protection. The regression
+test `cli/tests/skills_release_test.go` covers rejecting conflicting signed
+sequence 8, atomically accepting sequence 9, preserving unrelated Skills, and
+rejecting a later rollback to 8.
+
+For changed content, a successful sync returns `source=skills/latest`,
+`verified_manifest=true`, and `atomic=true`. If content is already current,
+`source=local` and `atomic=false` are expected; the higher signed sequence is
+still persisted and `verified_manifest` remains true.
+
+Production releases require the existing R2 and signing secrets plus Python 3,
+Go, GNU tar, and an AWS CLI supporting S3 conditional PutObject. Publishing
+through any other workflow is rejected before credentials are loaded.

--- a/tests/cli_release/test_release_state.py
+++ b/tests/cli_release/test_release_state.py
@@ -1,0 +1,118 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("release_state", ROOT / "cli/scripts/skills-release-state.py")
+release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release)
+
+
+class SequenceTests(unittest.TestCase):
+    def test_conflicting_legacy_eight_recovers_at_nine(self):
+        records = [{"sequence": 8, "revision": "old"}, {"sequence": 8, "revision": "new"}]
+        self.assertEqual(release.next_sequence(records), 9)
+        release.require_transition({"sequence": 9}, records, 9)
+        for candidate in (7, 8, 10):
+            with self.assertRaises(RuntimeError):
+                release.require_transition({"sequence": candidate}, records, 9)
+
+    def test_partial_release_consumes_reserved_number(self):
+        records = [{"sequence": 8}, {"sequence": 8}, {"sequence": 9}]
+        self.assertEqual(release.next_sequence(records), 10)
+        with self.assertRaises(RuntimeError):
+            release.require_transition({"sequence": 9}, records, 9)
+
+    def test_sequence_overflow_fails_closed(self):
+        with self.assertRaises(RuntimeError):
+            release.next_sequence([{"sequence": 2**64 - 1}])
+
+    def test_archive_uses_numeric_max_and_only_manifest_keys(self):
+        objects = {"Contents": [{"Key": key} for key in (
+            "skills/releases/9/manifest.json", "skills/releases/10/manifest.json",
+            "skills/releases/999/skills.tar.gz", "skills/releases/bogus/manifest.json") ]}
+        with patch.object(release, "aws", return_value=objects):
+            self.assertEqual(release.archive_head(), 10)
+
+    def test_snapshot_fails_on_invalid_signature_or_network_error(self):
+        with tempfile.TemporaryDirectory() as temp:
+            for failure in (RuntimeError("bad signature"), subprocess.CalledProcessError(1, "aws")):
+                with patch.object(release, "aws"), patch.object(release, "verified", side_effect=failure):
+                    with self.assertRaises(type(failure)):
+                        release.snapshot(Path(temp), Path("checker"))
+
+    def test_archive_sequence_must_match_signed_record(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with patch.object(release, "aws"), patch.object(release, "archive_head", return_value=10), patch.object(release, "verified", return_value={"sequence": 8}):
+                with self.assertRaisesRegex(RuntimeError, "disagree"):
+                    release.snapshot(Path(temp), Path("checker"))
+
+    def test_reservation_collision_stops_before_archive_upload(self):
+        with tempfile.TemporaryDirectory() as temp:
+            build = Path(temp)
+            state = build / "release-state"
+            state.mkdir()
+            records = [{"sequence": 8}]
+            (state / "plan.json").write_text(json.dumps({"sequence": 9, "records": records}))
+            (build / "skills.tar.gz").write_bytes(b"archive")
+            digest = release.hashlib.sha256(b"archive").hexdigest()
+            (build / "skills.tar.gz.sha256").write_text(digest)
+            candidate = {"sequence": 9, "tar_sha256": digest}
+            with patch.object(release, "verified", return_value=candidate), patch.object(release, "snapshot", return_value=records), patch.object(release, "aws", side_effect=subprocess.CalledProcessError(1, "aws")) as aws:
+                with self.assertRaises(subprocess.CalledProcessError):
+                    release.reserve(state, build / "checker", build)
+                self.assertEqual(aws.call_count, 1)
+                args = aws.call_args.args
+                self.assertIn("skills/releases/9/manifest.json", args)
+                self.assertEqual(args[-2:], ("--if-none-match", "*"))
+
+    def test_changed_origin_prevents_reservation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            state = Path(temp)
+            (state / "plan.json").write_text(json.dumps({"sequence": 9, "records": [{"sequence": 8, "revision": "old"}]}))
+            with patch.object(release, "verified", return_value={"sequence": 9}), patch.object(release, "snapshot", return_value=[{"sequence": 8, "revision": "changed"}]), patch.object(release, "aws") as aws:
+                with self.assertRaisesRegex(RuntimeError, "changed"):
+                    release.reserve(state, state / "checker", state)
+                aws.assert_not_called()
+
+    def test_successful_reservation_archives_manifest_before_payload(self):
+        with tempfile.TemporaryDirectory() as temp:
+            build = Path(temp)
+            records = [{"sequence": 8}]
+            (build / "plan.json").write_text(json.dumps({"sequence": 9, "records": records}))
+            (build / "skills.tar.gz").write_bytes(b"archive")
+            digest = release.hashlib.sha256(b"archive").hexdigest()
+            (build / "skills.tar.gz.sha256").write_text(digest)
+            with patch.object(release, "verified", return_value={"sequence": 9, "tar_sha256": digest}), patch.object(release, "snapshot", return_value=records), patch.object(release, "put_new") as put:
+                release.reserve(build, build / "checker", build)
+                self.assertEqual([call.args[1] for call in put.call_args_list], [
+                    "skills/releases/9/manifest.json", "skills/releases/9/skills.tar.gz",
+                    "skills/releases/9/skills.tar.gz.sha256"])
+
+    def test_live_verification_rejects_mismatched_alias(self):
+        with tempfile.TemporaryDirectory() as temp:
+            state = Path(temp)
+            with patch.object(release, "aws"), patch.object(release, "verified", side_effect=[{"sequence": 9}, {"sequence": 9}, {"sequence": 8}]):
+                with self.assertRaisesRegex(RuntimeError, "differs"):
+                    release.verify_live(state, state / "checker", state)
+
+    def test_manual_release_dispatches_main_without_loading_credentials(self):
+        with tempfile.TemporaryDirectory() as temp:
+            fake_gh = Path(temp) / "gh"
+            fake_gh.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+            fake_gh.chmod(0o700)
+            result = subprocess.run(["/bin/bash", str(ROOT / "cli/scripts/release-skills.sh")], env={"PATH": temp + ":/usr/bin:/bin"}, check=True, capture_output=True, text=True)
+            self.assertEqual(result.stdout.splitlines(), ["workflow", "run", "release-skills.yml", "--repo", "phronesis-io/eigenflux", "--ref", "main"])
+
+    def test_other_workflow_cannot_publish(self):
+        result = subprocess.run(["/bin/bash", str(ROOT / "cli/scripts/release-skills.sh")], env={"PATH": "/usr/bin:/bin", "GITHUB_ACTIONS": "true", "GITHUB_WORKFLOW_REF": "other"}, capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires the Release Skills workflow", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Skills releases reused signed sequence 8 for different content, so clients retaining the older bundle correctly refused updates. Allocate each release from verified R2 latest manifests and the highest archived release, reserve signed manifests with conditional writes, and route manual and legacy emergency releases through the serialized main workflow. Interrupted releases retain their sequence reservation.

Validate the signed archive through real Skills Sync before publishing; verify both R2/CDN aliases, atomic installation, and a verified repeat sync after publishing. The merge triggers a new signed release to recover affected clients without changing CLI runtime behavior or removing their local trust state.

Validation: CLI `go test ./...` and CLI build passed; 12 Python release-state/entry-point tests passed; shell syntax and diff checks passed. The signed regression covers conflicting sequence 8 rejection, sequence 9 atomic recovery, third-party Skill preservation, and rollback rejection. The release verifier also passed against the current production sequence 8 using the installed official CLI's public trust key.
