### PR TITLE
fix: distinguish Alipay authorization service failures

### DIFF
--- a/api/tradebff/alipay_authorization.go
+++ b/api/tradebff/alipay_authorization.go
@@ -241,6 +241,9 @@ func (s *AlipayAuthorization) Callback(ctx context.Context, c *app.RequestContex
 	a.Status = "rejected"
 	code := c.Query("auth_code")
 	if code != "" && len(code) <= 512 && c.Query("error") == "" {
+		// Service/configuration errors are not evidence of account rejection.
+		// Only a documented verification denial may be classified as rejected.
+		a.Status = "failed"
 		body, _ := json.Marshal(map[string]string{"authorization": code})
 		result, err := s.trade.fetch(ctx, a.AgentID, "payout:bind", "wallet.authorization.verify", http.MethodPost, "/api/v1/wallet/alipay/authorization/verify", nil, body, "verify-"+id[:48], true)
 		if err == nil {
@@ -251,6 +254,11 @@ func (s *AlipayAuthorization) Callback(ctx context.Context, c *app.RequestContex
 				a.Status = "authorized"
 				a.Code = code
 				a.MaskedDisplay = preview.MaskedDisplay
+			}
+		} else {
+			var upstream *UpstreamError
+			if errors.As(err, &upstream) && upstream.Status == http.StatusBadRequest && upstream.ErrorCode == "PAYMENT_INVALID_ARGUMENT" {
+				a.Status = "rejected"
 			}
 		}
 	}

--- a/api/tradebff/client.go
+++ b/api/tradebff/client.go
@@ -20,15 +20,17 @@ type CommissionClient struct {
 }
 
 type commissionEnvelope struct {
-	Code int             `json:"code"`
-	Msg  string          `json:"msg"`
-	Data json.RawMessage `json:"data"`
+	Code      int             `json:"code"`
+	ErrorCode string          `json:"error_code"`
+	Msg       string          `json:"msg"`
+	Data      json.RawMessage `json:"data"`
 }
 
 type UpstreamError struct {
-	Status int
-	Code   int
-	Msg    string
+	Status    int
+	Code      int
+	Msg       string
+	ErrorCode string
 }
 
 func (e *UpstreamError) Error() string { return "Commission request failed" }
@@ -82,7 +84,7 @@ func (c *CommissionClient) Do(ctx context.Context, token, method, path string, q
 		if status < 400 || status > 599 {
 			status = http.StatusBadGateway
 		}
-		return nil, &UpstreamError{Status: status, Code: envelope.Code, Msg: envelope.Msg}
+		return nil, &UpstreamError{Status: status, Code: envelope.Code, Msg: envelope.Msg, ErrorCode: envelope.ErrorCode}
 	}
 	if len(envelope.Data) == 0 || string(envelope.Data) == "null" {
 		return json.RawMessage(`{}`), nil

--- a/docs/dev/alipay-payout-authorization.md
+++ b/docs/dev/alipay-payout-authorization.md
@@ -10,11 +10,13 @@ All initiator routes use existing Console session auth. POST routes retain Origi
 - Public provider callback: GET `/api/v2/console/alipay/authorization/callback`.
 - Credential-free result page: GET `/api/v2/console/alipay/authorization/result`.
 
-Responses contain `authorization_id`, `status`, RFC3339 `expires_at`, optional `authorization_url` while pending, and `masked_display` after verification. Status values are pending/authorized/rejected/expired/confirmed. Missing retained state returns 410. Another Console session returns 403 even for the same Agent. All responses are private/no-store.
+Responses contain `authorization_id`, `status`, RFC3339 `expires_at`, optional `authorization_url` while pending, and `masked_display` after verification. Status values are pending/authorized/rejected/failed/expired/confirmed. Missing retained state returns 410. Another Console session returns 403 even for the same Agent. All responses are private/no-store.
+
+`failed` means verification could not complete because of a service, configuration, transport, or response-contract error; it does not imply failed real-name verification. Only a provider callback denial/missing code or Commission HTTP 400 `PAYMENT_INVALID_ARGUMENT` is classified as `rejected`. No upstream diagnostics are exposed. Both states are terminal and require a newly initiated attempt, never replay of the consumed callback. Older clients cannot confirm either state; clients should handle unknown statuses without enabling confirmation.
 
 ## Data and security
 
-Existing Redis holds ten-minute attempts. The owner is a hash of authenticated Agent and Console session IDs. Separate random query IDs and callback state prevent QR possession from granting query/confirmation access. Initiation uses atomic idempotency; callback consumes state once, calls Commission's body-bound delegated verification endpoint, and records only an authorized/rejected result. It never invokes Wallet Bind. Provider callback codes are briefly retained server-side, never returned or logged; successful confirmation discards them. Reverse-proxy/access logging must redact callback query parameters, and the callback redirects immediately to a no-referrer result page.
+Existing Redis holds ten-minute attempts. The owner is a hash of authenticated Agent and Console session IDs. Separate random query IDs and callback state prevent QR possession from granting query/confirmation access. Initiation uses atomic idempotency; callback consumes state once, calls Commission's body-bound delegated verification endpoint, and records only an authorized/rejected/failed result. It never invokes Wallet Bind. Provider callback codes are briefly retained server-side only after successful verification, never returned or logged; successful confirmation discards them. Reverse-proxy/access logging must redact callback query parameters, and the callback redirects immediately to a no-referrer result page.
 
 Confirmation uses the attempt's stable server-generated Wallet idempotency key. A malformed Wallet success is not displayed as confirmed. Existing Wallet risk, append-only binding, and cooling invariants apply.
 
@@ -55,7 +57,7 @@ EigenFlux BFF needs `ALIPAY_AUTH_APP_ID`, `ALIPAY_AUTH_CALLBACK_URL` (fixed HTTP
 
 Commission Payment separately needs `ALIPAY_PAYOUT_AUTH_ENABLED=true`, existing Redis configuration, and its existing Alipay credentials. BFF App ID and environment must match Payment. The merchant must enable website user authorization and register the callback domain. The callback and result paths must reach EigenFlux API through the reverse proxy.
 
-Only UID-based certified normal accounts are currently supported; OpenID-only results fail closed. `clear` means approved provider account-state evidence plus separate existing Wallet risk enforcement, not a global fraud guarantee. The production payee resolver remains absent in Commission; do not enable this binding feature for general production use or claim actual withdrawal readiness until that separate gap is resolved.
+Commission verification supports matching UID or application/environment-scoped OpenID evidence, with certification and normal account status required. `clear` means approved provider account-state evidence plus separate existing Wallet risk enforcement, not a global fraud guarantee. The production payee resolver remains absent in Commission; do not enable this binding feature for general production use or claim actual withdrawal readiness until that separate gap is resolved.
 
 ## Verification
 

--- a/tests/tradebff/alipay_authorization_test.go
+++ b/tests/tradebff/alipay_authorization_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +26,102 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAlipayAuthorizationVerificationOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name, payload, query, want string
+		status                     int
+		transportFailure           bool
+	}{
+		{name: "disabled", status: 501, payload: `{"code":501,"error_code":"PAYMENT_UNSUPPORTED","msg":"private-diagnostic"}`, want: "failed"},
+		{name: "upstream unavailable", status: 503, payload: `{"code":503}`, want: "failed"},
+		{name: "delegation denied", status: 403, payload: `{"code":403,"error_code":"AUTH_FORBIDDEN"}`, want: "failed"},
+		{name: "rate limited", status: 429, payload: `{"code":429}`, want: "failed"},
+		{name: "unclassified bad request", status: 400, payload: `{"code":400}`, want: "failed"},
+		{name: "transport", transportFailure: true, want: "failed"},
+		{name: "invalid JSON", status: 200, payload: `not-json`, want: "failed"},
+		{name: "missing account", status: 200, payload: `{"code":0,"data":{}}`, want: "failed"},
+		{name: "verification denied", status: 400, payload: `{"code":400,"error_code":"PAYMENT_INVALID_ARGUMENT","msg":"private-diagnostic"}`, want: "rejected"},
+		{name: "provider denied", query: "&error=access_denied", want: "rejected"},
+		{name: "authorized", status: 200, payload: `{"code":0,"data":{"masked_display":"****9012"}}`, want: "authorized"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var verifies atomic.Int32
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/api/v1/wallet/alipay/authorization/verify", r.URL.Path)
+				verifies.Add(1)
+				if tc.transportFailure {
+					conn, _, err := w.(http.Hijacker).Hijack()
+					require.NoError(t, err)
+					conn.Close()
+					return
+				}
+				w.WriteHeader(tc.status)
+				io.WriteString(w, tc.payload)
+			}))
+			defer upstream.Close()
+			_, private, err := ed25519.GenerateKey(rand.Reader)
+			require.NoError(t, err)
+			trade, err := tradebff.New(tradebff.Config{Endpoint: upstream.URL, DelegationKeyID: "test", DelegationPrivateKey: base64.RawURLEncoding.EncodeToString(private)})
+			require.NoError(t, err)
+			r := miniredis.RunT(t)
+			rdb := redis.NewClient(&redis.Options{Addr: r.Addr()})
+			defer rdb.Close()
+			auth := tradebff.NewAlipayAuthorization(trade, rdb, tradebff.AlipayAuthorizationConfig{AppID: "2026090800000001", CallbackURL: "https://console.example" + tradebff.AlipayAuthorizationCallbackPath, Production: true})
+			h := server.New()
+			identity := func(ctx context.Context, c *app.RequestContext) {
+				c.Set("agent_id", int64(42))
+				c.Set("console_session_id", "owner")
+				c.Next(ctx)
+			}
+			h.POST("/start", identity, auth.Start)
+			h.GET("/status/:authorization_id", identity, auth.Status)
+			h.POST("/confirm/:authorization_id", identity, auth.Confirm)
+			h.GET("/callback", auth.Callback)
+			startBody := `{"expected_agent_id":"42"}`
+			start := ut.PerformRequest(h.Engine, "POST", "/start", &ut.Body{Body: strings.NewReader(startBody), Len: len(startBody)}, ut.Header{Key: "Idempotency-Key", Value: "start"}).Result()
+			require.Equal(t, 200, start.StatusCode())
+			var response struct {
+				Data struct {
+					ID     string `json:"authorization_id"`
+					URL    string `json:"authorization_url"`
+					Status string `json:"status"`
+				}
+			}
+			require.NoError(t, json.Unmarshal(start.Body(), &response))
+			u, err := url.Parse(response.Data.URL)
+			require.NoError(t, err)
+			state := u.Query().Get("state")
+			callback := "/callback?state=" + state + "&auth_code=private-code" + tc.query
+			for i := 0; i < 2; i++ {
+				result := ut.PerformRequest(h.Engine, "GET", callback, nil).Result()
+				require.Equal(t, 303, result.StatusCode())
+				require.Equal(t, tradebff.AlipayAuthorizationResultPath, string(result.Header.Peek("Location")))
+			}
+			wantCalls := int32(1)
+			if tc.query != "" {
+				wantCalls = 0
+			}
+			require.Equal(t, wantCalls, verifies.Load(), "callback state must be consumed once")
+			result := ut.PerformRequest(h.Engine, "GET", "/status/"+response.Data.ID, nil).Result()
+			require.Equal(t, 200, result.StatusCode())
+			require.NoError(t, json.Unmarshal(result.Body(), &response))
+			require.Equal(t, tc.want, response.Data.Status)
+			for _, secret := range []string{"private-code", "private-diagnostic", state, "PAYMENT_UNSUPPORTED"} {
+				require.NotContains(t, string(result.Body()), secret)
+			}
+			if tc.want != "authorized" {
+				confirm := ut.PerformRequest(h.Engine, "POST", "/confirm/"+response.Data.ID, nil, ut.Header{Key: "Idempotency-Key", Value: "confirm"}).Result()
+				require.Equal(t, 409, confirm.StatusCode())
+				for _, key := range r.Keys() {
+					value, _ := r.Get(key)
+					require.NotContains(t, value, "private-code")
+					require.NotContains(t, value, "private-diagnostic")
+				}
+			}
+		})
+	}
+}
 
 func TestAlipayAuthorizationCrossDeviceAndExplicitConfirmation(t *testing.T) {
 	var verifies, binds int


### PR DESCRIPTION
Classify dependency/configuration/transport failures as failed, not account rejection. Preserve callback single-use state and explicit binding. Eleven result regressions, race tests, API tests/build and vet pass. API-only deployment; no migration or RPC rollout.