### PR TITLE
fix(console): enforce homepage eligibility in activity

### DIFF
--- a/api/consolev2/home_activity_handlers.go
+++ b/api/consolev2/home_activity_handlers.go
@@ -138,6 +138,7 @@ func (s *Service) loadHomeActivity(ctx context.Context, now int64) (homeActivity
 		       '' AS counterpart_country, r.item_id AS broadcast_id,
 		       LEFT(r.raw_content, 4001) AS broadcast_content, false AS is_private
 		FROM raw_items r JOIN processed_items p ON p.item_id=r.item_id AND p.status=3
+		  AND p.homepage_eligible=TRUE AND p.homepage_evaluation_version=?
 		JOIN agents a ON a.agent_id=r.author_agent_id LEFT JOIN agent_cards ap ON ap.agent_id=a.agent_id
 		WHERE r.created_at >= (SELECT cutoff FROM bounds) AND a.short_id IS NOT NULL
 		  AND COALESCE(a.email,'') NOT LIKE '%@pgc.eigenflux.one' AND COALESCE(a.email,'') NOT LIKE '%@bot.eigenflux.one'
@@ -164,6 +165,7 @@ func (s *Service) loadHomeActivity(ctx context.Context, now int64) (homeActivity
 		       COALESCE(sp.private_card->>'geo',''), '', '', '', r.item_id, LEFT(r.raw_content,4001), false
 		FROM private_messages pm JOIN conversations c ON c.conv_id=pm.conv_id AND c.origin_type='broadcast'
 		JOIN raw_items r ON r.item_id=c.origin_id JOIN processed_items p ON p.item_id=r.item_id AND p.status=3
+		  AND p.homepage_eligible=TRUE AND p.homepage_evaluation_version=?
 		JOIN agents sender ON sender.agent_id=pm.sender_id LEFT JOIN agent_cards sp ON sp.agent_id=sender.agent_id
 		WHERE pm.created_at >= (SELECT cutoff FROM bounds) AND sender.short_id IS NOT NULL
 		UNION ALL
@@ -174,7 +176,8 @@ func (s *Service) loadHomeActivity(ctx context.Context, now int64) (homeActivity
 		WHERE command.created_at >= (SELECT cutoff FROM bounds) AND command.command_type='task_delegation'
 	)
 	SELECT * FROM events ORDER BY created_at DESC, event_id DESC LIMIT ?`
-	if err := s.db.WithContext(ctx).Raw(query, homeActivityWindowStart(now), homeActivityLimit).Scan(&rows).Error; err != nil {
+	if err := s.db.WithContext(ctx).Raw(query, homeActivityWindowStart(now), homepageEvaluationVersion,
+		homepageEvaluationVersion, homeActivityLimit).Scan(&rows).Error; err != nil {
 		return homeActivityResponse{}, err
 	}
 	events := make([]homeActivityEvent, 0, len(rows))

--- a/api/consolev2/home_handlers_postgres_test.go
+++ b/api/consolev2/home_handlers_postgres_test.go
@@ -154,13 +154,16 @@ func TestHomeHTTPContracts(t *testing.T) {
 	oldDemandItemID := agentIDValue + 11
 	newDemandItemID := agentIDValue + 12
 	newPublishItemID := agentIDValue + 13
+	ineligibleItemID := agentIDValue + 14
 	if err := db.Exec(`INSERT INTO raw_items (item_id, author_agent_id, raw_content, created_at) VALUES
 		(?, ?, 'new Agent first voice', ?), (?, ?, 'older demand', ?),
-		(?, ?, 'newer demand', ?), (?, ?, 'newest general publish', ?)`,
+		(?, ?, 'newer demand', ?), (?, ?, 'newest general publish', ?),
+		(?, ?, 'homepage-ineligible content', ?)`,
 		firstVoiceItemID, agentIDValue, now-4000,
 		oldDemandItemID, demandAgentID, now-3000,
 		newDemandItemID, demandAgentID, now-2000,
-		newPublishItemID, publishAgentID, now-1000).Error; err != nil {
+		newPublishItemID, publishAgentID, now-1000,
+		ineligibleItemID, agentIDValue, now-500).Error; err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Exec(`INSERT INTO processed_items
@@ -169,11 +172,13 @@ func TestHomeHTTPContracts(t *testing.T) {
 		VALUES (?, 3, 'new Agent first voice', 'info', 0.70, 'en', ?, TRUE, ?, FALSE),
 		       (?, 3, 'older demand', 'demand', 0.95, 'en', ?, TRUE, ?, FALSE),
 		       (?, 3, 'newer demand', 'demand', 0.80, 'en', ?, TRUE, ?, FALSE),
-		       (?, 3, 'newest general publish', 'info', 0.99, 'en', ?, TRUE, ?, FALSE)`,
+		       (?, 3, 'newest general publish', 'info', 0.99, 'en', ?, TRUE, ?, FALSE),
+		       (?, 3, 'homepage-ineligible content', 'info', 0.99, 'en', ?, FALSE, ?, FALSE)`,
 		firstVoiceItemID, now, homepageEvaluationVersion,
 		oldDemandItemID, now, homepageEvaluationVersion,
 		newDemandItemID, now, homepageEvaluationVersion,
-		newPublishItemID, now, homepageEvaluationVersion).Error; err != nil {
+		newPublishItemID, now, homepageEvaluationVersion,
+		ineligibleItemID, now, homepageEvaluationVersion).Error; err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Exec(`INSERT INTO item_stats
@@ -187,8 +192,8 @@ func TestHomeHTTPContracts(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_ = db.Exec(`DELETE FROM processed_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
-		_ = db.Exec(`DELETE FROM raw_items WHERE item_id IN (?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID).Error
+		_ = db.Exec(`DELETE FROM processed_items WHERE item_id IN (?, ?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID, ineligibleItemID).Error
+		_ = db.Exec(`DELETE FROM raw_items WHERE item_id IN (?, ?, ?, ?, ?)`, firstVoiceItemID, oldDemandItemID, newDemandItemID, newPublishItemID, ineligibleItemID).Error
 	})
 
 	t.Run("official contacts remain first across pages", func(t *testing.T) {
@@ -270,6 +275,9 @@ func TestHomeHTTPContracts(t *testing.T) {
 					"new_agent_first_voice":  strconv.FormatInt(firstVoiceItemID, 10),
 				})
 			}
+			if path == "/api/v2/console/home/activity" {
+				assertHomeActivityExcludesBroadcast(t, rows, ineligibleItemID)
+			}
 		}
 		for _, key := range []string{discoveryKey, homeActivityCacheKey, worthKey} {
 			raw, err := redisClient.Get(context.Background(), key).Bytes()
@@ -297,6 +305,17 @@ func TestHomeHTTPContracts(t *testing.T) {
 			}
 		}
 	})
+}
+
+func assertHomeActivityExcludesBroadcast(t *testing.T, rows []interface{}, itemID int64) {
+	t.Helper()
+	wantID := "broadcast:" + strconv.FormatInt(itemID, 10)
+	for _, raw := range rows {
+		row, ok := raw.(map[string]interface{})
+		if ok && row["id"] == wantID {
+			t.Fatalf("homepage-ineligible broadcast appeared in home activity: %#v", row)
+		}
+	}
 }
 
 func assertHomeWorthWatchingReasons(t *testing.T, rows []interface{}, want map[string]string) {


### PR DESCRIPTION
## Summary
- require current homepage eligibility for broadcasts shown in Home Activity
- apply the same gate when replies surface their originating broadcast
- add a PostgreSQL contract regression for homepage-ineligible content

## Risk
Without this gate, processed ads, sexual content, spam, or other homepage-ineligible broadcasts could still expose up to 4000 characters on the Console homepage through publish or reply activity events.

## Verification
- `go test ./api/consolev2`
- `git diff --check`