### PR TITLE
fix(console): deduplicate browser account sessions

### DIFF
--- a/api/consolev2/account_session_handlers.go
+++ b/api/consolev2/account_session_handlers.go
@@ -46,6 +46,11 @@ func consoleSessionCookieName(slot int) string { return consoleSlotCookieName(co
 func consoleCSRFCookieName(slot int) string    { return consoleSlotCookieName(csrfCookieName, slot) }
 
 func activeConsoleSlot(c *app.RequestContext) int {
+	if value, ok := c.Get("console_session_slot"); ok {
+		if slot, valid := value.(int); valid && slot >= 0 && slot < maxConsoleAccountSlots {
+			return slot
+		}
+	}
 	slot, err := strconv.Atoi(strings.TrimSpace(string(c.Cookie(activeConsoleSlotCookieName))))
 	if err != nil || slot < 0 || slot >= maxConsoleAccountSlots {
 		return 0
@@ -187,8 +192,85 @@ func (s *Service) consoleAccounts(db *gorm.DB, c *app.RequestContext, now int64)
 			accounts = append(accounts, account)
 		}
 	}
-	sort.SliceStable(accounts, func(i, j int) bool { return accounts[i].LastActiveAt > accounts[j].LastActiveAt })
-	return accounts
+	return uniqueConsoleAccounts(accounts, activeConsoleSlot(c))
+}
+
+func uniqueConsoleAccounts(accounts []consoleAccountView, activeSlot int) []consoleAccountView {
+	unique := make([]consoleAccountView, 0, len(accounts))
+	indices := make(map[string]int, len(accounts))
+	for _, account := range accounts {
+		if index, exists := indices[account.AgentID]; exists {
+			current := unique[index]
+			prefer := current.Expired && !account.Expired
+			if current.Expired == account.Expired {
+				prefer = account.Slot == activeSlot || (current.Slot != activeSlot && account.LastActiveAt > current.LastActiveAt)
+			}
+			if prefer {
+				unique[index] = account
+			}
+			continue
+		}
+		indices[account.AgentID] = len(unique)
+		unique = append(unique, account)
+	}
+	sort.SliceStable(unique, func(i, j int) bool { return unique[i].LastActiveAt > unique[j].LastActiveAt })
+	return unique
+}
+
+func (s *Service) chooseEmailLoginSessionSlot(tx *gorm.DB, c *app.RequestContext, targetAgentID int64) (int, string) {
+	// A normal login refreshes an existing browser identity even when it lives
+	// outside slot zero. New identities retain the slot-zero replacement rule.
+	selectedSlot := 0
+	replacedSessionID := ""
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		credential, ok := consoleCredential(c, slot)
+		if !ok {
+			continue
+		}
+		session, err := s.loadConsoleSessionCredential(tx, credential)
+		if err != nil {
+			continue
+		}
+		if slot == 0 || session.AgentID == targetAgentID {
+			selectedSlot, replacedSessionID = slot, session.SessionID
+		}
+		if session.AgentID == targetAgentID {
+			break
+		}
+	}
+	return selectedSlot, replacedSessionID
+}
+
+func (s *Service) revokeConsoleAccountSessions(c *app.RequestContext, targetAgentID, now int64) ([]int, error) {
+	slots := make([]int, 0, maxConsoleAccountSlots)
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		sessionIDs := make([]string, 0, maxConsoleAccountSlots)
+		for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+			credential, ok := consoleCredential(c, slot)
+			if !ok {
+				continue
+			}
+			session, loadErr := s.loadConsoleSessionCredential(tx, credential)
+			if loadErr != nil || session.AgentID != targetAgentID {
+				continue
+			}
+			slots = append(slots, slot)
+			sessionIDs = append(sessionIDs, session.SessionID)
+		}
+		if len(sessionIDs) > 0 {
+			return tx.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
+				WHERE session_id IN ? AND status = 'active'`, now, sessionIDs).Error
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, slot := range slots {
+		s.setConsoleCookieAtSlot(c, slot, "", -1)
+		s.setCSRFCookieAtSlot(c, slot, "", -1)
+	}
+	return slots, nil
 }
 
 func parseReplacementAgentID(value string) (int64, error) {
@@ -204,6 +286,9 @@ func parseReplacementAgentID(value string) (int64, error) {
 
 func (s *Service) chooseConsoleSessionSlot(tx *gorm.DB, c *app.RequestContext, targetAgentID, replacementAgentID int64, now int64) (int, string, []consoleAccountView, error) {
 	freeSlot := -1
+	targetSlot, replacementSlot, duplicateSlot := -1, -1, -1
+	targetSessionID, replacementSessionID, duplicateSessionID := "", "", ""
+	seenAgents := make(map[int64]string, maxConsoleAccountSlots)
 	accounts := make([]consoleAccountView, 0, maxConsoleAccountSlots)
 	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
 		credential, ok := consoleCredential(c, slot)
@@ -224,15 +309,35 @@ func (s *Service) chooseConsoleSessionSlot(tx *gorm.DB, c *app.RequestContext, t
 		if accountErr == nil {
 			accounts = append(accounts, account)
 		}
-		if session.AgentID == targetAgentID || (replacementAgentID > 0 && session.AgentID == replacementAgentID) {
-			return slot, session.SessionID, accounts, nil
+		if session.AgentID == targetAgentID && (targetSlot < 0 || slot == activeConsoleSlot(c)) {
+			targetSlot, targetSessionID = slot, session.SessionID
 		}
+		if replacementAgentID > 0 && session.AgentID == replacementAgentID {
+			replacementSlot, replacementSessionID = slot, session.SessionID
+		}
+		if existingSessionID, exists := seenAgents[session.AgentID]; exists && duplicateSlot < 0 {
+			duplicateSlot = slot
+			if existingSessionID != session.SessionID {
+				duplicateSessionID = session.SessionID
+			}
+		}
+		seenAgents[session.AgentID] = session.SessionID
+	}
+	accounts = uniqueConsoleAccounts(accounts, activeConsoleSlot(c))
+	if targetSlot >= 0 {
+		return targetSlot, targetSessionID, accounts, nil
 	}
 	if replacementAgentID > 0 {
+		if replacementSlot >= 0 {
+			return replacementSlot, replacementSessionID, accounts, nil
+		}
 		return 0, "", accounts, errConflict
 	}
 	if freeSlot >= 0 {
 		return freeSlot, "", accounts, nil
+	}
+	if duplicateSlot >= 0 {
+		return duplicateSlot, duplicateSessionID, accounts, nil
 	}
 	return 0, "", accounts, errConsoleAccountLimit
 }
@@ -254,6 +359,8 @@ func (s *Service) activateConsoleAccount(_ context.Context, c *app.RequestContex
 		return
 	}
 	now := time.Now().UnixMilli()
+	selectedSlot := -1
+	var selectedSession consoleSession
 	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
 		credential, ok := consoleCredential(c, slot)
 		if !ok {
@@ -261,10 +368,16 @@ func (s *Service) activateConsoleAccount(_ context.Context, c *app.RequestContex
 		}
 		session, loadErr := s.loadConsoleSessionCredential(s.db, credential)
 		if loadErr == nil && validConsoleSessionAt(session, now) && session.AgentID == targetID {
-			s.setActiveConsoleSlot(c, slot, int(consoleAbsoluteTTL/time.Second))
-			reply(c, http.StatusOK, map[string]interface{}{"activated": true, "agent_id": c.Param("agent_id"), "slot": slot})
-			return
+			if selectedSlot < 0 || slot == activeConsoleSlot(c) ||
+				(selectedSlot != activeConsoleSlot(c) && session.LastSeenAt > selectedSession.LastSeenAt) {
+				selectedSlot, selectedSession = slot, session
+			}
 		}
+	}
+	if selectedSlot >= 0 {
+		s.setActiveConsoleSlot(c, selectedSlot, int(consoleAbsoluteTTL/time.Second))
+		reply(c, http.StatusOK, map[string]interface{}{"activated": true, "agent_id": c.Param("agent_id"), "slot": selectedSlot})
+		return
 	}
 	fail(c, http.StatusNotFound, "CONSOLE_ACCOUNT_NOT_FOUND", "this account is not available in the browser", nil)
 }
@@ -278,22 +391,14 @@ func (s *Service) removeConsoleAccount(_ context.Context, c *app.RequestContext)
 	now := time.Now().UnixMilli()
 	currentAgentID, _ := agentID(c)
 	removedSlot := -1
-	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
-		credential, ok := consoleCredential(c, slot)
-		if !ok {
-			continue
-		}
-		session, loadErr := s.loadConsoleSessionCredential(s.db, credential)
-		if loadErr == nil && session.AgentID == targetID {
-			if err := s.db.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
-				WHERE session_id = ? AND status = 'active'`, now, session.SessionID).Error; err != nil {
-				fail(c, http.StatusInternalServerError, "LOGOUT_FAILED", "could not revoke Console V2 session", nil)
-				return
-			}
-			s.setConsoleCookieAtSlot(c, slot, "", -1)
-			s.setCSRFCookieAtSlot(c, slot, "", -1)
+	removedSlots, err := s.revokeConsoleAccountSessions(c, targetID, now)
+	if err != nil {
+		fail(c, http.StatusInternalServerError, "LOGOUT_FAILED", "could not revoke Console V2 session", nil)
+		return
+	}
+	for _, slot := range removedSlots {
+		if removedSlot < 0 || slot == activeConsoleSlot(c) {
 			removedSlot = slot
-			break
 		}
 	}
 	if removedSlot < 0 {

--- a/api/consolev2/account_session_handlers_test.go
+++ b/api/consolev2/account_session_handlers_test.go
@@ -1,0 +1,257 @@
+package consolev2
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type browserSessionFixture struct {
+	service *Service
+	now     int64
+	cookies []string
+}
+
+func newBrowserSessionFixture(t *testing.T) *browserSessionFixture {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	for _, statement := range []string{
+		`CREATE TABLE agents (agent_id INTEGER PRIMARY KEY, identity_state TEXT, agent_name TEXT, agent_name_en TEXT, short_id TEXT)`,
+		`CREATE TABLE agent_principals (principal_id INTEGER PRIMARY KEY, agent_id INTEGER, status TEXT, revoked_at INTEGER)`,
+		`CREATE TABLE agent_email_bindings (binding_id INTEGER PRIMARY KEY, agent_id INTEGER, normalized_email TEXT, status TEXT, verification_state TEXT, updated_at INTEGER)`,
+		`CREATE TABLE console_v2_sessions (
+			session_id TEXT PRIMARY KEY, agent_id INTEGER, principal_id INTEGER,
+			session_secret_hash TEXT, csrf_secret_hash TEXT, scopes TEXT,
+			idle_expires_at INTEGER, absolute_expires_at INTEGER, last_seen_at INTEGER,
+			auth_method TEXT, recent_auth_at INTEGER, status TEXT, revoked_at INTEGER
+		)`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &browserSessionFixture{service: &Service{db: db, publicURL: "https://console.example.test"}, now: time.Now().UnixMilli()}
+}
+
+func (f *browserSessionFixture) add(t *testing.T, slot int, agentID int64, expired bool) string {
+	t.Helper()
+	sessionID := fmt.Sprintf("session-%d-%d", agentID, slot)
+	expiresAt := f.now + int64(time.Hour/time.Millisecond)
+	if expired {
+		expiresAt = f.now - 1
+	}
+	for _, statement := range []string{
+		`INSERT OR IGNORE INTO agents (agent_id, identity_state, agent_name, agent_name_en, short_id) VALUES (?, 'active', 'Same display name', '', 'AbCdE')`,
+		`INSERT OR IGNORE INTO agent_principals (principal_id, agent_id, status) VALUES (?, ?, 'active')`,
+	} {
+		args := []interface{}{agentID}
+		if strings.Contains(statement, "agent_principals") {
+			args = append(args, agentID)
+		}
+		if err := f.service.db.Exec(statement, args...).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.service.db.Exec(`INSERT INTO console_v2_sessions
+		(session_id, agent_id, principal_id, session_secret_hash, csrf_secret_hash, scopes,
+		idle_expires_at, absolute_expires_at, last_seen_at, auth_method, status)
+		VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, 'email_otp', 'active')`, sessionID, agentID, agentID,
+		hashString("secret"), hashString("csrf"), expiresAt, expiresAt, f.now-int64(slot)).Error; err != nil {
+		t.Fatal(err)
+	}
+	if slot >= 0 {
+		f.cookies = append(f.cookies, consoleSessionCookieName(slot)+"="+sessionID+".secret")
+	}
+	return sessionID
+}
+
+func (f *browserSessionFixture) context(activeSlot int) *app.RequestContext {
+	c := app.NewContext(0)
+	c.Request.Header.Set("Cookie", f.cookieHeader(activeSlot))
+	return c
+}
+
+func (f *browserSessionFixture) cookieHeader(activeSlot int) string {
+	return strings.Join(append(append([]string{}, f.cookies...), fmt.Sprintf("%s=%d", activeConsoleSlotCookieName, activeSlot)), "; ")
+}
+
+func TestConsoleAccountsDeduplicateBrowserSessions(t *testing.T) {
+	f := newBrowserSessionFixture(t)
+	f.add(t, 0, 10, true)
+	f.add(t, 1, 20, false)
+	f.add(t, 2, 10, false)
+	f.add(t, 3, 10, false)
+	for _, test := range []struct{ activeSlot, expectedSlot int }{{0, 2}, {3, 3}, {1, 2}} {
+		accounts := f.service.consoleAccounts(f.service.db, f.context(test.activeSlot), f.now)
+		if len(accounts) != 2 {
+			t.Fatalf("active slot %d returned %d accounts: %#v", test.activeSlot, len(accounts), accounts)
+		}
+		for _, account := range accounts {
+			if account.AgentID == "10" && (account.Expired || account.Slot != test.expectedSlot) {
+				t.Fatalf("wrong representative for duplicate account: %#v", account)
+			}
+		}
+	}
+}
+
+func TestEmailLoginReusesExistingBrowserAccountSlot(t *testing.T) {
+	for _, expired := range []bool{false, true} {
+		t.Run(fmt.Sprintf("expired=%t", expired), func(t *testing.T) {
+			f := newBrowserSessionFixture(t)
+			first := f.add(t, 0, 10, false)
+			target := f.add(t, 2, 20, expired)
+			c := f.context(0)
+			slot, sessionID := f.service.chooseEmailLoginSessionSlot(f.service.db, c, 20)
+			if slot != 2 || sessionID != target {
+				t.Fatalf("existing target got slot=%d session=%q", slot, sessionID)
+			}
+			slot, sessionID = f.service.chooseEmailLoginSessionSlot(f.service.db, c, 30)
+			if slot != 0 || sessionID != first {
+				t.Fatalf("new normal login changed slot-zero replacement: slot=%d session=%q", slot, sessionID)
+			}
+		})
+	}
+}
+
+func TestConsoleSlotSelectionPrefersTargetAndReclaimsDuplicates(t *testing.T) {
+	f := newBrowserSessionFixture(t)
+	for slot, agentID := range []int64{10, 20, 30, 20, 40} {
+		f.add(t, slot, agentID, false)
+	}
+	c := f.context(3)
+	slot, sessionID, accounts, err := f.service.chooseConsoleSessionSlot(f.service.db, c, 20, 10, f.now)
+	if err != nil || slot != 3 || sessionID != "session-20-3" || len(accounts) != 4 {
+		t.Fatalf("existing target must win over replacement: slot=%d session=%q accounts=%#v err=%v", slot, sessionID, accounts, err)
+	}
+	slot, sessionID, _, err = f.service.chooseConsoleSessionSlot(f.service.db, c, 50, 0, f.now)
+	if err != nil || slot != 3 || sessionID != "session-20-3" {
+		t.Fatalf("duplicate slot was counted as another account: slot=%d session=%q err=%v", slot, sessionID, err)
+	}
+}
+
+func TestConsoleSlotSelectionPreservesFiveDistinctAccountLimit(t *testing.T) {
+	f := newBrowserSessionFixture(t)
+	for slot := 0; slot < maxConsoleAccountSlots; slot++ {
+		f.add(t, slot, int64(slot+10), false)
+	}
+	_, _, accounts, err := f.service.chooseConsoleSessionSlot(f.service.db, f.context(0), 99, 0, f.now)
+	if err != errConsoleAccountLimit || len(accounts) != maxConsoleAccountSlots {
+		t.Fatalf("distinct-account limit changed: accounts=%#v err=%v", accounts, err)
+	}
+}
+
+func TestConsoleSlotSelectionReclaimsCookieAliasWithoutRevokingSharedSession(t *testing.T) {
+	f := newBrowserSessionFixture(t)
+	f.add(t, 0, 10, false)
+	shared := f.add(t, 1, 20, false)
+	f.add(t, 2, 30, false)
+	f.cookies = append(f.cookies, consoleSessionCookieName(3)+"="+shared+".secret")
+	f.add(t, 4, 40, false)
+	slot, revokedSessionID, _, err := f.service.chooseConsoleSessionSlot(f.service.db, f.context(0), 50, 0, f.now)
+	if err != nil || slot != 3 || revokedSessionID != "" {
+		t.Fatalf("reclaiming an alias would revoke the retained account's only session: slot=%d revoked=%q err=%v", slot, revokedSessionID, err)
+	}
+}
+
+func TestRemoveAndLogoutClearEveryBrowserSlotForAccount(t *testing.T) {
+	for _, logout := range []bool{false, true} {
+		t.Run(fmt.Sprintf("logout=%t", logout), func(t *testing.T) {
+			f := newBrowserSessionFixture(t)
+			f.add(t, 0, 10, false)
+			f.add(t, 1, 20, false)
+			duplicate := f.add(t, 2, 10, false)
+			f.cookies = append(f.cookies, consoleSessionCookieName(3)+"="+duplicate+".secret")
+			otherDevice := f.add(t, -1, 10, false)
+			forged := f.add(t, -2, 30, false)
+			f.cookies = append(f.cookies, consoleSessionCookieName(4)+"="+forged+".wrong-secret")
+			h := server.New(server.WithHostPorts("127.0.0.1:0"))
+			path := "/api/v2/console/accounts/10"
+			if logout {
+				path = "/api/v2/console/session"
+				h.DELETE(path, f.service.consoleAuth(true), f.service.deleteConsoleSession)
+			} else {
+				h.DELETE("/api/v2/console/accounts/:agent_id", f.service.consoleAuth(true), f.service.removeConsoleAccount)
+			}
+			status, payload, cookies := performJSON(t, h, http.MethodDelete, path, map[string]interface{}{},
+				ut.Header{Key: "Cookie", Value: f.cookieHeader(2)}, ut.Header{Key: "X-CSRF-Token", Value: "csrf"})
+			if status != http.StatusOK || responseData(t, payload)["active_agent_id"] != "20" {
+				t.Fatalf("account removal did not switch to the distinct account: status=%d payload=%#v", status, payload)
+			}
+			for _, slot := range []int{0, 2, 3} {
+				for _, cookieName := range []string{consoleSessionCookieName(slot), consoleCSRFCookieName(slot)} {
+					found := false
+					for _, cookie := range cookies {
+						if strings.Contains(string(cookie), cookieName+"=; max-age=0;") {
+							found = true
+						}
+					}
+					if !found {
+						t.Fatalf("cookie %s was not cleared: %q", cookieName, cookies)
+					}
+				}
+			}
+			for _, sessionID := range []string{"session-20-1", otherDevice, forged} {
+				var sessionStatus string
+				if err := f.service.db.Raw(`SELECT status FROM console_v2_sessions WHERE session_id = ?`, sessionID).Scan(&sessionStatus).Error; err != nil {
+					t.Fatal(err)
+				}
+				if sessionStatus != "active" {
+					t.Fatalf("unrelated or unproven session %q was revoked", sessionID)
+				}
+			}
+			accounts := f.service.consoleAccounts(f.service.db, f.context(1), f.now)
+			if len(accounts) != 1 || accounts[0].AgentID != "20" {
+				t.Fatalf("removed account reappeared through a duplicate slot: %#v", accounts)
+			}
+		})
+	}
+}
+
+func TestRemoveConsoleAccountUsesAuthenticatedFallbackSlot(t *testing.T) {
+	f := newBrowserSessionFixture(t)
+	f.add(t, 0, 20, true)
+	f.add(t, 1, 10, false)
+	f.add(t, 2, 30, false)
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	h.DELETE("/api/v2/console/accounts/:agent_id", f.service.consoleAuth(true), f.service.removeConsoleAccount)
+	status, payload, _ := performJSON(t, h, http.MethodDelete, "/api/v2/console/accounts/10", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: f.cookieHeader(0)}, ut.Header{Key: "X-CSRF-Token", Value: "csrf"})
+	if status != http.StatusOK || responseData(t, payload)["active_agent_id"] != "30" {
+		t.Fatalf("removal reported a revoked fallback account as active: status=%d payload=%#v", status, payload)
+	}
+}
+
+func TestActivateConsoleAccountUsesValidDuplicateSession(t *testing.T) {
+	f := newBrowserSessionFixture(t)
+	f.add(t, 0, 10, true)
+	f.add(t, 1, 20, false)
+	f.add(t, 2, 10, false)
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	h.POST("/api/v2/console/accounts/:agent_id/activate", f.service.consoleAuth(true), f.service.activateConsoleAccount)
+	status, payload, _ := performJSON(t, h, http.MethodPost, "/api/v2/console/accounts/10/activate", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: f.cookieHeader(1)}, ut.Header{Key: "X-CSRF-Token", Value: "csrf"})
+	if status != http.StatusOK || responseData(t, payload)["slot"] != float64(2) {
+		t.Fatalf("activation selected expired duplicate: status=%d payload=%#v", status, payload)
+	}
+	var sessionCount int64
+	if err := f.service.db.Table("console_v2_sessions").Count(&sessionCount).Error; err != nil || sessionCount != 3 {
+		t.Fatalf("activation unexpectedly created a session: count=%d err=%v", sessionCount, err)
+	}
+}

--- a/api/consolev2/email_handlers.go
+++ b/api/consolev2/email_handlers.go
@@ -948,10 +948,8 @@ func (s *Service) verifyEmailLogin(_ context.Context, c *app.RequestContext) {
 			if slotErr != nil {
 				return slotErr
 			}
-		} else if credential, ok := consoleCredential(c, 0); ok {
-			if existing, loadErr := s.loadConsoleSessionCredential(tx, credential); loadErr == nil {
-				replacedSessionID = existing.SessionID
-			}
+		} else {
+			selectedSlot, replacedSessionID = s.chooseEmailLoginSessionSlot(tx, c, recoveredAgentID)
 		}
 		consume := tx.Exec(`UPDATE v2_email_challenges SET status = 'consumed', consumed_at = ?
 			WHERE challenge_id = ? AND status = 'pending'`, now, req.ChallengeID)

--- a/api/consolev2/onboarding_handlers.go
+++ b/api/consolev2/onboarding_handlers.go
@@ -217,6 +217,11 @@ func (s *Service) deleteConsoleSession(_ context.Context, c *app.RequestContext)
 		return
 	}
 	now := time.Now().UnixMilli()
+	currentAgentID, _ := agentID(c)
+	if _, err := s.revokeConsoleAccountSessions(c, currentAgentID, now); err != nil {
+		fail(c, http.StatusInternalServerError, "LOGOUT_FAILED", "could not revoke Console V2 session", nil)
+		return
+	}
 	if err := s.db.Exec(`UPDATE console_v2_sessions SET status = 'revoked', revoked_at = ?
 		WHERE session_id = ? AND status = 'active'`, now, sessionID).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "LOGOUT_FAILED", "could not revoke Console V2 session", nil)

--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -97,14 +97,17 @@ with `_1` through `_4` suffixes. `ef_console_v2_active` identifies the active
 slot and contains no credential material. Session cookies remain HttpOnly and
 CSRF cookies remain readable only for the matching active slot.
 
-`GET /api/v2/console/accounts` lists browser accounts,
+`GET /api/v2/console/accounts` lists each Agent once, preferring a valid session
+and then the active slot when historical duplicate sessions exist.
 `POST /api/v2/console/accounts/{agent_id}/activate` switches the active slot,
-and `DELETE /api/v2/console/accounts/{agent_id}` revokes and removes one slot.
-Logging out revokes only the active slot and falls through to another valid
-slot when available.
+and `DELETE /api/v2/console/accounts/{agent_id}` revokes and removes every browser
+slot for that Agent. Logging out removes the active Agent's browser slots and
+falls through to another valid account when available. Sessions on other devices
+remain unchanged. Ordinary email login refreshes the Agent's existing browser
+slot; a new Agent replaces slot zero.
 
 Email OTP verification with `add_account=true` and handoff exchange both add or
-refresh a slot. At five valid accounts they return
+refresh a slot. Duplicate slots are reusable capacity. At five distinct valid accounts they return
 `CONSOLE_ACCOUNT_LIMIT_REACHED` with the replaceable account list. The verified
 OTP challenge or handoff remains unconsumed. Retrying with `replace_agent_id`
 atomically revokes the selected session, consumes the proof, creates the new


### PR DESCRIPTION
Normal email login previously always replaced slot zero, even when the same Agent already had a browser session in another slot. Listing each slot separately exposed duplicate account IDs and caused duplicate React rows when accounts were reordered.

Reuse an existing target Agent slot on login and return one account per Agent, preferring a valid active session. Reclaim duplicate slots when adding an account without exceeding the five-distinct-account limit. Removing or logging out an account revokes all proven sessions for that Agent in this browser, including cookie aliases, while preserving other accounts and sessions on other devices. Use the middleware-authenticated slot when an expired active cookie falls back to another account.

Validation: `go test ./api/consolev2 -count=1` and `go build -o build/api ./api` passed. Eight new regression tests cover duplicate ordering, normal login, slot capacity, cookie aliases, removal/logout, authentication fallback, and activation. New tests use SQLite and the Hertz handler boundary; existing PostgreSQL integration tests remain conditional on PG_DSN. Independent review found no blocking issues. No migration or RPC rollout is required.
