### PR TITLE
fix(deploy): verify isolated API actually runs target binary

### DIFF
--- a/scripts/cloud/DEPLOYMENT_POLICY.md
+++ b/scripts/cloud/DEPLOYMENT_POLICY.md
@@ -48,6 +48,9 @@ a root operator may install the main-merged `deploy_main_lib.sh` and
 API. It uses the same deployment lock, fixed official remote, clean-checkout
 gate and root-managed environment. No migration or other service restart runs.
 API has a separate root-owned release/source pointer and per-instance override;
+the override is named `zz-api-only.conf` so it loads after the template's
+`deployer.conf`. Successful health checks must also match the running
+`/proc/<MainPID>/exe` against the target API binary before recording success.
 health-check failure restores the previous override and API release. The old
 release is retained. A later full deployment advances both release pointers.
 Do not run the full installer for this update: it bootstraps every service and

--- a/scripts/cloud/deploy_main_lib.sh
+++ b/scripts/cloud/deploy_main_lib.sh
@@ -219,10 +219,19 @@ deploy_main_prepare_source() {
 
 # API releases have their own source and pointer: changing the shared current
 # bundle would also change relative resources for still-running RPC services.
+deploy_main_api_matches() {
+  local pid
+  pid="$(systemctl show eigenflux-app@api -p MainPID --value)" || return 1
+  [[ "${pid}" =~ ^[1-9][0-9]*$ ]] || return 1
+  cmp -s "/proc/${pid}/exe" "$1/bin/api"
+}
+
 deploy_main_api_only() {
   local source_dir=$1 state_dir=$2 target=$3
   local override_dir=${4:-/etc/systemd/system/eigenflux-app@api.service.d}
-  local override_file=${override_dir}/90-api-only.conf
+  # systemd sorts template and instance drop-ins together by filename.
+  # This must sort after the shared deployer.conf.
+  local override_file=${override_dir}/zz-api-only.conf
   local release_dir old_link="" had_override=0
   mkdir -p "${state_dir}/api-releases" || return 1
   release_dir="$(mktemp -d "${state_dir}/api-releases/${target}.XXXXXX")" || return 1
@@ -253,7 +262,8 @@ deploy_main_api_only() {
     systemctl daemon-reload &&
     bash "${release_dir}/source/scripts/cloud/restart.sh" api &&
     curl --retry 15 --retry-delay 1 --retry-connrefused --max-time 3 -fsS \
-      http://127.0.0.1:8080/api/v1/website/stats >/dev/null; then
+      http://127.0.0.1:8080/api/v1/website/stats >/dev/null &&
+    deploy_main_api_matches "${release_dir}"; then
     printf '%s\n' "${target}" > "${state_dir}/api-deployed-sha"
     echo "API-only deployment completed: ${target}; other services and migrations unchanged"
     return 0

--- a/tests/deployment/test_api_only.sh
+++ b/tests/deployment/test_api_only.sh
@@ -26,14 +26,20 @@ mv() {
   fi
 }
 
-for scenario in success build-failure health-failure; do
+deploy_main_api_matches() { [[ "$scenario" != binary-mismatch ]]; }
+
+# An instance drop-in starting with a digit loses to template deployer.conf.
+[[ zz-api-only.conf > deployer.conf ]]
+grep -Fq 'override_file=${override_dir}/zz-api-only.conf' "$repo/scripts/cloud/deploy_main_lib.sh"
+
+for scenario in success build-failure health-failure binary-mismatch; do
   case_root="$test_root/$scenario"
   mkdir -p "$case_root/source/scripts/cloud" "$case_root/state" "$case_root/override" "$case_root/old"
   printf '#!/bin/bash\n[[ "$1" == api ]]\n' > "$case_root/source/scripts/cloud/restart.sh"
   printf 'old-source\n' > "$case_root/old/resource"
   ln -s "$case_root/old" "$case_root/state/current"
   ln -s "$case_root/old" "$case_root/state/api-current"
-  printf 'old-override\n' > "$case_root/override/90-api-only.conf"
+  printf 'old-override\n' > "$case_root/override/zz-api-only.conf"
   if deploy_main_api_only "$case_root/source" "$case_root/state" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "$case_root/override"; then
     [[ "$scenario" == success ]]
     [[ "$(readlink "$case_root/state/api-current")" != "$case_root/old" ]]
@@ -41,7 +47,7 @@ for scenario in success build-failure health-failure; do
   else
     [[ "$scenario" != success ]]
     [[ "$(readlink "$case_root/state/api-current")" == "$case_root/old" ]]
-    [[ "$(< "$case_root/override/90-api-only.conf")" == old-override ]]
+    [[ "$(< "$case_root/override/zz-api-only.conf")" == old-override ]]
     [[ ! -f "$case_root/state/api-deployed-sha" ]]
   fi
   [[ "$(readlink "$case_root/state/current")" == "$case_root/old" ]]


### PR DESCRIPTION
Follow-up required by PR #265 rollout: systemd sorts instance and template drop-ins lexicographically, so 90-api-only.conf was overridden by deployer.conf. Use zz-api-only.conf and require /proc/MainPID/exe to match the target binary before recording deployment success. No application/API changes, migration, environment changes, or additional service restarts. Existing deployment tests and API-only success/build failure/health failure/binary mismatch fixtures pass. Discovered during final production verification before reporting success; old API stayed healthy.