### PR TITLE
docs(skills): require version bumps and document automatic publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ After each code change, check if documentation needs updating, especially README
 
 ## Agent skills
 
+Before modifying any file under `skills/`, read and follow [skills/AGENTS.md](skills/AGENTS.md).
+
 ### Issue tracker
 
 Issues tracked in GitHub Issues (`phronesis-io/eigenflux`) via the `gh` CLI; external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,44 @@
+# Skills maintenance
+
+Read this file before modifying anything under `skills/`.
+
+## Editing rules
+
+- Every change to an existing Skill must increase `metadata.version` in its
+  `SKILL.md` in the same commit. Include changes to references, scripts, and
+  assets. Increase at least the patch version relative to `main`; upgrade each
+  affected Skill. Give new Skills an explicit version.
+- Use concise, imperative instructions. Keep only necessary context and steps.
+  Omit repetition, filler, examples, and counterexamples.
+- Keep installation instructions in [install.md](install.md); link to that
+  source wherever installation guidance is needed.
+- Raise `SKILLS_MIN_CLI_VERSION` in `cli/.cli.config` when new instructions
+  require a newer CLI.
+
+## Automatic publishing
+
+Changes under `skills/**` merged into `main` trigger
+[Release Skills](../.github/workflows/release-skills.yml). Runs are serialized
+and check out current `main`. After tests pass,
+[release-skills.sh](../cli/scripts/release-skills.sh) builds and signs the
+production `ef-*` Skills bundle, excluding `ef-localdev`, then publishes the
+bundle and manifest to R2 at `skills/latest/` and `cli/latest/` and verifies
+the public CDN downloads.
+
+The workflow also publishes `install.md` unchanged to
+<https://cdn.eigenflux.ai/skills/latest/install.md> and verifies its content
+and `Cache-Control: no-store`. The `/install` page's `/r/:ref` entry points to
+this URL, so installation instructions refresh without an API redeployment.
+
+Clients adopt compatible updates on their next Skills sync. Content hashes
+determine the bundle `revision`; signed releases use an increasing `sequence`.
+The publisher does not increment Skill versions or enforce version bumps;
+editors must update `metadata.version` themselves. Pure Skills changes need
+no CLI or plugin release.
+
+The root `install.md` and this maintenance file are outside the Skills
+bundle and have no Skill version. Editing them still triggers the workflow;
+leave unrelated Skill versions unchanged.
+
+After merging, verify the workflow's publish step and live CDN content. The
+later `static/feed_contract.md` sync can fail independently after publishing.


### PR DESCRIPTION
Skills editors need one discoverable maintenance guide so instruction changes consistently include their version update. Add `skills/AGENTS.md` and a mandatory read link in the root `AGENTS.md`.

The guide requires a version increase for each changed Skill, including its references, scripts, and assets; concise imperative wording without examples or filler; and reuse of the canonical installation instructions. It describes the existing main-triggered publication workflow, the independent installation document, and adoption on the next compatible client sync. Root maintenance and installation documents do not have a Skill version.

Validation:
- Independent review against the current publisher and client sync implementation.
- 25 Python release tests passed; Markdown links and `git diff --check` passed.
- Latest Release Skills run [34324314958](https://github.com/phronesis-io/eigenflux/actions/runs/34324314958) and its preceding five runs succeeded.
- Live `skills/latest` and `cli/latest` manifests agree on sequence 12 and revision `d5ae241e629ae7c6`; both archives match all 17 main source files and their published checksum.
- Live installation instructions match main byte-for-byte and return `Cache-Control: no-store`.

Only documentation changes. The existing workflow already covers `skills/**`, including this new guide.
