### PR TITLE
fix: return broadcast detail read and helpful counts

### DIFF
--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -1022,9 +1022,18 @@ func GetItem(ctx context.Context, c *app.RequestContext) {
 		detail["distribution_skip_reason"] = skipReason
 	}
 
+	// Aggregate counters are visible to every caller allowed to read the item.
+	stats, statsErr := itemdal.GetItemStatsByID(db.DB, req.ItemID)
+	if statsErr == nil {
+		detail["consumed_count"] = stats.ConsumedCount
+		detail["praise_count"] = stats.Score1Count + stats.Score2Count
+	} else if !errors.Is(statsErr, gorm.ErrRecordNotFound) {
+		logger.Ctx(ctx).Warn("GetItem failed to load aggregate stats", "itemID", req.ItemID, "err", statsErr)
+	}
+
 	// Interaction details (who scored this broadcast, with what score and when)
 	// are private to the author. Gate on ownership so only the author sees them.
-	if stats, statsErr := itemdal.GetItemStatsByID(db.DB, req.ItemID); statsErr == nil && stats.AuthorAgentID == agentID {
+	if statsErr == nil && stats.AuthorAgentID == agentID {
 		// Count only "found helpful" (1/2), matching GetRecentItemInteractions'
 		// interface-layer filter so the total lines up with the returned list.
 		detail["interaction_total"] = stats.Score1Count + stats.Score2Count

--- a/api/handler_gen/eigenflux/api/item_stats_test.go
+++ b/api/handler_gen/eigenflux/api/item_stats_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"eigenflux_server/pkg/db"
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/route/param"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetItemAggregateStats(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := database.DB()
+	sqlDB.SetMaxOpenConns(1)
+	defer sqlDB.Close()
+	previous := db.DB
+	db.DB = database
+	defer func() { db.DB = previous }()
+	for _, query := range []string{
+		`CREATE TABLE raw_items (item_id INTEGER PRIMARY KEY, author_agent_id INTEGER, raw_content TEXT, raw_url TEXT)`,
+		`CREATE TABLE processed_items (item_id INTEGER PRIMARY KEY, status INTEGER)`,
+		`CREATE TABLE item_stats (item_id INTEGER PRIMARY KEY, author_agent_id INTEGER, consumed_count INTEGER, score_1_count INTEGER, score_2_count INTEGER)`,
+		`CREATE TABLE agents (agent_id INTEGER PRIMARY KEY, short_id TEXT, agent_name TEXT, agent_name_en TEXT, identity_state TEXT)`,
+		`CREATE TABLE feedback_logs (item_id INTEGER, agent_id INTEGER, score INTEGER, feedback_at INTEGER)`,
+		`CREATE TABLE agent_settings (agent_id INTEGER, show_add_friend BOOLEAN)`,
+		`CREATE TABLE user_relations (from_uid INTEGER, to_uid INTEGER, rel_type INTEGER)`,
+		`INSERT INTO raw_items VALUES (7, 42, 'broadcast', ''), (8, 42, 'new broadcast', ''), (9, 42, 'unknown statistics', '')`,
+		`INSERT INTO processed_items VALUES (7, 3), (8, 3), (9, 3)`,
+		`INSERT INTO item_stats VALUES (7, 42, 153, 12, 4), (8, 42, 0, 0, 0)`,
+	} {
+		if err := database.Exec(query).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct {
+		name, itemID   string
+		viewer         int64
+		reads, helpful float64
+		known          bool
+	}{
+		{"non-author", "7", 99, 153, 16, true},
+		{"author", "7", 42, 153, 16, true},
+		{"stored zero", "8", 99, 0, 0, true},
+		{"missing stats", "9", 99, 0, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := app.NewContext(1)
+			c.Request.SetRequestURI("/api/v1/items/" + tc.itemID)
+			c.Request.Header.SetMethod("GET")
+			c.Params = param.Params{{Key: "item_id", Value: tc.itemID}}
+			c.Set("agent_id", tc.viewer)
+			GetItem(context.Background(), c)
+			var result struct {
+				Code int
+				Data struct{ Item map[string]interface{} }
+			}
+			if err := json.Unmarshal(c.Response.Body(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if c.Response.StatusCode() != 200 || result.Code != 0 {
+				t.Fatalf("response: %s", c.Response.Body())
+			}
+			item := result.Data.Item
+			for key, want := range map[string]float64{"consumed_count": tc.reads, "praise_count": tc.helpful} {
+				got, exists := item[key]
+				if exists != tc.known || (exists && got != want) {
+					t.Errorf("%s=%v (present %v), want %v (present %v)", key, got, exists, want, tc.known)
+				}
+			}
+			for _, key := range []string{"interaction_total", "recent_interactions"} {
+				_, exists := item[key]
+				if exists != (tc.viewer == 42 && tc.known) {
+					t.Errorf("unexpected visibility for %s: %v", key, item)
+				}
+			}
+		})
+	}
+}

--- a/api/handler_gen/eigenflux/api/response.go
+++ b/api/handler_gen/eigenflux/api/response.go
@@ -202,6 +202,8 @@ type GetItemData struct {
 }
 
 type GetItemInfo struct {
+	ConsumedCount    *int64   `json:"consumed_count,omitempty"`
+	PraiseCount      *int64   `json:"praise_count,omitempty"`
 	ItemID           string   `json:"item_id"`
 	Summary          string   `json:"summary,omitempty"`
 	BroadcastType    string   `json:"broadcast_type,omitempty"`

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -265,6 +265,12 @@ Source of truth is `skills/ef-broadcast/references/contract.md`. The handler rea
 
 ## Item Detail Interactions
 
+For every authorized item reader, `data.item.consumed_count` contains the stored
+read counter and `data.item.praise_count` is the sum of score 1 and score 2
+feedback counters. Both come from `item_stats`. Zero is returned when stored;
+missing or unavailable statistics omit these fields, and clients must display
+an unknown value rather than infer zero. Individual feedback remains author-only.
+
 `GET /api/v1/items/:item_id` returns, **only when the caller is the item's author**, two extra fields in `data.item`:
 
 - `recent_interactions` — up to 15 most recent scoring-feedback events, newest first. Each entry: `agent_id` (string), `agent_name` (original string), `agent_name_en` (model-generated English display string, possibly empty while pending), `score` (-1/0/1/2), and `feedback_at` (epoch ms). Sourced from `feedback_logs` left-joined with `agents` (`itemdal.GetRecentItemInteractions`).


### PR DESCRIPTION
Broadcast detail omitted read counts, so opening a homepage broadcast showed 0 despite stored consumption. Return consumed_count and praise_count from item_stats to authorized readers, while retaining author-only access to individual feedback. Missing stats remain absent rather than becoming a fabricated zero.

Validation: API handler tests pass, including HTTP-context/database regression cases for non-author, author, stored zero and missing stats; API binary builds successfully. A read-only production check of the reported broadcast found consumed_count=153 and helpful count=16. No production data changed.
