### PR TITLE
fix(relations): restore official contacts first across pagination

### DIFF
--- a/api/consolev2/communication_handlers.go
+++ b/api/consolev2/communication_handlers.go
@@ -712,9 +712,14 @@ func (s *Service) listCommunicationFriends(_ context.Context, c *app.RequestCont
 		return
 	}
 	var friends []communicationFriend
-	if err := s.db.Raw(`SELECT id, to_uid, remark, created_at FROM user_relations
-		WHERE from_uid = ? AND rel_type = 1 AND (? = 0 OR id < ?)
-		ORDER BY id DESC LIMIT ?`, viewerID, cursor, cursor, limit+1).Scan(&friends).Error; err != nil {
+	if err := s.db.Raw(`SELECT r.id, r.to_uid, r.remark, r.created_at FROM user_relations r
+		JOIN agents a ON a.agent_id = r.to_uid
+		LEFT JOIN user_relations anchor ON anchor.id = ? AND anchor.from_uid = ?
+		LEFT JOIN agents anchor_agent ON anchor_agent.agent_id = anchor.to_uid
+		WHERE r.from_uid = ? AND r.rel_type = 1
+		  AND (? = 0 OR a.is_official < COALESCE(anchor_agent.is_official, false)
+		    OR (a.is_official = COALESCE(anchor_agent.is_official, false) AND r.id < ?))
+		ORDER BY a.is_official DESC, r.id DESC LIMIT ?`, cursor, viewerID, viewerID, cursor, cursor, limit+1).Scan(&friends).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "FRIENDS_READ_FAILED", "could not read friends", nil)
 		return
 	}

--- a/api/consolev2/home_handlers_postgres_test.go
+++ b/api/consolev2/home_handlers_postgres_test.go
@@ -81,6 +81,7 @@ func TestHomeHTTPContracts(t *testing.T) {
 	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
 	t.Cleanup(func() { _ = redisClient.Close() })
 	svc, err := NewService(db, &fixedIDGenerator{id: agentIDValue + 100}, &config.Config{
+		EnableCommunicationV2:    true,
 		ConsoleV2BootstrapSecret: "home-contract-secret",
 		ConsoleV2OTPPepper:       "home-contract-pepper",
 		ConsoleV2PublicURL:       "https://console.example.test",
@@ -190,6 +191,9 @@ func TestHomeHTTPContracts(t *testing.T) {
 		_ = db.Exec(`DELETE FROM raw_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
 	})
 
+	t.Run("official contacts remain first across pages", func(t *testing.T) {
+		testOfficialContactsPagination(t, db, svc, h, cookie, agentIDValue, demandAgentID, publishAgentID, now)
+	})
 	t.Run("country sources agree across Console", func(t *testing.T) {
 		testConsoleCountrySources(t, db, svc, h, cookie, agentIDValue, demandAgentID, publishAgentID, firstVoiceItemID, newPublishItemID, now)
 	})
@@ -465,5 +469,62 @@ func testConsoleCountrySources(t *testing.T, db *gorm.DB, svc *Service, h *serve
 	}
 	if blocked[strconv.FormatInt(peerID, 10)].CountryCode != "" {
 		t.Fatalf("blocked peer exposes country: %#v", blocked)
+	}
+}
+
+func testOfficialContactsPagination(t *testing.T, db *gorm.DB, svc *Service, h *server.Hertz, cookie ut.Header, viewerID, officialID, normalID, now int64) {
+	t.Helper()
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	originalDB := svc.db
+	svc.db = tx
+	defer func() { svc.db = originalDB; tx.Rollback() }()
+	if err := tx.Exec(`UPDATE agents SET is_official=true WHERE agent_id=?`, officialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	// The official assistant is the older contact. A descending relation-ID
+	// cursor alone would miss the newer ordinary contact after page one.
+	if err := tx.Exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, created_at) VALUES (?, ?, 1, ?), (?, ?, 1, ?)`, viewerID, officialID, now-1000, viewerID, normalID, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Without official contacts, the existing newest-relation-first order stays.
+	if err := tx.Exec(`UPDATE agents SET is_official=false WHERE agent_id=?`, officialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	status, payload, _ := performJSON(t, h, http.MethodGet, "/api/v2/console/relations/friends?limit=2", nil, cookie)
+	if status != http.StatusOK {
+		t.Fatalf("ordinary friends status=%d payload=%#v", status, payload)
+	}
+	ordinary := payload["data"].(map[string]interface{})["friends"].([]interface{})
+	if len(ordinary) != 2 || ordinary[0].(map[string]interface{})["peer_agent_id"] != strconv.FormatInt(normalID, 10) {
+		t.Fatalf("ordinary contacts reordered: %#v", ordinary)
+	}
+	if err := tx.Exec(`UPDATE agents SET is_official=true WHERE agent_id=?`, officialID).Error; err != nil {
+		t.Fatal(err)
+	}
+	cursor := ""
+	for index, wantID := range []int64{officialID, normalID} {
+		path := "/api/v2/console/relations/friends?limit=1"
+		if cursor != "" {
+			path += "&cursor=" + cursor
+		}
+		status, payload, _ := performJSON(t, h, http.MethodGet, path, nil, cookie)
+		if status != http.StatusOK {
+			t.Fatalf("friends status=%d payload=%#v", status, payload)
+		}
+		data := payload["data"].(map[string]interface{})
+		rows := data["friends"].([]interface{})
+		if len(rows) != 1 || rows[0].(map[string]interface{})["peer_agent_id"] != strconv.FormatInt(wantID, 10) {
+			t.Fatalf("page %d friends=%#v, want %d", index, rows, wantID)
+		}
+		if data["total"] != float64(2) || data["has_more"] != (index == 0) {
+			t.Fatalf("page %d metadata=%#v", index, data)
+		}
+		cursor, _ = data["next_cursor"].(string)
+		if (cursor != "") != (index == 0) {
+			t.Fatalf("page %d cursor=%q", index, cursor)
+		}
 	}
 }

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -275,3 +275,12 @@ Omitting runtime identity or model from a report means "no new observation"
 and does not clear the last known value. A later report with known facts
 replaces it; clients must never copy an old value merely to make a report look
 complete.
+
+
+## Console Contacts Ordering
+
+`GET /api/v2/console/relations/friends` returns server-verified official contacts
+first, followed by ordinary contacts. Each group retains descending relationship
+ID order. Numeric cursors resolve the anchor contact's official status so paging
+from an older official contact still includes newer ordinary contacts. Names and
+interface language do not influence official status or ordering.


### PR DESCRIPTION
Restore verified official contacts to the beginning of Relations → Contacts. The V2 friends endpoint now sorts official accounts first and preserves descending relationship-ID order within each group.

Pagination resolves the cursor contact's official status so an old official contact on page one does not cause newer ordinary contacts to disappear on later pages. Identification uses the server's official flag, independent of display name or language.

Validation: API build passed. HTTP/PostgreSQL integration tests passed against an isolated database with all 100 migrations, including official-first pagination, no skipped ordinary contacts, unchanged ordinary ordering, and response metadata. Existing Home HTTP contract checks also passed.
