### PR TITLE
Fix stale backend regression tests and test execution gaps

### DIFF
--- a/.github/workflows/postgres-contracts.yml
+++ b/.github/workflows/postgres-contracts.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - 'api/consolev2/**'
       - 'api/install/**'
+      - 'contracts/**'
       - 'migrations/**'
       - 'pipeline/cron/**'
       - 'pipeline/llm/**'
       - 'pkg/consolev2retention/**'
       - 'pkg/agentidentity/**'
+      - 'pkg/agentcard/**'
       - 'scripts/common/**'
       - '.github/workflows/postgres-contracts.yml'
   push:
@@ -17,11 +19,13 @@ on:
     paths:
       - 'api/consolev2/**'
       - 'api/install/**'
+      - 'contracts/**'
       - 'migrations/**'
       - 'pipeline/cron/**'
       - 'pipeline/llm/**'
       - 'pkg/consolev2retention/**'
       - 'pkg/agentidentity/**'
+      - 'pkg/agentcard/**'
       - 'scripts/common/**'
       - '.github/workflows/postgres-contracts.yml'
   workflow_dispatch:
@@ -63,7 +67,9 @@ jobs:
       - name: Verify short-ID install attribution
         run: go test -count=1 ./api/install -run '^TestPostgresShortIDInviteAttribution$'
       - name: Verify Console V2 PostgreSQL flow and races
-        run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*|AttentionContractGolden)'
+        run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*)'
+      - name: Verify Attention schema and golden corpus
+        run: go test -count=1 ./api/consolev2 -run '^(TestAttentionGoldenCorpusMatchesServerValidators|TestAttentionSchemaEnumsMatchServer)$'
       - name: Verify Console homepage HTTP and data contracts
         run: go test -count=1 ./api/consolev2 -run '^TestHome'
       - name: Verify homepage eligibility backfill and LLM contracts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Agent-oriented information distribution platform, built with Go and CloudWeGo mi
 - Default connection config in `pkg/config/config.go`, override via environment variables
 - Build: `bash scripts/common/build.sh` (core), `./console/console_api/scripts/build.sh` (console)
 - Start: `./scripts/local/start_local.sh` (core), `./console/console_api/scripts/start.sh` (console)
-- All tests: `go test -v ./tests/...` (requires all services running)
+- Root-module tests: `./tests/run.sh` (starts local services and runs `go test -v ./...`)
+- CLI, Console API, and Console Web tests have separate commands in `docs/dev/testing.md`.
 
 ## Directory Responsibilities
 
@@ -69,7 +70,7 @@ Read the relevant module doc before modifying that area:
 
 After each code change, add or modify test cases. Run build and e2e tests to ensure functionality works.
 
-- Test case code goes in `tests/`
+- Keep unit tests beside the package they exercise; service integration suites and their shared helpers live in `tests/`.
 - Don't add degradation logic just to make tests pass. Let humans handle errors that can't be handled
 - Build and tool scripts go in `scripts`
 - Build artifacts must go in `build/` directory, never in source directories. Always use `-o build/<name>` when running `go build` manually (e.g. `go build -o build/auth ./rpc/auth/`). Use `bash scripts/common/build.sh` for core services and `./console/console_api/scripts/build.sh` for console

--- a/cli/cmd/profile_refresh_test.go
+++ b/cli/cmd/profile_refresh_test.go
@@ -8,7 +8,7 @@ import (
 
 // The daily refresh must use the versioned field-level flow, never the legacy
 // whole-bio update that can overwrite unrelated human edits.
-func TestBuildRefreshPromptFivePartFormat(t *testing.T) {
+func TestBuildRefreshPromptUsesVersionedFieldLevelWorkflow(t *testing.T) {
 	prompt := buildRefreshPrompt(
 		"TestAgent",
 		"Domains: ai",

--- a/cli/cmd/settings_test.go
+++ b/cli/cmd/settings_test.go
@@ -130,8 +130,8 @@ type heartbeatCompatibilityReportForTest struct {
 	Revision string `json:"skill_revision"`
 }
 
-// TestSyncedSettingsBody_OtherKeysUnaffected confirms the intent guard is scoped
-// to feed_poll_interval and leaves the other synced keys behaving as before.
+// Generic settings sync excludes versioned security boundary fields while
+// retaining language and feed delivery preferences.
 func TestSyncedSettingsBodyExcludesVersionedSecurityBoundary(t *testing.T) {
 	cfg := &config.Config{KV: map[string]string{
 		"recurring_publish":        "true",

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -30,7 +30,7 @@ func TestSaveFeedResponse(t *testing.T) {
 	dir := t.TempDir()
 	dir = setHomeDir(t, dir)
 
-	rawData := json.RawMessage(`{"items":[{"id":"1","title":"test"}]}`)
+	rawData := json.RawMessage(`{"items":[{"item_id":"1","summary":"test"}]}`)
 	SaveFeedResponse("testserver", rawData)
 
 	today := time.Now().Format(dateFormat)

--- a/cli/internal/skills/skills_test.go
+++ b/cli/internal/skills/skills_test.go
@@ -337,7 +337,7 @@ func serveBundleAtSequence(t *testing.T, version, src string, names []string, se
 	return srv, m
 }
 
-func TestSyncIfStaleSkipsNetwork(t *testing.T) {
+func TestSyncIfStaleKeepsLocalWhenManifestUnavailable(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "skills")
 	src := stageSkills(t, map[string]map[string]string{"ef-broadcast": {"SKILL.md": "b"}})
 	names := []string{"ef-broadcast"}
@@ -345,15 +345,68 @@ func TestSyncIfStaleSkipsNetwork(t *testing.T) {
 	if _, err := Sync(syncOpts(dst, "0.0.16", srv.URL, names)); err != nil {
 		t.Fatal(err)
 	}
-	// Point at a dead server; --if-stale with matching version must not hit it.
-	o := syncOpts(dst, "0.0.16", "http://127.0.0.1:1", names)
+	manifestBefore, err := os.ReadFile(filepath.Join(dst, ManifestFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A failed manifest fetch must preserve the installed copy without failing
+	// a background freshness check.
+	srv.Close()
+	o := syncOpts(dst, "0.0.16", srv.URL, names)
 	o.IfStale = true
 	res, err := Sync(o)
 	if err != nil {
 		t.Fatalf("if-stale should be offline-safe: %v", err)
 	}
-	if res.Source != "local" {
-		t.Fatalf("expected local short-circuit, got %s", res.Source)
+	if res == nil || res.Source != "local" || !res.NoNetwork || res.VerifiedManifest {
+		t.Fatalf("expected local fallback after failed manifest fetch, got %+v", res)
+	}
+	content, err := os.ReadFile(filepath.Join(dst, "ef-broadcast", "SKILL.md"))
+	if err != nil || string(content) != "b" {
+		t.Fatalf("installed Skill changed during offline fallback: %q, %v", content, err)
+	}
+	manifestAfter, err := os.ReadFile(filepath.Join(dst, ManifestFileName))
+	if err != nil || !bytes.Equal(manifestBefore, manifestAfter) {
+		t.Fatalf("installed manifest changed during offline fallback: %s, %v", manifestAfter, err)
+	}
+}
+
+func TestSyncIfStaleFetchesManifestWithoutDownloadingUnchangedBundle(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "skills")
+	src := stageSkills(t, map[string]map[string]string{"ef-broadcast": {"SKILL.md": "b"}})
+	names := []string{"ef-broadcast"}
+	bundleServer, _ := serveBundle(t, "0.0.16", src, names)
+	var manifestRequests, tarballRequests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch filepath.Base(r.URL.Path) {
+		case RemoteManifest:
+			manifestRequests.Add(1)
+		case TarName:
+			tarballRequests.Add(1)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		bundleServer.Config.Handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	o := syncOpts(dst, "0.0.16", srv.URL, names)
+	if _, err := Sync(o); err != nil {
+		t.Fatal(err)
+	}
+	if manifests, tarballs := manifestRequests.Swap(0), tarballRequests.Swap(0); manifests != 1 || tarballs != 1 {
+		t.Fatalf("initial install requests: manifest=%d, tarball=%d; want 1 each", manifests, tarballs)
+	}
+
+	o.IfStale = true
+	res, err := Sync(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil || res.Source != "local" || !res.VerifiedManifest || res.NoNetwork {
+		t.Fatalf("expected verified, unchanged local bundle, got %+v", res)
+	}
+	if manifests, tarballs := manifestRequests.Load(), tarballRequests.Load(); manifests != 1 || tarballs != 0 {
+		t.Fatalf("freshness check requests: manifest=%d, tarball=%d; want 1 manifest and no tarball", manifests, tarballs)
 	}
 }
 

--- a/console/webapp/tests/useSessionState.test.ts
+++ b/console/webapp/tests/useSessionState.test.ts
@@ -20,7 +20,7 @@ class MemoryStorage {
 }
 
 describe("session page state", () => {
-  it("restores the third page with 100 rows after navigating away", () => {
+  it("stores and reads page number and page size independently", () => {
     const storage = new MemoryStorage();
 
     writeSessionValue(storage, "agents.page", 3);

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Test code organized by functional modules in `tests/` subdirectories, shared utility functions in `tests/testutil/` package.
+Tests live beside the packages they exercise and in the service integration suites under `tests/`. Shared integration helpers live in `tests/testutil/`. The CLI and Console API are independent Go modules; Console Web has its own Node test command.
 
 ## Test Directories
 
@@ -41,9 +41,19 @@ that is not `APP_ENV=test` with deterministic providers.
 ## Running Tests
 
 ```bash
-# Run all tests (requires all services running)
-./scripts/local/start_local.sh
-go test -v ./tests/...
+# Root module: start local services and run all root packages
+./tests/run.sh
+
+# Root module with an already-running local stack
+./tests/run.sh --skip-start
+
+# Run only the service integration suites
+./tests/run.sh --dir ./tests/... --skip-start
+
+# Independent modules (run from each module directory)
+(cd cli && go test ./...)
+(cd console/console_api && go test ./...)
+(cd console/webapp && npm test)
 
 # Unit tests
 go test -v ./pipeline/llm/           # LLM client
@@ -53,5 +63,7 @@ go test -v ./pkg/cache/              # Cache
 # Manual email integration
 python3 scripts/local/manual_register.py --email you@example.com
 ```
+
+The runner uses the root `.env` to supply missing exported test settings, including `PG_DSN` for PostgreSQL-specific suites. Explicit caller environment values, including empty values, take precedence. With an existing isolated stack, pass its settings and use `--skip-start`; startup scripts configure their stack from `.env`. The root `./...` pattern does not cross nested `go.mod` boundaries. A full repository check includes all three independent module commands above. Root packages include both local unit tests and environment-dependent tests; use a disposable local stack with explicit `PG_DSN`, Redis, Elasticsearch, and API settings. PostgreSQL-specific tests may skip when `PG_DSN` is absent; a skipped test is not a verified contract.
 
 Whitelist-matched emails automatically use `MOCK_UNIVERSAL_OTP`, other emails manually input OTP.

--- a/pipeline/consumer/official_welcome_e2e_test.go
+++ b/pipeline/consumer/official_welcome_e2e_test.go
@@ -2,12 +2,15 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"testing"
 	"time"
 
+	"eigenflux_server/kitex_gen/eigenflux/pm"
 	"eigenflux_server/kitex_gen/eigenflux/pm/pmservice"
 	"eigenflux_server/pipeline/llm"
 	"eigenflux_server/pipeline/official"
@@ -18,25 +21,83 @@ import (
 	pmdal "eigenflux_server/rpc/pm/dal"
 
 	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/pkg/kerrors"
 	etcd "github.com/kitex-contrib/registry-etcd"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
 // TestOfficialWelcomeE2E drives the welcome consumer's handle() against the live
 // PM service: it must friend the new agent and deliver exactly one welcome PM.
 // Requires the local stack (PM RPC + etcd + PG + Redis) and a provisioned
-// official account; it skips otherwise.
+// official account. Only missing prerequisites or an unreachable service skip
+// the test; failures after the welcome begins must fail it.
 func TestOfficialWelcomeE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires the local PM, PostgreSQL, and Redis integration stack")
+	}
 	cfg := config.Load()
-	db.InitWithLogLevel(cfg.PgDSN, logger.Silent)
-	mq.Init(cfg.RedisAddr, cfg.RedisPassword)
+	gdb, err := gorm.Open(postgres.Open(cfg.PgDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent), DisableAutomaticPing: true,
+	})
+	require.NoError(t, err)
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+	probeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := sqlDB.PingContext(probeCtx); err != nil {
+		if welcomePrerequisiteUnavailable(err) {
+			t.Skipf("local PostgreSQL is unreachable before welcome: %v", err)
+		}
+		t.Fatalf("PostgreSQL preflight: %v", err)
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: cfg.RedisAddr, Password: cfg.RedisPassword})
+	t.Cleanup(func() { require.NoError(t, rdb.Close()) })
+	if err := rdb.Ping(probeCtx).Err(); err != nil {
+		if welcomePrerequisiteUnavailable(err) {
+			t.Skipf("local Redis is unreachable before welcome: %v", err)
+		}
+		t.Fatalf("Redis preflight: %v", err)
+	}
+	previousDB, previousRedis := db.DB, mq.RDB
+	db.DB, mq.RDB = gdb, rdb
+	t.Cleanup(func() { db.DB, mq.RDB = previousDB, previousRedis })
 
 	var officialID int64
 	if err := db.DB.Raw(
 		"SELECT agent_id FROM agents WHERE email = ? AND is_official", cfg.OfficialAgentEmail,
-	).Scan(&officialID).Error; err != nil || officialID == 0 {
-		t.Skipf("official account not provisioned locally (err=%v)", err)
+	).Scan(&officialID).Error; err != nil {
+		t.Fatalf("look up official account: %v", err)
 	}
+	if officialID == 0 {
+		t.Skip("official account not provisioned locally")
+	}
+
+	// Probe the real RPC before creating friendship or sending anything. A
+	// reachable service returning a business error is a failure, not a skip.
+	var pmClient pmservice.Client
+	if addr := os.Getenv("PM_DIRECT_ADDR"); addr != "" {
+		pmClient, err = pmservice.NewClient("PMService", client.WithHostPorts(addr), client.WithRPCTimeout(5*time.Second))
+	} else {
+		resolver, rerr := etcd.NewEtcdResolver([]string{cfg.EtcdAddr})
+		require.NoError(t, rerr)
+		pmClient, err = pmservice.NewClient("PMService", rpcx.ClientOptions(resolver)...)
+	}
+	require.NoError(t, err)
+	pmProbeCtx, pmCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer pmCancel()
+	probe, err := pmClient.ListFriends(pmProbeCtx, &pm.ListFriendsReq{AgentId: officialID})
+	if welcomePrerequisiteUnavailable(err) {
+		t.Skipf("local PM service is unavailable before welcome: %v", err)
+	}
+	require.NoError(t, err, "PM preflight")
+	require.NotNil(t, probe)
+	require.NotNil(t, probe.BaseResp)
+	require.Zero(t, probe.BaseResp.Code, "PM preflight rejected: %s", probe.BaseResp.Msg)
 
 	const userID int64 = 9_100_000_000_000_000_077
 	now := time.Now().UnixMilli()
@@ -46,23 +107,37 @@ func TestOfficialWelcomeE2E(t *testing.T) {
 		lo, hi = hi, lo
 	}
 	cleanup := func() {
-		db.DB.Exec("DELETE FROM private_messages WHERE sender_id IN (?,?) AND receiver_id IN (?,?)", officialID, userID, officialID, userID)
-		db.DB.Exec("DELETE FROM conversations WHERE participant_a IN (?,?) AND participant_b IN (?,?)", officialID, userID, officialID, userID)
-		db.DB.Exec("DELETE FROM user_relations WHERE from_uid IN (?,?) OR to_uid IN (?,?)", officialID, userID, officialID, userID)
-		db.DB.Exec("DELETE FROM friend_requests WHERE from_uid IN (?,?) OR to_uid IN (?,?)", officialID, userID, officialID, userID)
-		db.DB.Exec("DELETE FROM agents WHERE agent_id = ?", userID)
+		for _, statement := range []struct {
+			sql  string
+			args []any
+		}{
+			{"DELETE FROM private_messages WHERE sender_id IN (?,?) AND receiver_id IN (?,?)", []any{officialID, userID, officialID, userID}},
+			{"DELETE FROM conversations WHERE participant_a IN (?,?) AND participant_b IN (?,?)", []any{officialID, userID, officialID, userID}},
+			{"DELETE FROM user_relations WHERE from_uid = ? OR to_uid = ?", []any{userID, userID}},
+			{"DELETE FROM friend_requests WHERE from_uid = ? OR to_uid = ?", []any{userID, userID}},
+			{"DELETE FROM agents WHERE agent_id = ?", []any{userID}},
+		} {
+			if err := db.DB.Exec(statement.sql, statement.args...).Error; err != nil {
+				t.Errorf("clean up welcome fixture: %v", err)
+			}
+		}
 		// Clear PM-service Redis caches so a re-run is not poisoned by a stale
 		// conversation mapping / friend set pointing at deleted rows.
-		mq.RDB.Del(context.Background(),
+		if err := mq.RDB.Del(context.Background(),
 			officialWelcomedKey(userID),
 			fmt.Sprintf("pm:convmap:%d:%d:0", lo, hi),
 			fmt.Sprintf("friend:%d", officialID),
 			fmt.Sprintf("friend:%d", userID),
 			fmt.Sprintf("pm:fetch:%d", userID),
-		)
+		).Err(); err != nil {
+			t.Errorf("clean up welcome Redis keys: %v", err)
+		}
 	}
 	cleanup()
 	t.Cleanup(cleanup)
+	if t.Failed() {
+		t.FailNow()
+	}
 
 	// A new, profile-complete agent.
 	if err := db.DB.Exec(
@@ -73,28 +148,9 @@ func TestOfficialWelcomeE2E(t *testing.T) {
 		t.Fatalf("insert test user: %v", err)
 	}
 
-	// Real PM client → running PM service. Prefer a direct host:port when set
-	// (local stacks register a LAN IP in etcd that may be unreachable from the
-	// test host); otherwise discover via etcd.
-	var pmClient pmservice.Client
-	var err error
-	if addr := os.Getenv("PM_DIRECT_ADDR"); addr != "" {
-		pmClient, err = pmservice.NewClient("PMService", client.WithHostPorts(addr))
-	} else {
-		resolver, rerr := etcd.NewEtcdResolver([]string{cfg.EtcdAddr})
-		if rerr != nil {
-			t.Fatalf("etcd resolver: %v", rerr)
-		}
-		pmClient, err = pmservice.NewClient("PMService", rpcx.ClientOptions(resolver)...)
-	}
-	if err != nil {
-		t.Fatalf("pm client: %v", err)
-	}
-
-	prompts, perr := llm.LoadDefaultPrompts()
-	if perr != nil {
-		t.Fatalf("load prompts: %v", perr)
-	}
+	// Exercise delivery with the supported static-message fallback. An empty
+	// registry fails rendering before any external LLM request is attempted.
+	prompts := &llm.PromptRegistry{}
 	sender := official.NewSender(cfg, pmClient, llm.NewClient(cfg, prompts), prompts)
 	c := &OfficialWelcomeConsumer{
 		sender:         sender,
@@ -103,6 +159,9 @@ func TestOfficialWelcomeE2E(t *testing.T) {
 	}
 
 	res := c.handle(context.Background(), "0-0", map[string]any{"agent_id": strconv.FormatInt(userID, 10)})
+	if res != HandleSuccess {
+		t.Fatalf("handle result = %v, want HandleSuccess", res)
+	}
 
 	// Friendship is created in PG before the PM hop, so it must always hold.
 	friend, ferr := pmdal.IsFriend(db.DB, officialID, userID)
@@ -113,24 +172,43 @@ func TestOfficialWelcomeE2E(t *testing.T) {
 		t.Fatal("expected official and user to be friends after welcome")
 	}
 
-	// Content is now prompt-generated (or the static fallback), so assert that a
-	// welcome PM was delivered rather than matching exact text.
 	var msgs int64
-	db.DB.Raw(
+	if err := db.DB.Raw(
 		"SELECT count(*) FROM private_messages WHERE sender_id = ? AND receiver_id = ?",
 		officialID, userID,
-	).Scan(&msgs)
-
-	// The PM hop needs the PM service reachable from this host. Local stacks may
-	// register a LAN IP in etcd that the test host cannot dial; skip delivery
-	// assertion in that case (set PM_DIRECT_ADDR to force a reachable address).
-	if res != HandleSuccess && msgs == 0 {
-		t.Skipf("PM service unreachable (result=%v); friendship verified, welcome delivery not asserted", res)
-	}
-	if res != HandleSuccess {
-		t.Fatalf("handle result = %v, want HandleSuccess", res)
+	).Scan(&msgs).Error; err != nil {
+		t.Fatalf("count welcome messages: %v", err)
 	}
 	if msgs != 1 {
 		t.Fatalf("welcome PM count = %d, want 1", msgs)
+	}
+}
+
+func welcomePrerequisiteUnavailable(err error) bool {
+	var dialErr *net.OpError
+	return (errors.As(err, &dialErr) && dialErr.Op == "dial") ||
+		errors.Is(err, kerrors.ErrGetConnection) ||
+		errors.Is(err, kerrors.ErrNoInstance) ||
+		errors.Is(err, kerrors.ErrNoMoreInstance)
+}
+
+func TestWelcomePrerequisiteUnavailable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"ready", nil, false},
+		{"dial_failure", fmt.Errorf("connect: %w", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}), true},
+		{"rpc_connection_failure", kerrors.ErrGetConnection, true},
+		{"rpc_no_instance", kerrors.ErrNoInstance, true},
+		{"rpc_no_more_instances", kerrors.ErrNoMoreInstance, true},
+		{"business_rejection", kerrors.ErrBiz.WithCause(errors.New("not friends")), false},
+		{"rpc_timeout", kerrors.ErrRPCTimeout, false},
+		{"database_query_failure", errors.New("missing relation private_messages"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, welcomePrerequisiteUnavailable(tc.err))
+		})
 	}
 }

--- a/pipeline/cron/agentcard_upsert_integration_test.go
+++ b/pipeline/cron/agentcard_upsert_integration_test.go
@@ -7,6 +7,8 @@ import (
 
 	"eigenflux_server/pkg/agentcard"
 	profiledal "eigenflux_server/rpc/profile/dal"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -252,11 +254,28 @@ func TestRollingDeploymentFenceTrigger(t *testing.T) {
 	if err := profiledal.UpsertAgentCardWithFence(tx, agentID, `{"v":2}`, `{}`, 1, 1, 1); err != nil {
 		t.Fatal(err)
 	}
-	if err := tx.Exec(`UPDATE agent_cards SET card_version=card_version+1,generated_at=3 WHERE agent_id=?`, agentID).Error; err == nil {
-		t.Fatal("post-fence legacy metadata write was accepted")
-	}
-	if err := tx.Exec(`UPDATE agent_cards SET public_card='{"legacy":true}',source_version=source_version+1,card_version=card_version+1,generated_at=4 WHERE agent_id=?`, agentID).Error; err == nil {
-		t.Fatal("post-fence legacy writer bypassed the fence with a newer source_version")
+	before, err := profiledal.GetAgentCard(tx, agentID)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{"metadata_only", `UPDATE agent_cards SET card_version=card_version+1,generated_at=3 WHERE agent_id=?`},
+		{"newer_source", `UPDATE agent_cards SET public_card='{"legacy":true}',source_version=source_version+1,card_version=card_version+1,generated_at=4 WHERE agent_id=?`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, tx.Exec("SAVEPOINT legacy_writer").Error)
+			err := tx.Exec(tc.sql, agentID).Error
+			// Recover the transaction before the next case, even if this assertion fails.
+			require.NoError(t, tx.Exec("ROLLBACK TO SAVEPOINT legacy_writer").Error)
+			require.NoError(t, tx.Exec("RELEASE SAVEPOINT legacy_writer").Error)
+			var pgErr *pgconn.PgError
+			require.ErrorAs(t, err, &pgErr, "legacy write must be rejected by the fence trigger")
+			require.Equal(t, "40001", pgErr.Code, "an aborted transaction (25P02) is not a fence rejection")
+			after, err := profiledal.GetAgentCard(tx, agentID)
+			require.NoError(t, err)
+			require.Equal(t, before, after, "rejected writer must leave the projection unchanged")
+		})
 	}
 }
 

--- a/rpc/item/delete_test.go
+++ b/rpc/item/delete_test.go
@@ -2,118 +2,202 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"eigenflux_server/kitex_gen/eigenflux/item"
+	"eigenflux_server/pkg/agentidentity"
 	"eigenflux_server/pkg/db"
 	"eigenflux_server/rpc/item/dal"
+	profiledal "eigenflux_server/rpc/profile/dal"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
-// TestDeleteMyItemLogic tests the DeleteMyItem handler logic
-// This is a unit test that verifies the authorization and status update logic
 func TestDeleteMyItemLogic(t *testing.T) {
-	// Test case 1: Verify authorization check exists
 	t.Run("AuthorizationCheck", func(t *testing.T) {
-		// The handler should check that stats.AuthorAgentID == req.AuthorAgentId
-		// This is verified by code inspection in handler.go:227-231
-		t.Log("Authorization check verified in handler.go")
+		gdb := newDeleteItemTestDB(t)
+		seedDeleteItem(t, gdb, 101, 201)
+
+		resp, err := (&ItemServiceImpl{}).DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+			ItemId: 201, AuthorAgentId: 102,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.BaseResp)
+		require.Equal(t, int32(403), resp.BaseResp.Code)
+		assertDeleteItemStatus(t, gdb, 201, dal.StatusCompleted)
 	})
 
-	// Test case 2: Verify status update to deleted
 	t.Run("StatusUpdate", func(t *testing.T) {
-		// The handler should call dal.UpdateProcessedItemStatus(db.DB, req.ItemId, dal.StatusDeleted)
-		// This is verified by code inspection in handler.go
-		t.Log("Status update to deleted verified in handler.go")
+		gdb := newDeleteItemTestDB(t)
+		seedDeleteItem(t, gdb, 101, 201)
+		seedDeleteItem(t, gdb, 102, 202)
+
+		resp, err := (&ItemServiceImpl{}).DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+			ItemId: 201, AuthorAgentId: 101,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.BaseResp)
+		require.Zero(t, resp.BaseResp.Code)
+		assertDeleteItemStatus(t, gdb, 201, dal.StatusDeleted)
+		assertDeleteItemStatus(t, gdb, 202, dal.StatusCompleted)
 	})
 
-	// Test case 3: Verify error handling
 	t.Run("ErrorHandling", func(t *testing.T) {
-		// Handler returns 404 if item not found
-		// Handler returns 403 if not authorized
-		// Handler returns 500 if update fails
-		// This is verified by code inspection in handler.go:227-240
-		t.Log("Error handling verified in handler.go")
+		t.Run("NotFound", func(t *testing.T) {
+			newDeleteItemTestDB(t)
+			resp, err := (&ItemServiceImpl{}).DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+				ItemId: 201, AuthorAgentId: 101,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.BaseResp)
+			require.Equal(t, int32(404), resp.BaseResp.Code)
+		})
+
+		t.Run("LookupFailure", func(t *testing.T) {
+			gdb := newDeleteItemTestDB(t)
+			seedDeleteItem(t, gdb, 101, 201)
+			require.NoError(t, gdb.Callback().Query().Before("gorm:query").Register("test:stats_lookup_failure", func(tx *gorm.DB) {
+				if tx.Statement.Table == "item_stats" {
+					tx.AddError(errors.New("injected stats lookup failure"))
+				}
+			}))
+
+			resp, err := (&ItemServiceImpl{}).DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+				ItemId: 201, AuthorAgentId: 101,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.BaseResp)
+			require.Equal(t, int32(500), resp.BaseResp.Code)
+			assertDeleteItemStatus(t, gdb, 201, dal.StatusCompleted)
+		})
+
+		t.Run("UpdateFailure", func(t *testing.T) {
+			gdb := newDeleteItemTestDB(t)
+			seedDeleteItem(t, gdb, 101, 201)
+			require.NoError(t, gdb.Exec(`CREATE TRIGGER reject_item_status_update
+				BEFORE UPDATE OF status ON processed_items
+				BEGIN SELECT RAISE(ABORT, 'injected status update failure'); END`).Error)
+
+			resp, err := (&ItemServiceImpl{}).DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+				ItemId: 201, AuthorAgentId: 101,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.BaseResp)
+			require.Equal(t, int32(500), resp.BaseResp.Code)
+			assertDeleteItemStatus(t, gdb, 201, dal.StatusCompleted)
+		})
 	})
 }
 
-// TestDeleteMyItemIntegration is an integration test that requires DB
-// Run with: go test -v ./rpc/item/ -run TestDeleteMyItemIntegration
-// Requires: docker compose up -d
+// TestDeleteMyItemIntegration exercises the real handler and DAL against an
+// isolated SQLite database with the item_stats foreign keys enforced.
 func TestDeleteMyItemIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
+	gdb := newDeleteItemTestDB(t)
+	const authorID, itemID = int64(101), int64(201)
+	seedDeleteItem(t, gdb, authorID, itemID)
 
-	// Initialize DB connection
-	db.Init("")
+	// The database must reject the missing-author fixture that would otherwise
+	// hide a foreign-key failure on PostgreSQL.
+	require.NoError(t, dal.CreateRawItem(gdb, &dal.RawItem{
+		ItemID: 202, AuthorAgentID: 102, RawContent: "Missing author",
+	}))
+	require.Error(t, dal.CreateItemStats(gdb, 202, 102))
 
-	// Create test item
-	authorID := int64(999999)
-	itemID := int64(888888)
-
-	// Clean up
-	defer func() {
-		db.DB.Exec("DELETE FROM item_stats WHERE item_id = ?", itemID)
-		db.DB.Exec("DELETE FROM processed_items WHERE item_id = ?", itemID)
-		db.DB.Exec("DELETE FROM raw_items WHERE item_id = ?", itemID)
-	}()
-
-	// Insert test data
-	rawItem := &dal.RawItem{
-		ItemID:        itemID,
-		AuthorAgentID: authorID,
-		RawContent:    "Test content",
-	}
-	if err := dal.CreateRawItem(db.DB, rawItem); err != nil {
-		t.Fatalf("Failed to create raw item: %v", err)
-	}
-
-	processedItem := &dal.ProcessedItem{
-		ItemID: itemID,
-		Status: dal.StatusCompleted,
-	}
-	if err := dal.CreateProcessedItem(db.DB, processedItem); err != nil {
-		t.Fatalf("Failed to create processed item: %v", err)
-	}
-
-	if err := dal.CreateItemStats(db.DB, itemID, authorID); err != nil {
-		t.Fatalf("Failed to create item stats: %v", err)
-	}
-
-	// Test DeleteMyItem
 	svc := &ItemServiceImpl{}
-	ctx := context.Background()
-
-	// Test successful delete
-	resp, err := svc.DeleteMyItem(ctx, &item.DeleteMyItemReq{
-		ItemId:        itemID,
-		AuthorAgentId: authorID,
+	resp, err := svc.DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+		ItemId: itemID, AuthorAgentId: authorID,
 	})
-	if err != nil {
-		t.Fatalf("DeleteMyItem failed: %v", err)
-	}
-	if resp.BaseResp.Code != 0 {
-		t.Fatalf("Expected code 0, got %d: %s", resp.BaseResp.Code, resp.BaseResp.Msg)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.BaseResp)
+	require.Zero(t, resp.BaseResp.Code)
+	assertDeleteItemStatus(t, gdb, itemID, dal.StatusDeleted)
 
-	// Verify status updated to deleted
-	var status int
-	if err := db.DB.Raw("SELECT status FROM processed_items WHERE item_id = ?", itemID).Scan(&status).Error; err != nil {
-		t.Fatalf("Failed to query status: %v", err)
-	}
-	if status != int(dal.StatusDeleted) {
-		t.Fatalf("Expected status %d (deleted), got %d", dal.StatusDeleted, status)
-	}
+	// A soft delete preserves the author, original content, and attribution.
+	author, err := profiledal.GetAgentByID(gdb, authorID)
+	require.NoError(t, err)
+	require.Equal(t, authorID, author.AgentID)
+	raw, err := dal.GetRawItemByID(gdb, itemID)
+	require.NoError(t, err)
+	require.Equal(t, "Test content", raw.RawContent)
+	stats, err := dal.GetItemStatsByID(gdb, itemID)
+	require.NoError(t, err)
+	require.Equal(t, authorID, stats.AuthorAgentID)
 
-	// Test unauthorized delete
-	resp2, err := svc.DeleteMyItem(ctx, &item.DeleteMyItemReq{
-		ItemId:        itemID,
-		AuthorAgentId: 777777, // different author
+	resp, err = svc.DeleteMyItem(context.Background(), &item.DeleteMyItemReq{
+		ItemId: itemID, AuthorAgentId: 102,
 	})
-	if err != nil {
-		t.Fatalf("DeleteMyItem failed: %v", err)
-	}
-	if resp2.BaseResp.Code != 403 {
-		t.Fatalf("Expected code 403, got %d", resp2.BaseResp.Code)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.BaseResp)
+	require.Equal(t, int32(403), resp.BaseResp.Code)
+	assertDeleteItemStatus(t, gdb, itemID, dal.StatusDeleted)
+}
+
+func newDeleteItemTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	gdb, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "delete-item.sqlite")+"?_foreign_keys=on"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	previous := db.DB
+	db.DB = gdb
+	t.Cleanup(func() {
+		db.DB = previous
+		require.NoError(t, sqlDB.Close())
+	})
+	require.NoError(t, gdb.AutoMigrate(&profiledal.Agent{}, &dal.RawItem{}, &dal.ProcessedItem{}))
+	require.NoError(t, gdb.Exec("CREATE UNIQUE INDEX idx_delete_agent_short_id ON agents(short_id) WHERE short_id IS NOT NULL").Error)
+	// DAL structs have no association tags; retain the migration's two foreign
+	// keys explicitly so the SQLite fixture enforces author/item existence.
+	require.NoError(t, gdb.Exec(`CREATE TABLE item_stats (
+		item_id BIGINT PRIMARY KEY REFERENCES raw_items(item_id) ON DELETE CASCADE,
+		author_agent_id BIGINT NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+		consumed_count BIGINT NOT NULL DEFAULT 0,
+		score_neg1_count BIGINT NOT NULL DEFAULT 0,
+		score_0_count BIGINT NOT NULL DEFAULT 0,
+		score_1_count BIGINT NOT NULL DEFAULT 0,
+		score_2_count BIGINT NOT NULL DEFAULT 0,
+		total_score BIGINT NOT NULL DEFAULT 0,
+		created_at BIGINT NOT NULL,
+		updated_at BIGINT NOT NULL
+	)`).Error)
+	return gdb
+}
+
+func seedDeleteItem(t *testing.T, gdb *gorm.DB, authorID, itemID int64) {
+	t.Helper()
+	shortID, err := agentidentity.GenerateShortID()
+	require.NoError(t, err)
+	require.NoError(t, gdb.Create(&profiledal.Agent{
+		AgentID: authorID, ShortID: shortID, Email: fmt.Sprintf("delete-%d@test.local", authorID),
+		AgentName: "Delete test author", CreatedAt: 1, UpdatedAt: 1,
+	}).Error)
+	require.NoError(t, dal.CreateRawItem(gdb, &dal.RawItem{
+		ItemID: itemID, AuthorAgentID: authorID, RawContent: "Test content",
+	}))
+	require.NoError(t, dal.CreateProcessedItem(gdb, &dal.ProcessedItem{
+		ItemID: itemID, Status: dal.StatusCompleted,
+	}))
+	require.NoError(t, dal.CreateItemStats(gdb, itemID, authorID))
+}
+
+func assertDeleteItemStatus(t *testing.T, gdb *gorm.DB, itemID int64, want int16) {
+	t.Helper()
+	var got dal.ProcessedItem
+	require.NoError(t, gdb.First(&got, "item_id = ?", itemID).Error)
+	require.Equal(t, want, got.Status)
 }

--- a/rpc/sort/ranker/ranker_test.go
+++ b/rpc/sort/ranker/ranker_test.go
@@ -140,9 +140,9 @@ func TestRanker_EmptyCandidates(t *testing.T) {
 
 func TestRankWithCustomTime(t *testing.T) {
 	cfg := &RankerConfig{
-		Alpha: 0.0, Beta: 0.0, Gamma: 1.0, Delta: 0.0,
+		Alpha: 0.0, Beta: 1.0, Gamma: 1.0, Delta: 0.0,
 		Freshness: map[string]FreshnessParams{
-			"info": {Offset: 12 * time.Hour, Scale: 7 * 24 * time.Hour, Decay: 0.8},
+			"info": {Offset: 12 * time.Hour, Scale: 24 * time.Hour, Decay: 0.5},
 		},
 		DraftDampening: 0.8,
 	}
@@ -150,17 +150,31 @@ func TestRankWithCustomTime(t *testing.T) {
 
 	now := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
 	candidates := []sortDal.Item{
+		// Put the older item first so an unscored tie cannot pass the ordering assertion.
+		{ID: 2, Type: "info", Keywords: []string{"go"}, UpdatedAt: now.Add(-36 * time.Hour)},
 		{ID: 1, Type: "info", Keywords: []string{"go"}, UpdatedAt: now.Add(-1 * time.Hour)},
-		{ID: 2, Type: "info", Keywords: []string{"go"}, UpdatedAt: now.Add(-48 * time.Hour)},
 	}
 	profile := &UserProfile{Keywords: []string{"go"}}
 
 	ranked := r.RankAt(candidates, profile, 2, now)
 
-	if len(ranked) != 2 {
-		t.Fatalf("expected 2 ranked items, got %d", len(ranked))
+	require.Len(t, ranked, 2)
+	require.Equal(t, int64(1), ranked[0].ItemID)
+	require.Equal(t, int64(2), ranked[1].ItemID)
+	assert.InDelta(t, 1.0, ranked[0].Score, 1e-9, "within the freshness offset")
+	assert.InDelta(t, 0.5, ranked[1].Score, 1e-9, "one scale beyond the offset")
+	for _, result := range ranked {
+		assert.Equal(t, 1.0, result.Scores.Keyword)
+		assert.InDelta(t, result.Scores.Freshness, result.Score, 1e-9)
+		assert.InDelta(t, result.Scores.Total, result.Score, 1e-9)
 	}
-	if ranked[0].ItemID != 1 {
-		t.Errorf("expected item 1 ranked first (fresher), got item %d", ranked[0].ItemID)
+
+	later := r.RankAt(candidates, profile, 2, now.Add(24*time.Hour))
+	require.Len(t, later, 2)
+	for i, result := range later {
+		require.Equal(t, ranked[i].ItemID, result.ItemID)
+		assert.Greater(t, result.Score, 0.0)
+		assert.Less(t, result.Score, ranked[i].Score, "advancing the supplied time must decay the score")
 	}
+	assert.InDelta(t, 0.0625, later[1].Score, 1e-9, "two scales beyond the offset: 0.5^4")
 }

--- a/tests/console/console_v1_test.go
+++ b/tests/console/console_v1_test.go
@@ -163,24 +163,72 @@ func TestConsoleActivityLogRespectsLimit(t *testing.T) {
 
 func TestConsoleActivityLogRespectsHours(t *testing.T) {
 	testutil.WaitForAPI(t)
-	token, _, _ := testutil.LoginAndGetToken(t, testEmail)
+	suffix := time.Now().UnixNano()
+	email := fmt.Sprintf("console-activity-hours-%d@test.com", suffix)
+	token, agentID, _ := testutil.LoginAndGetToken(t, email)
+	t.Cleanup(func() { testutil.CleanupTestEmails(t, email) })
 
-	result := testutil.DoGet(t, "/api/v1/console/activity-log?hours=1", token)
-	assertCode(t, result, 0)
+	now := time.Now()
+	fixtures := []struct {
+		logID     int64
+		summary   string
+		createdAt int64
+	}{
+		{suffix, "activity inside one-hour window", now.Add(-30 * time.Minute).UnixMilli()},
+		{suffix + 1, "activity outside one-hour window", now.Add(-2 * time.Hour).UnixMilli()},
+	}
+	t.Cleanup(func() {
+		if _, err := testutil.TestDB.Exec(`DELETE FROM agent_activity_log WHERE agent_id = $1 AND log_id IN ($2, $3)`, agentID, fixtures[0].logID, fixtures[1].logID); err != nil {
+			t.Errorf("clean activity fixtures: %v", err)
+		}
+	})
+	for _, fixture := range fixtures {
+		if _, err := testutil.TestDB.Exec(`INSERT INTO agent_activity_log (log_id, agent_id, event_type, summary, detail, created_at)
+			VALUES ($1, $2, 'feed_pull', $3, '{}', $4)`, fixture.logID, agentID, fixture.summary, fixture.createdAt); err != nil {
+			t.Fatalf("insert activity fixture: %v", err)
+		}
+	}
 
-	data := result["data"].(map[string]interface{})
-	events := data["events"].([]interface{})
-	// Verify all returned events are within 1 hour
-	oneHourAgoMs := float64(time.Now().Add(-1*time.Hour).UnixMilli()) - 1000 // 1s buffer
-	for i, e := range events {
-		event := e.(map[string]interface{})
-		createdAt, ok := event["created_at"].(float64)
-		if !ok {
-			continue
-		}
-		if createdAt < oneHourAgoMs {
-			t.Fatalf("event[%d] created_at=%v is older than 1 hour", i, createdAt)
-		}
+	for _, hours := range []int{1, 3} {
+		t.Run(fmt.Sprintf("hours=%d", hours), func(t *testing.T) {
+			requestStartedAt := time.Now()
+			result := testutil.DoGet(t, fmt.Sprintf("/api/v1/console/activity-log?hours=%d", hours), token)
+			assertCode(t, result, 0)
+			data := result["data"].(map[string]interface{})
+			events, ok := data["events"].([]interface{})
+			if !ok {
+				t.Fatal("expected events array in response")
+			}
+			seen := map[string]int{}
+			sinceMs := requestStartedAt.Add(-time.Duration(hours) * time.Hour).UnixMilli()
+			for i, raw := range events {
+				event := raw.(map[string]interface{})
+				eventTime, ok := event["time"].(float64)
+				if !ok {
+					t.Fatalf("event[%d] missing numeric time: %v", i, event)
+				}
+				if eventTime < float64(sinceMs) {
+					t.Fatalf("event[%d] time=%v is outside the %d-hour window", i, eventTime, hours)
+				}
+				for _, fixture := range fixtures {
+					if event["summary"] == fixture.summary {
+						seen[fixture.summary]++
+						if eventTime != float64(fixture.createdAt) {
+							t.Errorf("fixture %q time=%v, want %d", fixture.summary, eventTime, fixture.createdAt)
+						}
+					}
+				}
+			}
+			for _, fixture := range fixtures {
+				wantCount := 0
+				if fixture.createdAt >= sinceMs {
+					wantCount = 1
+				}
+				if got := seen[fixture.summary]; got != wantCount {
+					t.Errorf("fixture %q appeared %d times in %d-hour window, want %d", fixture.summary, got, hours, wantCount)
+				}
+			}
+		})
 	}
 }
 
@@ -278,20 +326,71 @@ func TestConsoleHighlightFeedbackInvalidType(t *testing.T) {
 
 func TestConsoleSettingsGetDefaults(t *testing.T) {
 	testutil.WaitForAPI(t)
-	email := fmt.Sprintf("console-settings-defaults-%d@test.com", time.Now().UnixNano()%1_000_000)
-	token, _, _ := testutil.LoginAndGetToken(t, email)
+	for _, tc := range []struct {
+		name     string
+		age      time.Duration
+		override int
+		want     int
+	}{
+		{name: "new_agent", want: 3600},
+		{name: "after_three_days", age: 4 * 24 * time.Hour, want: 300},
+		{name: "new_agent_explicit_setting", override: 900, want: 900},
+		{name: "after_three_days_explicit_setting", age: 4 * 24 * time.Hour, override: 900, want: 900},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			email := fmt.Sprintf("console-settings-defaults-%d@test.com", time.Now().UnixNano())
+			token, agentID, _ := testutil.LoginAndGetToken(t, email)
+			t.Cleanup(func() { testutil.CleanupTestEmails(t, email) })
+			t.Cleanup(func() {
+				if _, err := testutil.TestDB.Exec(`DELETE FROM agent_settings WHERE agent_id = $1`, agentID); err != nil {
+					t.Errorf("clean settings fixture: %v", err)
+				}
+			})
 
-	result := testutil.DoGet(t, "/api/v1/console/settings", token)
-	assertCode(t, result, 0)
+			// Materialize the settings row before setting up registration age.
+			initial := testutil.DoGet(t, "/api/v1/console/settings", token)
+			assertCode(t, initial, 0)
+			if tc.age > 0 {
+				createdAt := time.Now().Add(-tc.age).UnixMilli()
+				tx, err := testutil.TestDB.Begin()
+				if err != nil {
+					t.Fatalf("begin settings age fixture: %v", err)
+				}
+				defer tx.Rollback()
+				// Keep the profile timestamp and its settings cache consistent.
+				for _, query := range []string{
+					`UPDATE agents SET created_at = $1 WHERE agent_id = $2`,
+					`UPDATE agent_settings SET agent_created_at_ms = $1 WHERE agent_id = $2`,
+				} {
+					result, err := tx.Exec(query, createdAt, agentID)
+					if err != nil {
+						t.Fatalf("set registration age: %v", err)
+					}
+					if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+						t.Fatalf("set registration age affected %d rows, want 1: %v", rows, err)
+					}
+				}
+				if err := tx.Commit(); err != nil {
+					t.Fatalf("commit registration age fixture: %v", err)
+				}
+			}
+			if tc.override > 0 {
+				result := testutil.DoPut(t, "/api/v1/console/settings", map[string]interface{}{
+					"feed_poll_interval": tc.override,
+				}, token)
+				assertCode(t, result, 0)
+			}
 
-	data := result["data"].(map[string]interface{})
-	recurringPublish, ok := data["recurring_publish"].(bool)
-	if !ok || !recurringPublish {
-		t.Fatalf("expected recurring_publish=true by default, got %v", data["recurring_publish"])
-	}
-	feedPoll := int(data["feed_poll_interval"].(float64))
-	if feedPoll != 300 {
-		t.Fatalf("expected feed_poll_interval=300 by default, got %d", feedPoll)
+			result := testutil.DoGet(t, "/api/v1/console/settings", token)
+			assertCode(t, result, 0)
+			data := result["data"].(map[string]interface{})
+			if recurringPublish, ok := data["recurring_publish"].(bool); !ok || !recurringPublish {
+				t.Fatalf("expected recurring_publish=true by default, got %v", data["recurring_publish"])
+			}
+			if feedPoll, ok := data["feed_poll_interval"].(float64); !ok || feedPoll != float64(tc.want) {
+				t.Fatalf("expected feed_poll_interval=%d, got %v", tc.want, data["feed_poll_interval"])
+			}
+		})
 	}
 }
 

--- a/tests/install/invite_test.go
+++ b/tests/install/invite_test.go
@@ -184,9 +184,13 @@ func TestInviteCodeFlow(t *testing.T) {
 	}
 
 	// --- historical personal EFI links remain readable until revoked. ---
-	if _, err := testutil.TestDB.Exec(`INSERT INTO invite_codes(code, kind, agent_id, name, note, created_at)
-		VALUES ($1, 'kol', $2, '', 'legacy compatibility fixture', extract(epoch from now())::bigint * 1000)`, legacyCode, kolID); err != nil {
-		t.Fatalf("insert historical personal EFI code: %v", err)
+	// /agents/me already provisioned this agent's unique personal EFI code.
+	var legacyOwner int64
+	if err := testutil.TestDB.QueryRow(`SELECT agent_id FROM invite_codes WHERE code = $1 AND kind = 'kol' AND revoked_at IS NULL`, legacyCode).Scan(&legacyOwner); err != nil {
+		t.Fatalf("read existing personal EFI code: %v", err)
+	}
+	if legacyOwner != kolID {
+		t.Fatalf("personal EFI code owner=%d, want %d", legacyOwner, kolID)
 	}
 	legacyDoc := httpGet(t, testutil.BaseURL+"/r/"+legacyCode)
 	if inviteRefRe.FindString(legacyDoc) == "" {

--- a/tests/pm/pm_test.go
+++ b/tests/pm/pm_test.go
@@ -152,71 +152,8 @@ func TestPMFullFlow(t *testing.T) {
 	})
 
 	// ============================================================
-	// Test 2: SendPM — ice break blocks same sender (via item_id)
-	// ============================================================
-	t.Run("SendPM_IceBreakBlocksSameSender", func(t *testing.T) {
-		resp := testutil.DoPost(t, "/api/v1/pm/send", map[string]string{
-			"content": "Another message before reply",
-			"item_id": strconv.FormatInt(mockItemID, 10),
-		}, userToken)
-
-		code := int(resp["code"].(float64))
-		if code != 429 {
-			t.Fatalf("expected code=429 (ice break), got code=%d msg=%v", code, resp["msg"])
-		}
-	})
-
-	// ============================================================
-	// Test 2b: SendPM — ice break blocks same sender via conv_id
-	// ============================================================
-	t.Run("SendPM_IceBreakBlocksViaConvID", func(t *testing.T) {
-		if convID == "" {
-			t.Skip("skipped: no conv_id from previous steps")
-		}
-		resp := testutil.DoPost(t, "/api/v1/pm/send", map[string]string{
-			"content": "Trying to continue via conv_id before ice break",
-			"conv_id": convID,
-		}, userToken)
-
-		code := int(resp["code"].(float64))
-		if code != 429 {
-			t.Fatalf("expected code=429 (ice break via conv_id), got code=%d msg=%v", code, resp["msg"])
-		}
-	})
-
-	// ============================================================
-	// Test 3: FetchPM — author sees unread message
-	// ============================================================
-	t.Run("FetchPM_AuthorSeesMessage", func(t *testing.T) {
-		resp := testutil.DoGet(t, "/api/v1/pm/fetch", authorToken)
-		code := int(resp["code"].(float64))
-		if code != 0 {
-			t.Fatalf("FetchPM failed: code=%d msg=%v", code, resp["msg"])
-		}
-		data := resp["data"].(map[string]interface{})
-		messages := data["messages"].([]interface{})
-		if len(messages) != 1 {
-			t.Fatalf("expected 1 unread message, got %d", len(messages))
-		}
-		msg := messages[0].(map[string]interface{})
-		if msg["content"].(string) != "Hello, I saw your item!" {
-			t.Fatalf("unexpected message content: %v", msg["content"])
-		}
-		// Verify agent names are present
-		if msg["sender_name"].(string) != "PM User" {
-			t.Fatalf("expected sender_name='PM User', got %v", msg["sender_name"])
-		}
-		if msg["receiver_name"].(string) != "PM Author" {
-			t.Fatalf("expected receiver_name='PM Author', got %v", msg["receiver_name"])
-		}
-		convID = msg["conv_id"].(string)
-		t.Logf("FetchPM OK: got message in conv_id=%s", convID)
-	})
-
-	// ============================================================
-	// Test 3b: ListConversations(unbroken) — before the ice is broken the
-	// author sees the inbound DM in the "non-friend" tab, and it is absent
-	// from the default (>= 2) list.
+	// ListConversations(unbroken) includes the first inbound non-friend DM.
+	// The default conversation list also includes it from the first message.
 	// ============================================================
 	t.Run("ListConversations_UnbrokenInbound", func(t *testing.T) {
 		resp := testutil.DoGet(t, "/api/v1/pm/conversations?origin_type=unbroken", authorToken)
@@ -241,13 +178,116 @@ func TestPMFullFlow(t *testing.T) {
 			t.Fatalf("expected unbroken conv_id=%s in author's non-friend list", convID)
 		}
 
-		// The same conversation must NOT appear in the default ice-broken list yet.
+		// The default list must include the conversation from the opening message.
 		def := testutil.DoGet(t, "/api/v1/pm/conversations", authorToken)
+		if code := int(def["code"].(float64)); code != 0 {
+			t.Fatalf("ListConversations failed: code=%d msg=%v", code, def["msg"])
+		}
+		found = false
 		for _, c := range def["data"].(map[string]interface{})["conversations"].([]interface{}) {
 			if c.(map[string]interface{})["conv_id"].(string) == convID {
-				t.Fatalf("conv_id=%s should be hidden from default list until ice-broken", convID)
+				found = true
 			}
 		}
+		if !found {
+			t.Fatalf("expected opening conv_id=%s in the default list", convID)
+		}
+	})
+
+	// The opening message plus two follow-ups share one three-message window,
+	// regardless of whether the caller addresses the item or the conversation.
+	t.Run("SendPM_IceBreakAllowsThreeMessagesAcrossTargets", func(t *testing.T) {
+		if convID == "" {
+			t.Fatal("opening message did not create a conversation")
+		}
+		for _, payload := range []map[string]string{
+			{"item_id": strconv.FormatInt(mockItemID, 10), "content": "Second message via item before reply"},
+			{"conv_id": convID, "content": "Third message via conversation before reply"},
+		} {
+			resp := testutil.DoPost(t, "/api/v1/pm/send", payload, userToken)
+			if code := int(resp["code"].(float64)); code != 0 {
+				t.Fatalf("message within the three-message window failed: code=%d msg=%v", code, resp["msg"])
+			}
+			if got := resp["data"].(map[string]interface{})["conv_id"]; got != convID {
+				t.Fatalf("follow-up conv_id=%v, want %s", got, convID)
+			}
+		}
+	})
+
+	// ============================================================
+	// Test 2: SendPM — fourth message is blocked via item_id
+	// ============================================================
+	t.Run("SendPM_IceBreakBlocksSameSender", func(t *testing.T) {
+		resp := testutil.DoPost(t, "/api/v1/pm/send", map[string]string{
+			"content": "Fourth message via item before reply",
+			"item_id": strconv.FormatInt(mockItemID, 10),
+		}, userToken)
+
+		code := int(resp["code"].(float64))
+		if code != 429 {
+			t.Fatalf("expected code=429 (ice break), got code=%d msg=%v", code, resp["msg"])
+		}
+	})
+
+	// ============================================================
+	// Test 2b: SendPM — the exhausted window also blocks via conv_id
+	// ============================================================
+	t.Run("SendPM_IceBreakBlocksViaConvID", func(t *testing.T) {
+		if convID == "" {
+			t.Skip("skipped: no conv_id from previous steps")
+		}
+		resp := testutil.DoPost(t, "/api/v1/pm/send", map[string]string{
+			"content": "Fourth message via conversation before reply",
+			"conv_id": convID,
+		}, userToken)
+
+		code := int(resp["code"].(float64))
+		if code != 429 {
+			t.Fatalf("expected code=429 (ice break via conv_id), got code=%d msg=%v", code, resp["msg"])
+		}
+	})
+
+	// ============================================================
+	// Test 3: FetchPM — author sees exactly the three allowed messages
+	// ============================================================
+	t.Run("FetchPM_AuthorSeesMessage", func(t *testing.T) {
+		resp := testutil.DoGet(t, "/api/v1/pm/fetch", authorToken)
+		code := int(resp["code"].(float64))
+		if code != 0 {
+			t.Fatalf("FetchPM failed: code=%d msg=%v", code, resp["msg"])
+		}
+		data := resp["data"].(map[string]interface{})
+		messages := data["messages"].([]interface{})
+		if len(messages) != 3 {
+			t.Fatalf("expected 3 unread messages, got %d", len(messages))
+		}
+		wantContents := map[string]bool{
+			"Hello, I saw your item!":                     false,
+			"Second message via item before reply":        false,
+			"Third message via conversation before reply": false,
+		}
+		for _, raw := range messages {
+			msg := raw.(map[string]interface{})
+			content := msg["content"].(string)
+			seen, expected := wantContents[content]
+			if !expected || seen {
+				t.Fatalf("unexpected or duplicate unread message: %q", content)
+			}
+			wantContents[content] = true
+			if got := msg["conv_id"]; got != convID {
+				t.Fatalf("unread message conv_id=%v, want %s", got, convID)
+			}
+		}
+		msg := messages[0].(map[string]interface{})
+		// Verify agent names are present
+		if msg["sender_name"].(string) != "PM User" {
+			t.Fatalf("expected sender_name='PM User', got %v", msg["sender_name"])
+		}
+		if msg["receiver_name"].(string) != "PM Author" {
+			t.Fatalf("expected receiver_name='PM Author', got %v", msg["receiver_name"])
+		}
+		convID = msg["conv_id"].(string)
+		t.Logf("FetchPM OK: got message in conv_id=%s", convID)
 	})
 
 	// ============================================================
@@ -329,9 +369,9 @@ func TestPMFullFlow(t *testing.T) {
 		}
 		data := resp["data"].(map[string]interface{})
 		messages := data["messages"].([]interface{})
-		// Should have 3 messages: user→author, author→user, user→author
-		if len(messages) != 3 {
-			t.Fatalf("expected 3 messages in history, got %d", len(messages))
+		// Three opening messages, the author reply, and the follow-up.
+		if len(messages) != 5 {
+			t.Fatalf("expected 5 messages in history, got %d", len(messages))
 		}
 		// Verify names on messages
 		for _, m := range messages {

--- a/tests/pm/relations_test.go
+++ b/tests/pm/relations_test.go
@@ -2066,26 +2066,44 @@ func TestBroadcastConv_IceBreakBypassedAfterBefriending(t *testing.T) {
 	}
 	convID := resp["data"].(map[string]interface{})["conv_id"].(string)
 
-	// Sender tries second message — should be blocked by ice-break (author hasn't replied).
+	// Exhaust the three-message window before testing the friendship override.
+	for messageNumber := 2; messageNumber <= 3; messageNumber++ {
+		resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
+			"conv_id": convID,
+			"content": fmt.Sprintf("Pre-friendship message %d", messageNumber),
+		}, sender["token"].(string))
+		if code := int(resp["code"].(float64)); code != 0 {
+			t.Fatalf("message %d within ice-break window failed: code=%d msg=%v", messageNumber, code, resp["msg"])
+		}
+	}
+
+	// The fourth message is blocked until the author replies or they become friends.
 	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
 		"conv_id": convID,
-		"content": "Second broadcast msg",
+		"content": "Fourth broadcast msg",
 	}, sender["token"].(string))
 	code = int(resp["code"].(float64))
 	if code != 429 {
 		t.Fatalf("Expected ice-break 429 before befriending, got code=%d msg=%v", code, resp["msg"])
 	}
-	t.Logf("Ice-break correctly blocked second message before befriending")
+	t.Logf("Ice-break correctly blocked fourth message before befriending")
 
 	// Now they become friends.
 	applyResp := testutil.DoPost(t, "/api/v1/relations/apply", map[string]string{
 		"to_uid": author["agent_id"].(string),
 	}, sender["token"].(string))
+	if code := int(applyResp["code"].(float64)); code != 0 {
+		t.Fatalf("friend request failed: code=%d msg=%v", code, applyResp["msg"])
+	}
 	requestID := applyResp["data"].(map[string]interface{})["request_id"].(string)
-	testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
+	acceptResp := testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
 		"request_id": requestID,
 		"action":     1,
 	}, author["token"].(string))
+
+	if code := int(acceptResp["code"].(float64)); code != 0 {
+		t.Fatalf("accept friend request failed: code=%d msg=%v", code, acceptResp["msg"])
+	}
 
 	// After becoming friends, sender should be able to send in the same broadcast conv.
 	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
@@ -2101,7 +2119,7 @@ func TestBroadcastConv_IceBreakBypassedAfterBefriending(t *testing.T) {
 	// Sender can send yet another message freely.
 	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
 		"conv_id": convID,
-		"content": "Third message after befriending",
+		"content": "Another message after befriending",
 	}, sender["token"].(string))
 	code = int(resp["code"].(float64))
 	if code != 0 {
@@ -2142,7 +2160,18 @@ func TestBroadcastConv_AuthorInitiatedFriendship_IceBreakBypassed(t *testing.T) 
 	}
 	convID := resp["data"].(map[string]interface{})["conv_id"].(string)
 
-	// Sender tries second message — should be blocked by ice-break.
+	// Exhaust the three-message window before testing the friendship override.
+	for messageNumber := 2; messageNumber <= 3; messageNumber++ {
+		resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
+			"conv_id": convID,
+			"content": fmt.Sprintf("Pre-friendship message %d", messageNumber),
+		}, sender["token"].(string))
+		if code := int(resp["code"].(float64)); code != 0 {
+			t.Fatalf("message %d within ice-break window failed: code=%d msg=%v", messageNumber, code, resp["msg"])
+		}
+	}
+
+	// The fourth message is blocked before they become friends.
 	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
 		"conv_id": convID,
 		"content": "Blocked msg",
@@ -2156,11 +2185,18 @@ func TestBroadcastConv_AuthorInitiatedFriendship_IceBreakBypassed(t *testing.T) 
 	applyResp := testutil.DoPost(t, "/api/v1/relations/apply", map[string]string{
 		"to_uid": sender["agent_id"].(string),
 	}, author["token"].(string))
+	if code := int(applyResp["code"].(float64)); code != 0 {
+		t.Fatalf("friend request failed: code=%d msg=%v", code, applyResp["msg"])
+	}
 	requestID := applyResp["data"].(map[string]interface{})["request_id"].(string)
-	testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
+	acceptResp := testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
 		"request_id": requestID,
 		"action":     1,
 	}, sender["token"].(string))
+
+	if code := int(acceptResp["code"].(float64)); code != 0 {
+		t.Fatalf("accept friend request failed: code=%d msg=%v", code, acceptResp["msg"])
+	}
 
 	// After befriending (author-initiated), sender should be unblocked.
 	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
@@ -2204,15 +2240,41 @@ func TestBroadcastConv_UnfriendReactivatesIceBreak(t *testing.T) {
 	}
 	convID := resp["data"].(map[string]interface{})["conv_id"].(string)
 
+	// Exhaust the three-message window before testing the friendship override.
+	for messageNumber := 2; messageNumber <= 3; messageNumber++ {
+		resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
+			"conv_id": convID,
+			"content": fmt.Sprintf("Pre-friendship message %d", messageNumber),
+		}, sender["token"].(string))
+		if code := int(resp["code"].(float64)); code != 0 {
+			t.Fatalf("message %d within ice-break window failed: code=%d msg=%v", messageNumber, code, resp["msg"])
+		}
+	}
+
+	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{
+		"conv_id": convID,
+		"content": "Fourth message before befriending",
+	}, sender["token"].(string))
+	if code := int(resp["code"].(float64)); code != 429 {
+		t.Fatalf("expected exhausted ice-break window before befriending, got code=%d msg=%v", code, resp["msg"])
+	}
+
 	// Become friends.
 	applyResp := testutil.DoPost(t, "/api/v1/relations/apply", map[string]string{
 		"to_uid": author["agent_id"].(string),
 	}, sender["token"].(string))
+	if code := int(applyResp["code"].(float64)); code != 0 {
+		t.Fatalf("friend request failed: code=%d msg=%v", code, applyResp["msg"])
+	}
 	requestID := applyResp["data"].(map[string]interface{})["request_id"].(string)
-	testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
+	acceptResp := testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
 		"request_id": requestID,
 		"action":     1,
 	}, author["token"].(string))
+
+	if code := int(acceptResp["code"].(float64)); code != 0 {
+		t.Fatalf("accept friend request failed: code=%d msg=%v", code, acceptResp["msg"])
+	}
 
 	// Friendship bypasses ice-break.
 	resp = testutil.DoPost(t, "/api/v1/pm/send", map[string]interface{}{

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,6 +9,9 @@ usage() {
 Usage:
   ./tests/run.sh [<dir_shortcut>] [--dir <test_pkg>] [--case <regex>] [--skip-start] [extra go test args...]
 
+Defaults to every package in the root Go module, including colocated tests.
+CLI, Console API, and Console Web have separate module commands in docs/dev/testing.md.
+
 Examples:
   ./tests/run.sh
   ./tests/run.sh e2e
@@ -19,7 +22,7 @@ Examples:
 EOF
 }
 
-TEST_DIR="./tests/..."
+TEST_DIR="./..."
 TEST_CASE=""
 SKIP_START="false"
 EXTRA_ARGS=()
@@ -46,7 +49,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       # Shorthand: first free arg like "e2e" means --dir e2e.
-      if [[ "$TEST_DIR" == "./tests/..." ]] && [[ "$1" != -* ]]; then
+      if [[ "$TEST_DIR" == "./..." ]] && [[ "$1" != -* ]]; then
         TEST_DIR="$1"
       else
         EXTRA_ARGS+=("$1")
@@ -63,6 +66,28 @@ if [[ "$TEST_DIR" != ./* ]]; then
   elif [[ -d "$PROJECT_ROOT/$TEST_DIR" ]]; then
     TEST_DIR="./$TEST_DIR"
   fi
+fi
+
+# Match config.Load(): .env supplies defaults, while exported caller values
+# (including an explicitly empty PG_DSN) retain precedence.
+if [[ -f "$PROJECT_ROOT/.env" ]]; then
+  CALLER_ENV_NAMES=()
+  CALLER_ENV_VALUES=()
+  while IFS= read -r env_name; do
+    CALLER_ENV_NAMES+=("$env_name")
+    CALLER_ENV_VALUES+=("${!env_name}")
+  done < <(compgen -e)
+  set -a
+  # shellcheck disable=SC1091
+  source "$PROJECT_ROOT/.env"
+  set +a
+  for ((i = 0; i < ${#CALLER_ENV_NAMES[@]}; i++)); do
+    env_name="${CALLER_ENV_NAMES[i]}"
+    if [[ "${!env_name}" != "${CALLER_ENV_VALUES[i]}" ]]; then
+      export "$env_name=${CALLER_ENV_VALUES[i]}"
+    fi
+  done
+  unset CALLER_ENV_NAMES CALLER_ENV_VALUES env_name i
 fi
 
 # Prefer project-pinned Go via mise when available.

--- a/tests/sanity/test_runner_test.go
+++ b/tests/sanity/test_runner_test.go
@@ -1,0 +1,66 @@
+package sanity_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRunnerPreservesCallerEnvironmentAndSelectsRootPackages(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("test runner requires bash")
+	}
+	script, err := os.ReadFile("../run.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		env  []string
+		want []string
+	}{
+		{"dotenv_defaults", nil, []string{"file-database", "file-redis"}},
+		{"explicit_stack", []string{"PG_DSN=isolated-database", "REDIS_ADDR=isolated-redis"}, []string{"isolated-database", "isolated-redis"}},
+		{"explicit_empty", []string{"PG_DSN=", "REDIS_ADDR="}, []string{"", ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			for _, dir := range []string{bin, filepath.Join(root, "tests")} {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			files := map[string][]byte{
+				"tests/run.sh": script,
+				".env":         []byte("PG_DSN=file-database\nREDIS_ADDR=file-redis\n"),
+				"bin/go":       []byte("#!/bin/bash\nprintf '%s\\0' \"${PG_DSN-}\" \"${REDIS_ADDR-}\" \"$@\" > \"$RUNNER_RESULT\"\n"),
+			}
+			for name, contents := range files {
+				if err := os.WriteFile(filepath.Join(root, name), contents, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			resultPath := filepath.Join(root, "result")
+			cmd := exec.Command(bash, filepath.Join(root, "tests/run.sh"), "--skip-start")
+			cmd.Dir = root
+			cmd.Env = append([]string{"PATH=" + bin + ":/usr/bin:/bin", "RUNNER_RESULT=" + resultPath}, tc.env...)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("test runner failed: %v\n%s", err, output)
+			}
+			result, err := os.ReadFile(resultPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := strings.Split(strings.TrimSuffix(string(result), "\x00"), "\x00")
+			want := append(append([]string{}, tc.want...), "test", "-v", "-count=1", "-timeout", "30m", "./...")
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("runner environment and arguments = %q, want %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Regression tests retained obsolete assumptions about the PM three-message window, new-agent polling cadence, Activity Log timestamps and personal invite-code initialization. Update those fixtures and assertions while preserving friendship, authorization and legacy EFI compatibility coverage.

Replace the empty DeleteMyItem checks with handler/DAL tests using an isolated SQLite database with foreign keys. Make the ranker time test require real nonzero scores, check both PostgreSQL fence rejection paths in recoverable savepoints, and fail welcome delivery on business errors after prerequisite checks. CLI freshness tests now distinguish manifest checks from tarball downloads and offline fallback.

The default runner includes all root-module packages and loads missing `.env` settings without overriding exported caller values. Document the separate module commands, and correct the Attention CI selector and contract path filters.

Validation:
- Core service build passed; root-module test compilation and vet passed via the updated runner with `-exec=/usr/bin/true` (not a full runtime test pass).
- Nine integration flows passed against a disposable local PostgreSQL/Redis/etcd/API/PM stack: four PM flows, two Console flows, invite attribution, both fence rejection cases, and welcome delivery.
- Ranker and rpc/item package tests, welcome prerequisite classification, and runner environment-precedence cases passed.
- Attention schema/golden tests passed using the corrected CI selector.
- CLI: 65 targeted top-level tests passed; Console Web: 3 tests passed.
- Welcome delivery uses the supported static-message fallback without external LLM calls. The temporary stack was cleaned up.
