### PR TITLE
feat(console): add account-wide private message search

### DIFF
--- a/api/consolev2/communication_anchor_postgres_test.go
+++ b/api/consolev2/communication_anchor_postgres_test.go
@@ -1,0 +1,168 @@
+package consolev2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+)
+
+func TestPostgresCommunicationAnchorContinuationsAndSearchPreview(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for anchor PostgreSQL contracts")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	t.Cleanup(func() { tx.Rollback() })
+	exec := func(query string, args ...interface{}) {
+		t.Helper()
+		if err := tx.Exec(query, args...).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	base, now := time.Now().UnixNano(), time.Now().UnixMilli()
+	viewerID, peerID, convID := base, base+1, base+100
+	for _, id := range []int64{viewerID, peerID} {
+		shortID, err := agentidentity.GenerateShortID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		exec(`INSERT INTO agents (agent_id, short_id, email, agent_name, bio, created_at, updated_at)
+            VALUES (?, ?, ?, 'Anchor Peer', '', ?, ?)`, id, shortID, fmt.Sprintf("anchor-%d@example.test", id), now, now)
+	}
+	exec(`INSERT INTO conversations (conv_id, participant_a, participant_b, initiator_id,
+        last_sender_id, origin_type, origin_id, msg_count, status, updated_at, topic_status)
+        VALUES (?, ?, ?, ?, ?, 'friend', 0, 100, 0, ?, 1)`, convID, viewerID, peerID, viewerID, peerID, now)
+	for offset := int64(1); offset <= 100; offset++ {
+		exec(`INSERT INTO private_messages (msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at)
+            VALUES (?, ?, ?, ?, 'context message', true, ?)`, base+1000+offset, convID, peerID, viewerID, now+offset)
+	}
+	svc := &Service{db: tx}
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	h.GET("/conversations/:conv_id/messages", func(ctx context.Context, c *app.RequestContext) {
+		c.Set("agent_id", viewerID)
+		svc.listCommunicationMessages(ctx, c)
+	})
+	h.GET("/search", func(ctx context.Context, c *app.RequestContext) {
+		c.Set("agent_id", viewerID)
+		svc.searchCommunicationMessages(ctx, c)
+	})
+	request := func(t *testing.T, path string) map[string]interface{} {
+		t.Helper()
+		status, payload, _ := performJSON(t, h, http.MethodGet, path, nil)
+		if status != http.StatusOK {
+			t.Fatalf("status=%d payload=%#v", status, payload)
+		}
+		return responseData(t, payload)
+	}
+	historyPath := fmt.Sprintf("/conversations/%d/messages?", convID)
+	messageIDs := func(t *testing.T, data map[string]interface{}) []int64 {
+		t.Helper()
+		ids := []int64{}
+		for _, raw := range data["messages"].([]interface{}) {
+			ids = append(ids, mustParseInt64(t, raw.(map[string]interface{})["msg_id"].(string))-base-1000)
+		}
+		if len(ids) == 0 {
+			t.Fatal("history unexpectedly empty")
+		}
+		for i := 1; i < len(ids); i++ {
+			if ids[i] != ids[i-1]-1 {
+				t.Fatalf("non-contiguous history: %v", ids)
+			}
+		}
+		if !communicationReplyFits(data) {
+			t.Fatal("history exceeded response budget")
+		}
+		return ids
+	}
+	verifyOlder := func(t *testing.T, data map[string]interface{}) {
+		t.Helper()
+		ids := messageIDs(t, data)
+		expected := ids[len(ids)-1] - 1
+		for expected > 0 {
+			cursor, _ := data["next_cursor"].(string)
+			if data["has_more"] != true || cursor == "" {
+				t.Fatalf("lost older continuation before %d", expected)
+			}
+			data = request(t, historyPath+url.Values{"cursor": {cursor}}.Encode())
+			ids = messageIDs(t, data)
+			if ids[0] != expected {
+				t.Fatalf("continuation jumped from %d to %d", expected, ids[0])
+			}
+			expected = ids[len(ids)-1] - 1
+		}
+		if data["has_more"] != false || data["next_cursor"] != "" {
+			t.Fatal("history reports continuation past oldest message")
+		}
+	}
+	for _, test := range []struct{ anchor, limit, first, last int64 }{
+		{100, 20, 100, 91}, {95, 20, 100, 86}, {50, 20, 60, 41}, {1, 20, 11, 1},
+		{100, 1, 100, 100}, {50, 1, 50, 50}, {1, 1, 1, 1},
+	} {
+		t.Run(fmt.Sprintf("anchor_%d_limit_%d", test.anchor, test.limit), func(t *testing.T) {
+			data := request(t, historyPath+url.Values{"anchor_message_id": {strconv.FormatInt(base+1000+test.anchor, 10)}, "limit": {strconv.FormatInt(test.limit, 10)}}.Encode())
+			ids := messageIDs(t, data)
+			if ids[0] != test.first || ids[len(ids)-1] != test.last {
+				t.Fatalf("unexpected window: %v", ids)
+			}
+			verifyOlder(t, data)
+		})
+	}
+	exec(`UPDATE private_messages SET content=? WHERE conv_id=?`, strings.Repeat("长", 56000), convID)
+	for _, anchor := range []int64{100, 95, 50, 1} {
+		t.Run(fmt.Sprintf("large_context_anchor_%d", anchor), func(t *testing.T) {
+			data := request(t, historyPath+url.Values{"anchor_message_id": {strconv.FormatInt(base+1000+anchor, 10)}}.Encode())
+			ids := messageIDs(t, data)
+			found := false
+			for _, id := range ids {
+				found = found || id == anchor
+			}
+			if !found {
+				t.Fatalf("budget trimming removed anchor %d: %v", anchor, ids)
+			}
+			verifyOlder(t, data)
+		})
+	}
+	for _, test := range []struct{ content, query, match string }{
+		{strings.Repeat("a", 1500) + "NEEDLE" + strings.Repeat("b", 1500), "needle", "NEEDLE"},
+		{strings.Repeat("前", 1500) + "合同编号" + strings.Repeat("后", 1500), "合同编号", "合同编号"},
+		{strings.Repeat("前", 1500) + "_%!" + strings.Repeat("后", 1500), "_%!", "_%!"},
+	} {
+		exec(`UPDATE private_messages SET content=? WHERE msg_id=?`, test.content, base+1100)
+		data := request(t, "/search?"+url.Values{"q": {test.query}}.Encode())
+		rows := data["results"].([]interface{})
+		if len(rows) != 1 {
+			t.Fatalf("search rows=%#v", rows)
+		}
+		row := rows[0].(map[string]interface{})
+		preview := row["matched_message_preview"].(string)
+		if !strings.Contains(preview, test.match) || utf8.RuneCountInString(preview) > 1000 || row["matched_message_id"] != strconv.FormatInt(base+1100, 10) {
+			t.Fatalf("search preview lost match: %#v", row)
+		}
+	}
+}

--- a/api/consolev2/communication_handlers.go
+++ b/api/consolev2/communication_handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/cloudwego/hertz/pkg/app"
@@ -19,9 +20,10 @@ import (
 )
 
 const (
-	communicationDefaultLimit = 20
-	communicationMaxLimit     = 50
-	communicationMaxReplySize = 256 << 10
+	communicationDefaultLimit  = 20
+	communicationMaxLimit      = 50
+	communicationMaxReplySize  = 256 << 10
+	communicationSearchTimeout = 3 * time.Second
 )
 
 type communicationCardSummary struct {
@@ -82,8 +84,11 @@ type communicationSearchCursor struct {
 	ConvID    int64 `json:"c"`
 }
 
+// CommunicationSearchConversation makes the embedded fields visible to GORM.
+type CommunicationSearchConversation = communicationConversation
+
 type communicationSearchResult struct {
-	communicationConversation
+	CommunicationSearchConversation
 	MatchedBy      string `gorm:"column:matched_by" json:"matched_by"`
 	Remark         string `gorm:"column:remark" json:"remark,omitempty"`
 	MatchedMsgID   int64  `gorm:"column:matched_message_id" json:"matched_message_id,string"`
@@ -545,7 +550,9 @@ func (s *Service) loadViewerRelations(viewerID int64, peerIDs []int64) (map[int6
 	return result, nil
 }
 
-func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestContext) {
+func (s *Service) searchCommunicationMessages(ctx context.Context, c *app.RequestContext) {
+	ctx, cancel := context.WithTimeout(ctx, communicationSearchTimeout)
+	defer cancel()
 	viewerID, _ := agentID(c)
 	limit, err := parseCommunicationLimit(c)
 	if err != nil {
@@ -562,8 +569,18 @@ func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestC
 		fail(c, http.StatusBadRequest, "INVALID_CURSOR", err.Error(), nil)
 		return
 	}
-	pattern := "%" + queryText + "%"
-	prefix := queryText + "%"
+	// These search reads share one deadline without copying Service's locks.
+	s = &Service{db: s.db.WithContext(ctx)}
+	searchFail := func(code, message string) {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			fail(c, http.StatusGatewayTimeout, "MESSAGE_SEARCH_TIMEOUT", "message search timed out", nil)
+			return
+		}
+		fail(c, http.StatusInternalServerError, code, message, nil)
+	}
+	escaped := strings.NewReplacer("!", "!!", "%", "!%", "_", "!_").Replace(queryText)
+	pattern := "%" + escaped + "%"
+	prefix := escaped + "%"
 	cursorFilter := ""
 	cursorArgs := []interface{}{}
 	if cursor.MatchedAt > 0 {
@@ -580,34 +597,42 @@ func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestC
 			CASE e.topic_status WHEN 0 THEN 'pending_verify' WHEN 2 THEN 'closed' ELSE 'open' END AS topic_status,
 			e.peer_agent_id,
 			CASE WHEN lower(COALESCE(a.agent_name, '')) = lower(?) OR lower(COALESCE(a.agent_name_en, '')) = lower(?) OR lower(COALESCE(a.short_id, '')) = lower(?) THEN 0
-				 WHEN COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ? OR COALESCE(a.short_id, '') ILIKE ? THEN 1
-				 WHEN COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ? OR COALESCE(a.short_id, '') ILIKE ? THEN 2
-				 WHEN COALESCE(ur.remark, '') ILIKE ? THEN 3 ELSE 4 END AS match_rank,
-			CASE WHEN COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ? OR COALESCE(a.short_id, '') ILIKE ? THEN 'agent_name'
-				 WHEN COALESCE(ur.remark, '') ILIKE ? THEN 'remark' ELSE 'message' END AS matched_by,
+				 WHEN COALESCE(a.agent_name, '') ILIKE ? ESCAPE '!' OR COALESCE(a.agent_name_en, '') ILIKE ? ESCAPE '!' OR COALESCE(a.short_id, '') ILIKE ? ESCAPE '!' THEN 1
+				 WHEN COALESCE(a.agent_name, '') ILIKE ? ESCAPE '!' OR COALESCE(a.agent_name_en, '') ILIKE ? ESCAPE '!' OR COALESCE(a.short_id, '') ILIKE ? ESCAPE '!' THEN 2
+				 WHEN COALESCE(ur.remark, '') ILIKE ? ESCAPE '!' THEN 3 ELSE 4 END AS match_rank,
+			CASE WHEN COALESCE(a.agent_name, '') ILIKE ? ESCAPE '!' OR COALESCE(a.agent_name_en, '') ILIKE ? ESCAPE '!' OR COALESCE(a.short_id, '') ILIKE ? ESCAPE '!' THEN 'agent_name'
+				 WHEN COALESCE(ur.remark, '') ILIKE ? ESCAPE '!' THEN 'remark' ELSE 'message' END AS matched_by,
 			COALESCE(ur.remark, '') AS remark,
 			COALESCE(mm.msg_id, lm.msg_id) AS matched_message_id,
 			COALESCE(mm.sender_id, lm.sender_id) AS matched_sender_id,
 			COALESCE(mm.content, lm.content, '') AS matched_message_preview,
-			COALESCE(mm.created_at, lm.created_at, e.updated_at) AS matched_at,
-			CASE WHEN mm.msg_id IS NOT NULL THEN mm.match_count ELSE 0 END AS match_count
+			COALESCE(mm.created_at, lm.created_at, e.updated_at) AS matched_at
 		FROM eligible e
 		LEFT JOIN agents a ON a.agent_id = e.peer_agent_id
 		LEFT JOIN user_relations ur ON ur.from_uid = ? AND ur.to_uid = e.peer_agent_id AND ur.rel_type = 1
 		LEFT JOIN LATERAL (
-			SELECT pm.msg_id, pm.sender_id, pm.content, pm.created_at, COUNT(*) OVER () AS match_count
-			FROM private_messages pm WHERE pm.conv_id = e.conv_id AND pm.content ILIKE ?
+			SELECT pm.msg_id, pm.sender_id, pm.content, pm.created_at
+			FROM private_messages pm WHERE pm.conv_id = e.conv_id AND pm.content ILIKE ? ESCAPE '!'
 			ORDER BY pm.msg_id DESC LIMIT 1
 		) mm ON TRUE
 		LEFT JOIN LATERAL (
 			SELECT pm.msg_id, pm.sender_id, pm.content, pm.created_at FROM private_messages pm
 			WHERE pm.conv_id = e.conv_id ORDER BY pm.msg_id DESC LIMIT 1
 		) lm ON TRUE
-		WHERE COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ?
-			OR COALESCE(a.short_id, '') ILIKE ? OR COALESCE(ur.remark, '') ILIKE ? OR mm.msg_id IS NOT NULL
+		WHERE COALESCE(a.agent_name, '') ILIKE ? ESCAPE '!' OR COALESCE(a.agent_name_en, '') ILIKE ? ESCAPE '!'
+			OR COALESCE(a.short_id, '') ILIKE ? ESCAPE '!' OR COALESCE(ur.remark, '') ILIKE ? ESCAPE '!' OR mm.msg_id IS NOT NULL
+	), page AS MATERIALIZED (
+		SELECT * FROM candidates ` + cursorFilter + `
+		ORDER BY match_rank ASC, matched_at DESC, conv_id DESC LIMIT ?
+	), match_counts AS (
+		SELECT pm.conv_id, COUNT(*) AS match_count
+		FROM private_messages pm JOIN page ON page.conv_id = pm.conv_id
+		WHERE pm.content ILIKE ? ESCAPE '!'
+		GROUP BY pm.conv_id
 	)
-	SELECT * FROM candidates ` + cursorFilter + `
-	ORDER BY match_rank ASC, matched_at DESC, conv_id DESC LIMIT ?`
+	SELECT page.*, COALESCE(mc.match_count, 0) AS match_count
+	FROM page LEFT JOIN match_counts mc ON mc.conv_id = page.conv_id
+	ORDER BY page.match_rank ASC, page.matched_at DESC, page.conv_id DESC`
 	args := []interface{}{viewerID, viewerID, viewerID,
 		queryText, queryText, queryText,
 		prefix, prefix, prefix,
@@ -619,10 +644,10 @@ func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestC
 		pattern,
 		pattern, pattern, pattern, pattern}
 	args = append(args, cursorArgs...)
-	args = append(args, limit+1)
-	var rows []communicationSearchResult
+	args = append(args, limit+1, pattern)
+	rows := make([]communicationSearchResult, 0)
 	if err := s.db.Raw(sql, args...).Scan(&rows).Error; err != nil {
-		fail(c, http.StatusInternalServerError, "MESSAGE_SEARCH_FAILED", "could not search messages", nil)
+		searchFail("MESSAGE_SEARCH_FAILED", "could not search messages")
 		return
 	}
 	hasMore := len(rows) > limit
@@ -643,7 +668,7 @@ func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestC
 		}
 		if err := s.db.Raw(`SELECT conv_id, COUNT(*) AS count FROM private_messages
 			WHERE conv_id = ANY(?) AND receiver_id = ? AND is_read = false GROUP BY conv_id`, pq.Array(convIDs), viewerID).Scan(&unreadRows).Error; err != nil {
-			fail(c, http.StatusInternalServerError, "MESSAGE_SEARCH_FAILED", "could not read unread counts", nil)
+			searchFail("MESSAGE_SEARCH_FAILED", "could not read unread counts")
 			return
 		}
 		unreadByConversation := make(map[int64]int64, len(unreadRows))
@@ -656,12 +681,12 @@ func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestC
 	}
 	relations, err := s.loadViewerRelations(viewerID, peerIDs)
 	if err != nil {
-		fail(c, http.StatusInternalServerError, "MESSAGE_SEARCH_FAILED", "could not read relationship state", nil)
+		searchFail("MESSAGE_SEARCH_FAILED", "could not read relationship state")
 		return
 	}
 	contexts, err := s.loadCommunicationContexts(viewerID, peerIDs, relations)
 	if err != nil {
-		fail(c, http.StatusInternalServerError, "IDENTITY_READ_FAILED", "could not resolve Agent identities", nil)
+		searchFail("IDENTITY_READ_FAILED", "could not resolve Agent identities")
 		return
 	}
 	for index := range rows {

--- a/api/consolev2/communication_handlers.go
+++ b/api/consolev2/communication_handlers.go
@@ -186,6 +186,21 @@ func truncateRunes(value string, limit int) (string, bool) {
 	return string(runes[:limit]), true
 }
 
+func communicationSearchPreview(content, query string, limit int) string {
+	runes := []rune(content)
+	if len(runes) <= limit {
+		return content
+	}
+	start := 0
+	lowerContent := strings.ToLower(content)
+	if match := strings.Index(lowerContent, strings.ToLower(query)); match >= 0 {
+		matchStart := utf8.RuneCountInString(lowerContent[:match])
+		start = max(0, matchStart-(limit-utf8.RuneCountInString(query))/2)
+		start = min(start, len(runes)-limit)
+	}
+	return string(runes[start : start+limit])
+}
+
 func boundCommunicationMessage(message *communicationMessage, runeLimit int) {
 	if message == nil {
 		return
@@ -659,7 +674,7 @@ func (s *Service) searchCommunicationMessages(ctx context.Context, c *app.Reques
 	for index := range rows {
 		peerIDs = append(peerIDs, rows[index].PeerAgentID)
 		convIDs = append(convIDs, rows[index].ConvID)
-		rows[index].MatchedPreview, _ = truncateRunes(rows[index].MatchedPreview, 1000)
+		rows[index].MatchedPreview = communicationSearchPreview(rows[index].MatchedPreview, queryText, 1000)
 	}
 	if len(convIDs) > 0 {
 		var unreadRows []struct {
@@ -744,12 +759,13 @@ func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestCon
 		peerID = conversation.ParticipantB
 	}
 	messageSQL := `SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
-		FROM private_messages WHERE conv_id = ? AND (? = 0 OR msg_id < ?)
+		FROM private_messages WHERE conv_id = ? AND (CAST(? AS BIGINT) = 0 OR msg_id < ?)
 		ORDER BY msg_id DESC LIMIT ?`
 	messageArgs := []interface{}{convID, cursor, cursor, limit + 1}
-	if anchor > 0 && cursor == 0 {
-		olderLimit := (limit+1)/2 + 1
-		newerLimit := limit + 1 - olderLimit
+	anchored := anchor > 0 && cursor == 0
+	olderLimit := (limit + 1) / 2
+	if anchored {
+		newerLimit := limit - olderLimit
 		messageSQL = `SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at FROM (
 			SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
 			FROM private_messages WHERE conv_id = ? AND msg_id <= ? ORDER BY msg_id DESC LIMIT ?
@@ -759,7 +775,7 @@ func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestCon
 			SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
 			FROM private_messages WHERE conv_id = ? AND msg_id > ? ORDER BY msg_id ASC LIMIT ?
 		) newer ORDER BY msg_id DESC`
-		messageArgs = []interface{}{convID, anchor, olderLimit, convID, anchor, newerLimit}
+		messageArgs = []interface{}{convID, anchor, olderLimit + 1, convID, anchor, newerLimit}
 	}
 	query := s.db.Raw(messageSQL, messageArgs...)
 	var messages []communicationMessage
@@ -768,7 +784,18 @@ func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestCon
 		return
 	}
 	hasMore := len(messages) > limit
-	if hasMore {
+	if anchored {
+		olderCount := 0
+		for _, message := range messages {
+			if message.MsgID <= anchor {
+				olderCount++
+			}
+		}
+		hasMore = olderCount > olderLimit
+		if hasMore {
+			messages = messages[:len(messages)-1]
+		}
+	} else if hasMore {
 		messages = messages[:limit]
 	}
 	for index := range messages {
@@ -793,9 +820,25 @@ func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestCon
 		"messages": messages, "agent_contexts": contexts, "next_cursor": nextCursor, "has_more": hasMore,
 	}
 	for len(messages) > 1 && !communicationReplyFits(data) {
-		messages = messages[:len(messages)-1]
-		hasMore = true
-		nextCursor = strconv.FormatInt(messages[len(messages)-1].MsgID, 10)
+		anchorIndex := -1
+		if anchored {
+			for index, message := range messages {
+				if message.MsgID == anchor {
+					anchorIndex = index
+					break
+				}
+			}
+		}
+		// Trim only window edges, keeping the anchor and a continuous ID range.
+		if anchorIndex > 0 && anchorIndex >= len(messages)-1-anchorIndex {
+			messages = messages[1:]
+		} else {
+			messages = messages[:len(messages)-1]
+			hasMore = true
+		}
+		if hasMore {
+			nextCursor = strconv.FormatInt(messages[len(messages)-1].MsgID, 10)
+		}
 		data["messages"], data["next_cursor"], data["has_more"] = messages, nextCursor, hasMore
 	}
 	if !communicationReplyFits(data) {

--- a/api/consolev2/communication_handlers.go
+++ b/api/consolev2/communication_handlers.go
@@ -76,6 +76,24 @@ type conversationCursor struct {
 	TopicStatus int16 `json:"t"`
 }
 
+type communicationSearchCursor struct {
+	Rank      int   `json:"r"`
+	MatchedAt int64 `json:"m"`
+	ConvID    int64 `json:"c"`
+}
+
+type communicationSearchResult struct {
+	communicationConversation
+	MatchedBy      string `gorm:"column:matched_by" json:"matched_by"`
+	Remark         string `gorm:"column:remark" json:"remark,omitempty"`
+	MatchedMsgID   int64  `gorm:"column:matched_message_id" json:"matched_message_id,string"`
+	MatchedSender  int64  `gorm:"column:matched_sender_id" json:"matched_sender_id,string"`
+	MatchedPreview string `gorm:"column:matched_message_preview" json:"matched_message_preview"`
+	MatchedAt      int64  `gorm:"column:matched_at" json:"matched_at"`
+	MatchCount     int64  `gorm:"column:match_count" json:"match_count"`
+	MatchRank      int    `gorm:"column:match_rank" json:"-"`
+}
+
 func parseCommunicationLimit(c *app.RequestContext) (int, error) {
 	raw := c.Query("limit")
 	if raw == "" {
@@ -104,6 +122,26 @@ func decodeConversationCursor(raw string) (conversationCursor, error) {
 	var value conversationCursor
 	if json.Unmarshal(decoded, &value) != nil || value.UpdatedAt <= 0 || value.ConvID <= 0 {
 		return conversationCursor{}, errors.New("invalid cursor")
+	}
+	return value, nil
+}
+
+func encodeCommunicationSearchCursor(value communicationSearchCursor) string {
+	raw, _ := json.Marshal(value)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func decodeCommunicationSearchCursor(raw string) (communicationSearchCursor, error) {
+	if raw == "" {
+		return communicationSearchCursor{}, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return communicationSearchCursor{}, errors.New("invalid cursor")
+	}
+	var value communicationSearchCursor
+	if json.Unmarshal(decoded, &value) != nil || value.Rank < 0 || value.Rank > 4 || value.MatchedAt <= 0 || value.ConvID <= 0 {
+		return communicationSearchCursor{}, errors.New("invalid cursor")
 	}
 	return value, nil
 }
@@ -507,6 +545,146 @@ func (s *Service) loadViewerRelations(viewerID int64, peerIDs []int64) (map[int6
 	return result, nil
 }
 
+func (s *Service) searchCommunicationMessages(_ context.Context, c *app.RequestContext) {
+	viewerID, _ := agentID(c)
+	limit, err := parseCommunicationLimit(c)
+	if err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_LIMIT", err.Error(), nil)
+		return
+	}
+	queryText := strings.Join(strings.Fields(strings.TrimSpace(c.Query("q"))), " ")
+	if utf8.RuneCountInString(queryText) < 2 || utf8.RuneCountInString(queryText) > 100 {
+		fail(c, http.StatusBadRequest, "INVALID_QUERY", "q must contain between 2 and 100 characters", nil)
+		return
+	}
+	cursor, err := decodeCommunicationSearchCursor(c.Query("cursor"))
+	if err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_CURSOR", err.Error(), nil)
+		return
+	}
+	pattern := "%" + queryText + "%"
+	prefix := queryText + "%"
+	cursorFilter := ""
+	cursorArgs := []interface{}{}
+	if cursor.MatchedAt > 0 {
+		cursorFilter = `WHERE match_rank > ? OR (match_rank = ? AND (matched_at, conv_id) < (?, ?))`
+		cursorArgs = append(cursorArgs, cursor.Rank, cursor.Rank, cursor.MatchedAt, cursor.ConvID)
+	}
+	sql := `WITH eligible AS (
+		SELECT c.*, CASE WHEN c.participant_a = ? THEN c.participant_b ELSE c.participant_a END AS peer_agent_id
+		FROM conversations c
+		WHERE c.status = 0 AND c.msg_count >= 1 AND (c.participant_a = ? OR c.participant_b = ?)
+	), candidates AS (
+		SELECT e.conv_id, e.participant_a, e.participant_b, COALESCE(e.origin_type, '') AS origin_type,
+			COALESCE(e.origin_id, 0) AS origin_id, e.msg_count, e.updated_at,
+			CASE e.topic_status WHEN 0 THEN 'pending_verify' WHEN 2 THEN 'closed' ELSE 'open' END AS topic_status,
+			e.peer_agent_id,
+			CASE WHEN lower(COALESCE(a.agent_name, '')) = lower(?) OR lower(COALESCE(a.agent_name_en, '')) = lower(?) OR lower(COALESCE(a.short_id, '')) = lower(?) THEN 0
+				 WHEN COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ? OR COALESCE(a.short_id, '') ILIKE ? THEN 1
+				 WHEN COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ? OR COALESCE(a.short_id, '') ILIKE ? THEN 2
+				 WHEN COALESCE(ur.remark, '') ILIKE ? THEN 3 ELSE 4 END AS match_rank,
+			CASE WHEN COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ? OR COALESCE(a.short_id, '') ILIKE ? THEN 'agent_name'
+				 WHEN COALESCE(ur.remark, '') ILIKE ? THEN 'remark' ELSE 'message' END AS matched_by,
+			COALESCE(ur.remark, '') AS remark,
+			COALESCE(mm.msg_id, lm.msg_id) AS matched_message_id,
+			COALESCE(mm.sender_id, lm.sender_id) AS matched_sender_id,
+			COALESCE(mm.content, lm.content, '') AS matched_message_preview,
+			COALESCE(mm.created_at, lm.created_at, e.updated_at) AS matched_at,
+			CASE WHEN mm.msg_id IS NOT NULL THEN mm.match_count ELSE 0 END AS match_count
+		FROM eligible e
+		LEFT JOIN agents a ON a.agent_id = e.peer_agent_id
+		LEFT JOIN user_relations ur ON ur.from_uid = ? AND ur.to_uid = e.peer_agent_id AND ur.rel_type = 1
+		LEFT JOIN LATERAL (
+			SELECT pm.msg_id, pm.sender_id, pm.content, pm.created_at, COUNT(*) OVER () AS match_count
+			FROM private_messages pm WHERE pm.conv_id = e.conv_id AND pm.content ILIKE ?
+			ORDER BY pm.msg_id DESC LIMIT 1
+		) mm ON TRUE
+		LEFT JOIN LATERAL (
+			SELECT pm.msg_id, pm.sender_id, pm.content, pm.created_at FROM private_messages pm
+			WHERE pm.conv_id = e.conv_id ORDER BY pm.msg_id DESC LIMIT 1
+		) lm ON TRUE
+		WHERE COALESCE(a.agent_name, '') ILIKE ? OR COALESCE(a.agent_name_en, '') ILIKE ?
+			OR COALESCE(a.short_id, '') ILIKE ? OR COALESCE(ur.remark, '') ILIKE ? OR mm.msg_id IS NOT NULL
+	)
+	SELECT * FROM candidates ` + cursorFilter + `
+	ORDER BY match_rank ASC, matched_at DESC, conv_id DESC LIMIT ?`
+	args := []interface{}{viewerID, viewerID, viewerID,
+		queryText, queryText, queryText,
+		prefix, prefix, prefix,
+		pattern, pattern, pattern,
+		pattern,
+		pattern, pattern, pattern,
+		pattern,
+		viewerID,
+		pattern,
+		pattern, pattern, pattern, pattern}
+	args = append(args, cursorArgs...)
+	args = append(args, limit+1)
+	var rows []communicationSearchResult
+	if err := s.db.Raw(sql, args...).Scan(&rows).Error; err != nil {
+		fail(c, http.StatusInternalServerError, "MESSAGE_SEARCH_FAILED", "could not search messages", nil)
+		return
+	}
+	hasMore := len(rows) > limit
+	if hasMore {
+		rows = rows[:limit]
+	}
+	peerIDs := make([]int64, 0, len(rows))
+	convIDs := make([]int64, 0, len(rows))
+	for index := range rows {
+		peerIDs = append(peerIDs, rows[index].PeerAgentID)
+		convIDs = append(convIDs, rows[index].ConvID)
+		rows[index].MatchedPreview, _ = truncateRunes(rows[index].MatchedPreview, 1000)
+	}
+	if len(convIDs) > 0 {
+		var unreadRows []struct {
+			ConvID int64 `gorm:"column:conv_id"`
+			Count  int64 `gorm:"column:count"`
+		}
+		if err := s.db.Raw(`SELECT conv_id, COUNT(*) AS count FROM private_messages
+			WHERE conv_id = ANY(?) AND receiver_id = ? AND is_read = false GROUP BY conv_id`, pq.Array(convIDs), viewerID).Scan(&unreadRows).Error; err != nil {
+			fail(c, http.StatusInternalServerError, "MESSAGE_SEARCH_FAILED", "could not read unread counts", nil)
+			return
+		}
+		unreadByConversation := make(map[int64]int64, len(unreadRows))
+		for _, row := range unreadRows {
+			unreadByConversation[row.ConvID] = row.Count
+		}
+		for index := range rows {
+			rows[index].UnreadCount = unreadByConversation[rows[index].ConvID]
+		}
+	}
+	relations, err := s.loadViewerRelations(viewerID, peerIDs)
+	if err != nil {
+		fail(c, http.StatusInternalServerError, "MESSAGE_SEARCH_FAILED", "could not read relationship state", nil)
+		return
+	}
+	contexts, err := s.loadCommunicationContexts(viewerID, peerIDs, relations)
+	if err != nil {
+		fail(c, http.StatusInternalServerError, "IDENTITY_READ_FAILED", "could not resolve Agent identities", nil)
+		return
+	}
+	for index := range rows {
+		switch {
+		case rows[index].OriginType == "friend":
+			rows[index].Category = "friend"
+		case relations[rows[index].PeerAgentID] == "friend":
+			rows[index].Category = "broadcast_comment"
+		default:
+			rows[index].Category = "non_friend"
+		}
+	}
+	nextCursor := ""
+	if hasMore && len(rows) > 0 {
+		last := rows[len(rows)-1]
+		nextCursor = encodeCommunicationSearchCursor(communicationSearchCursor{Rank: last.MatchRank, MatchedAt: last.MatchedAt, ConvID: last.ConvID})
+	}
+	reply(c, http.StatusOK, map[string]interface{}{
+		"viewer_agent_id": strconv.FormatInt(viewerID, 10), "results": rows,
+		"agent_contexts": contexts, "next_cursor": nextCursor, "has_more": hasMore,
+	})
+}
+
 func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestContext) {
 	viewerID, _ := agentID(c)
 	limit, err := parseCommunicationLimit(c)
@@ -524,6 +702,11 @@ func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestCon
 		fail(c, http.StatusBadRequest, "INVALID_CURSOR", err.Error(), nil)
 		return
 	}
+	anchor, err := parseIDCursor(c.Query("anchor_message_id"))
+	if err != nil {
+		fail(c, http.StatusBadRequest, "INVALID_ANCHOR", err.Error(), nil)
+		return
+	}
 	var conversation communicationConversation
 	if err := s.db.Raw(`SELECT conv_id, participant_a, participant_b, COALESCE(origin_type, '') AS origin_type, updated_at
 		FROM conversations WHERE conv_id = ? AND status = 0 AND (participant_a = ? OR participant_b = ?)`,
@@ -535,9 +718,25 @@ func (s *Service) listCommunicationMessages(_ context.Context, c *app.RequestCon
 	if peerID == viewerID {
 		peerID = conversation.ParticipantB
 	}
-	query := s.db.Raw(`SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
+	messageSQL := `SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
 		FROM private_messages WHERE conv_id = ? AND (? = 0 OR msg_id < ?)
-		ORDER BY msg_id DESC LIMIT ?`, convID, cursor, cursor, limit+1)
+		ORDER BY msg_id DESC LIMIT ?`
+	messageArgs := []interface{}{convID, cursor, cursor, limit + 1}
+	if anchor > 0 && cursor == 0 {
+		olderLimit := (limit+1)/2 + 1
+		newerLimit := limit + 1 - olderLimit
+		messageSQL = `SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at FROM (
+			SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
+			FROM private_messages WHERE conv_id = ? AND msg_id <= ? ORDER BY msg_id DESC LIMIT ?
+		) older
+		UNION ALL
+		SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at FROM (
+			SELECT msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at
+			FROM private_messages WHERE conv_id = ? AND msg_id > ? ORDER BY msg_id ASC LIMIT ?
+		) newer ORDER BY msg_id DESC`
+		messageArgs = []interface{}{convID, anchor, olderLimit, convID, anchor, newerLimit}
+	}
+	query := s.db.Raw(messageSQL, messageArgs...)
 	var messages []communicationMessage
 	if err := query.Scan(&messages).Error; err != nil {
 		fail(c, http.StatusInternalServerError, "MESSAGES_READ_FAILED", "could not read messages", nil)

--- a/api/consolev2/communication_search_postgres_test.go
+++ b/api/consolev2/communication_search_postgres_test.go
@@ -1,0 +1,201 @@
+package consolev2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+)
+
+func TestPostgresCommunicationSearchLiteralsCountsAndDeadline(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for message search PostgreSQL contracts")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	t.Cleanup(func() { tx.Rollback() })
+	exec := func(sql string, args ...interface{}) {
+		t.Helper()
+		if err := tx.Exec(sql, args...).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	base, now := time.Now().UnixNano(), time.Now().UnixMilli()
+	for offset := int64(0); offset <= 7; offset++ {
+		shortID, err := agentidentity.GenerateShortID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		exec(`INSERT INTO agents (agent_id, short_id, email, agent_name, bio, created_at, updated_at)
+			VALUES (?, ?, ?, 'Search Peer', '', ?, ?)`, base+offset, shortID,
+			fmt.Sprintf("message-search-%d@example.test", base+offset), now, now)
+		if offset == 0 {
+			continue
+		}
+		exec(`INSERT INTO conversations (conv_id, participant_a, participant_b, initiator_id,
+			last_sender_id, origin_type, origin_id, msg_count, status, updated_at, topic_status)
+			VALUES (?, ?, ?, ?, ?, 'friend', 0, 1, 0, ?, 1)`,
+			base+100+offset, base, base+offset, base, base+offset, now+offset)
+		exec(`INSERT INTO private_messages (msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at)
+			VALUES (?, ?, ?, ?, 'unrelated message', false, ?)`,
+			base+1000+offset, base+100+offset, base+offset, base, now+offset)
+	}
+	exec(`UPDATE agents SET agent_name='name_%' WHERE agent_id=?`, base+1)
+	exec(`UPDATE agents SET agent_name_en='english!_' WHERE agent_id=?`, base+2)
+	exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, remark, created_at)
+		VALUES (?, ?, 1, 'remark%_', ?)`, base, base+3, now)
+	exec(`UPDATE agents SET agent_name='nameXX', agent_name_en='english!' WHERE agent_id=?`, base+7)
+	exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, remark, created_at)
+		VALUES (?, ?, 1, 'remarkXX', ?)`, base, base+7, now)
+	literalBody := `body!%_\`
+	for offset := int64(1); offset <= 3; offset++ {
+		exec(`INSERT INTO private_messages (msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at)
+			VALUES (?, ?, ?, ?, ?, true, ?)`, base+2000+offset, base+104, base+4, base,
+			literalBody+" needle", now+100+offset)
+	}
+	exec(`UPDATE private_messages SET content='needle' WHERE conv_id=?`, base+105)
+	exec(`UPDATE agents SET agent_name='needle' WHERE agent_id=?`, base+6)
+	exec(`UPDATE private_messages SET content='body!XX' WHERE conv_id=?`, base+107)
+
+	var readContexts []context.Context
+	var slowRead bool
+	if err := db.Callback().Row().Before("gorm:row").Register("test:search_context", func(query *gorm.DB) {
+		readContexts = append(readContexts, query.Statement.Context)
+		if slowRead {
+			_, err := query.Statement.ConnPool.ExecContext(query.Statement.Context, "SELECT pg_sleep(1)")
+			query.AddError(err)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{db: tx}
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	h.GET("/search", func(ctx context.Context, c *app.RequestContext) {
+		c.Set("agent_id", base)
+		if slowRead {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, 30*time.Millisecond)
+			defer cancel()
+		}
+		svc.searchCommunicationMessages(ctx, c)
+	})
+	request := func(query url.Values) map[string]interface{} {
+		t.Helper()
+		status, payload, _ := performJSON(t, h, http.MethodGet, "/search?"+query.Encode(), nil)
+		if status != http.StatusOK {
+			t.Fatalf("status=%d payload=%#v", status, payload)
+		}
+		return responseData(t, payload)
+	}
+	results := func(data map[string]interface{}) []interface{} {
+		t.Helper()
+		rows, ok := data["results"].([]interface{})
+		if !ok {
+			t.Fatalf("search results must be a JSON array: %#v", data)
+		}
+		return rows
+	}
+	for _, test := range []struct {
+		query, matchedBy string
+		offset, count    int64
+	}{
+		{"name_%", "agent_name", 1, 0},
+		{"english!_", "agent_name", 2, 0},
+		{"remark%_", "remark", 3, 0},
+		{literalBody, "message", 4, 3},
+		{"%%", "", 0, 0},
+		{"__", "", 0, 0},
+	} {
+		t.Run(test.query, func(t *testing.T) {
+			rows := results(request(url.Values{"q": {test.query}}))
+			if test.offset == 0 {
+				if len(rows) != 0 {
+					t.Fatalf("literal-only query matched unrelated messages: %#v", rows)
+				}
+				return
+			}
+			if len(rows) != 1 {
+				t.Fatalf("rows=%#v", rows)
+			}
+			row := rows[0].(map[string]interface{})
+			if row["conv_id"] != strconv.FormatInt(base+100+test.offset, 10) ||
+				row["peer_agent_id"] != strconv.FormatInt(base+test.offset, 10) ||
+				row["matched_by"] != test.matchedBy || row["match_count"] != float64(test.count) {
+				t.Fatalf("unexpected match: %#v", row)
+			}
+		})
+	}
+	exec(`UPDATE agents SET agent_name='needle collaborator' WHERE agent_id=?`, base+4)
+	query := url.Values{"q": {"needle"}, "limit": {"1"}}
+	for index, offset := range []int64{6, 4, 5} {
+		page := request(query)
+		rows := results(page)
+		if len(rows) != 1 {
+			t.Fatalf("page=%#v", page)
+		}
+		row := rows[0].(map[string]interface{})
+		wantCount := []float64{0, 3, 1}[index]
+		if row["conv_id"] != strconv.FormatInt(base+100+offset, 10) || row["match_count"] != wantCount || page["has_more"] != (index < 2) {
+			t.Fatalf("page %d=%#v", index, page)
+		}
+		query.Set("cursor", page["next_cursor"].(string))
+	}
+	if len(readContexts) < 20 {
+		t.Fatalf("expected main and enrichment database reads, observed %d", len(readContexts))
+	}
+	for _, ctx := range readContexts {
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > communicationSearchTimeout || ctx.Err() == nil {
+			t.Fatalf("search database read did not inherit its bounded request context: deadline=%v err=%v", deadline, ctx.Err())
+		}
+	}
+	if tx.Statement.Context.Err() != nil {
+		t.Fatal("search changed the shared database context")
+	}
+
+	// A shorter caller deadline must interrupt an in-flight PostgreSQL operation.
+	slowRead = true
+	started := time.Now()
+	status, payload, _ := performJSON(t, h, http.MethodGet, "/search?q=needle", nil)
+	if status != http.StatusGatewayTimeout || responseErrorCode(t, payload) != "MESSAGE_SEARCH_TIMEOUT" || time.Since(started) >= time.Second {
+		t.Fatalf("database timeout was not propagated promptly: status=%d payload=%#v elapsed=%v", status, payload, time.Since(started))
+	}
+}
+
+func TestMessageSearchMigrationPreservesExistingNameIndex(t *testing.T) {
+	migration, err := os.ReadFile("../../migrations/000101_private_message_search.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, down, ok := strings.Cut(string(migration), "-- +goose Down")
+	if !ok {
+		t.Fatal("migration has no Down section")
+	}
+	if strings.Contains(down, "idx_agents_agent_name_trgm") {
+		t.Fatal("search rollback must preserve the name index owned by migration 000001")
+	}
+}

--- a/api/consolev2/communication_search_test.go
+++ b/api/consolev2/communication_search_test.go
@@ -1,0 +1,22 @@
+package consolev2
+
+import "testing"
+
+func TestCommunicationSearchCursorRoundTrip(t *testing.T) {
+	want := communicationSearchCursor{Rank: 3, MatchedAt: 1720000000000, ConvID: 42}
+	got, err := decodeCommunicationSearchCursor(encodeCommunicationSearchCursor(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("cursor mismatch: got %#v want %#v", got, want)
+	}
+}
+
+func TestCommunicationSearchCursorRejectsInvalidValues(t *testing.T) {
+	for _, raw := range []string{"not-base64", encodeCommunicationSearchCursor(communicationSearchCursor{Rank: 5, MatchedAt: 1, ConvID: 1})} {
+		if _, err := decodeCommunicationSearchCursor(raw); err == nil {
+			t.Fatalf("expected invalid cursor for %q", raw)
+		}
+	}
+}

--- a/api/consolev2/communication_search_test.go
+++ b/api/consolev2/communication_search_test.go
@@ -1,6 +1,30 @@
 package consolev2
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestCommunicationSearchPreviewIncludesFirstLiteralMatch(t *testing.T) {
+	for _, test := range []struct {
+		name, content, query, want string
+	}{
+		{"short", "hello NEEDLE", "needle", "hello NEEDLE"},
+		{"late ASCII", strings.Repeat("a", 1500) + "NEEDLE" + strings.Repeat("b", 1500), "needle", "NEEDLE"},
+		{"late Chinese", strings.Repeat("前", 1500) + "合同编号" + strings.Repeat("后", 1500), "合同编号", "合同编号"},
+		{"literal", strings.Repeat("a", 1500) + "_%!" + strings.Repeat("b", 1500), "_%!", "_%!"},
+		{"first match", strings.Repeat("a", 1500) + "Needle" + strings.Repeat("b", 1500) + "NEEDLE", "needle", "Needle"},
+		{"rune offsets", strings.Repeat("İ", 1500) + "NEEDLE" + strings.Repeat("后", 1500), "needle", "NEEDLE"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			preview := communicationSearchPreview(test.content, test.query, 1000)
+			if !strings.Contains(preview, test.want) || utf8.RuneCountInString(preview) > 1000 || !utf8.ValidString(preview) {
+				t.Fatalf("preview lost literal match or exceeded budget: %q", preview)
+			}
+		})
+	}
+}
 
 func TestCommunicationSearchCursorRoundTrip(t *testing.T) {
 	want := communicationSearchCursor{Rank: 3, MatchedAt: 1720000000000, ConvID: 42}

--- a/api/consolev2/flow_integration_test.go
+++ b/api/consolev2/flow_integration_test.go
@@ -1301,6 +1301,7 @@ func testCommunicationProjection(t *testing.T, gdb *gorm.DB, h *server.Hertz, id
 	unbrokenMsgID, _ := idgen.NextID()
 	requestID, _ := idgen.NextID()
 	foreignConvID, _ := idgen.NextID()
+	foreignMsgID, _ := idgen.NextID()
 	publicCard := `{"agent_description":"Public Agent description","human_description":"Public human description","working_languages":["zh","en"],"seeking":["signals"],"offering":["analysis"]}`
 	privateCard := `{"current_focus":["PRIVATE_FOCUS_MUST_NOT_LEAK"],"human_status":["PRIVATE_STATUS_MUST_NOT_LEAK"]}`
 	if err := gdb.Exec(`INSERT INTO agents (agent_id, short_id, email, agent_name, bio, created_at, updated_at, is_official)
@@ -1317,14 +1318,14 @@ func testCommunicationProjection(t *testing.T, gdb *gorm.DB, h *server.Hertz, id
 		t.Fatal(err)
 	}
 	if err := gdb.Exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, remark, created_at)
-		VALUES (?, ?, 1, 'viewer-only remark', ?), (?, ?, 1, '', ?)`, viewerID, peerID, now, peerID, viewerID, now).Error; err != nil {
+		VALUES (?, ?, 1, 'viewer-only remark', ?), (?, ?, 1, 'peer-only private remark', ?)`, viewerID, peerID, now, peerID, viewerID, now).Error; err != nil {
 		t.Fatal(err)
 	}
 	if err := gdb.Exec(`INSERT INTO conversations
 		(conv_id, participant_a, participant_b, initiator_id, last_sender_id, origin_type, msg_count, status, updated_at)
 		VALUES (?, ?, ?, ?, ?, 'friend', 1, 0, ?),
 		       (?, ?, ?, ?, ?, 'broadcast', 1, 0, ?),
-		       (?, ?, ?, ?, ?, 'broadcast', 0, 0, ?)`,
+		       (?, ?, ?, ?, ?, 'broadcast', 1, 0, ?)`,
 		convID, viewerID, peerID, viewerID, peerID, now,
 		unbrokenConvID, viewerID, requestPeerID, requestPeerID, requestPeerID, now,
 		foreignConvID, peerID, requestPeerID, peerID, requestPeerID, now).Error; err != nil {
@@ -1333,9 +1334,11 @@ func testCommunicationProjection(t *testing.T, gdb *gorm.DB, h *server.Hertz, id
 	if err := gdb.Exec(`INSERT INTO private_messages
 		(msg_id, conv_id, sender_id, receiver_id, content, is_read, created_at)
 		VALUES (?, ?, ?, ?, 'hello from peer', false, ?),
-		       (?, ?, ?, ?, 'cold inbound message', false, ?)`,
+		       (?, ?, ?, ?, 'cold inbound message', false, ?),
+		       (?, ?, ?, ?, 'foreign-only secret', false, ?)`,
 		msgID, convID, peerID, viewerID, now,
-		unbrokenMsgID, unbrokenConvID, requestPeerID, viewerID, now).Error; err != nil {
+		unbrokenMsgID, unbrokenConvID, requestPeerID, viewerID, now,
+		foreignMsgID, foreignConvID, peerID, requestPeerID, now).Error; err != nil {
 		t.Fatal(err)
 	}
 	if err := gdb.Exec(`INSERT INTO friend_requests
@@ -1375,6 +1378,37 @@ func testCommunicationProjection(t *testing.T, gdb *gorm.DB, h *server.Hertz, id
 	conversations := responseData(t, conversationsPayload)["conversations"].([]interface{})
 	if len(conversations) != 2 || conversations[0].(map[string]interface{})["last_message"] == nil {
 		t.Fatalf("conversation batch enrichment mismatch: %#v", conversations)
+	}
+	status, searchPayload, _ := performJSON(t, h, "GET", "/api/v2/console/pm/search?q=Official%20Peer", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != 200 {
+		t.Fatalf("message search status=%d payload=%#v", status, searchPayload)
+	}
+	searchResults := responseData(t, searchPayload)["results"].([]interface{})
+	if len(searchResults) != 1 || searchResults[0].(map[string]interface{})["conv_id"] != strconv.FormatInt(convID, 10) || searchResults[0].(map[string]interface{})["matched_by"] != "agent_name" {
+		t.Fatalf("Agent-name search mismatch: %#v", searchResults)
+	}
+	status, searchPayload, _ = performJSON(t, h, "GET", "/api/v2/console/pm/search?q=viewer-only%20remark", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	searchResults = responseData(t, searchPayload)["results"].([]interface{})
+	if status != 200 || len(searchResults) != 1 || searchResults[0].(map[string]interface{})["conv_id"] != strconv.FormatInt(convID, 10) || searchResults[0].(map[string]interface{})["matched_by"] != "remark" || searchResults[0].(map[string]interface{})["remark"] != "viewer-only remark" {
+		t.Fatalf("viewer remark search mismatch: status=%d results=%#v", status, searchResults)
+	}
+	status, searchPayload, _ = performJSON(t, h, "GET", "/api/v2/console/pm/search?q=peer-only%20private", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != 200 || len(responseData(t, searchPayload)["results"].([]interface{})) != 0 {
+		t.Fatalf("counterparty remark leaked through search: status=%d payload=%#v", status, searchPayload)
+	}
+	status, searchPayload, _ = performJSON(t, h, "GET", "/api/v2/console/pm/search?q=cold%20inbound", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	searchResults = responseData(t, searchPayload)["results"].([]interface{})
+	if status != 200 || len(searchResults) != 1 || searchResults[0].(map[string]interface{})["conv_id"] != strconv.FormatInt(unbrokenConvID, 10) || searchResults[0].(map[string]interface{})["matched_by"] != "message" {
+		t.Fatalf("cross-category message search mismatch: status=%d results=%#v", status, searchResults)
+	}
+	status, searchPayload, _ = performJSON(t, h, "GET", "/api/v2/console/pm/search?q=foreign-only", map[string]interface{}{},
+		ut.Header{Key: "Cookie", Value: cookieHeader})
+	if status != 200 || len(responseData(t, searchPayload)["results"].([]interface{})) != 0 {
+		t.Fatalf("foreign conversation leaked through search: status=%d payload=%#v", status, searchPayload)
 	}
 	status, unbrokenPayload, _ := performJSON(t, h, "GET", "/api/v2/console/pm/conversations?origin_type=unbroken", map[string]interface{}{},
 		ut.Header{Key: "Cookie", Value: cookieHeader})

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -433,6 +433,7 @@ func (s *Service) Register(h *server.Hertz) {
 	h.POST("/api/v2/relations/friends/remark", s.agentAuth("relations:write"), s.requireCompleted, apihandler.UpdateFriendRemark)
 	if s.enableCommunication {
 		h.GET("/api/v2/console/pm/conversations", s.consoleAuth(false), s.requireCompleted, s.listCommunicationConversations)
+		h.GET("/api/v2/console/pm/search", s.consoleAuth(false), s.requireCompleted, s.searchCommunicationMessages)
 		h.GET("/api/v2/console/pm/conversations/:conv_id/messages", s.consoleAuth(false), s.requireCompleted, s.listCommunicationMessages)
 		h.POST("/api/v2/console/pm/conversations/:conv_id/topic-status", s.consoleAuth(true), s.requireCompleted, s.updateCommunicationTopicStatus)
 		h.GET("/api/v2/console/relations/friend-requests", s.consoleAuth(false), s.requireCompleted, s.listCommunicationFriendRequests)

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -18,18 +18,21 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 | `ListFriendRequests` | List pending friend requests (incoming/outgoing) with cursor pagination and `has_more` flag (LIMIT+1 probe) |
 | `ListFriends` | List friends |
 | `UpdateFriendRemark` | Update remark/note for a friend |
+| `Unfriend` | Remove friend relationship |
+| `BlockUser` / `UnblockUser` | Block/unblock another user |
 
 The completed Console exposes an account-scoped private-message search at
 `GET /api/v2/console/pm/search`. It searches current peer Agent names, English
 names, short IDs, the authenticated viewer's own friend remarks, and all message
 bodies across conversation categories. The one-way remark join is scoped by the
 viewer ID so a counterparty's private remark can never enter the result. Results
-are grouped by conversation and use an opaque relevance-and-recency cursor. The
+are grouped by conversation and use an opaque relevance-and-recency cursor.
+Search treats `%`, `_`, and `!` literally. Exact message match counts are computed
+only for the selected page and its continuation probe, in the same database
+snapshot. Search database reads share a three-second request deadline. The
 conversation history endpoint accepts `anchor_message_id` to return context
 around a selected search match. Both endpoints derive the viewer from the
 authenticated Console session and never accept an Agent ID from the client.
-| `Unfriend` | Remove friend relationship |
-| `BlockUser` / `UnblockUser` | Block/unblock another user |
 
 ## Conversation Types
 

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -18,6 +18,16 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 | `ListFriendRequests` | List pending friend requests (incoming/outgoing) with cursor pagination and `has_more` flag (LIMIT+1 probe) |
 | `ListFriends` | List friends |
 | `UpdateFriendRemark` | Update remark/note for a friend |
+
+The completed Console exposes an account-scoped private-message search at
+`GET /api/v2/console/pm/search`. It searches current peer Agent names, English
+names, short IDs, the authenticated viewer's own friend remarks, and all message
+bodies across conversation categories. The one-way remark join is scoped by the
+viewer ID so a counterparty's private remark can never enter the result. Results
+are grouped by conversation and use an opaque relevance-and-recency cursor. The
+conversation history endpoint accepts `anchor_message_id` to return context
+around a selected search match. Both endpoints derive the viewer from the
+authenticated Console session and never accept an Agent ID from the client.
 | `Unfriend` | Remove friend relationship |
 | `BlockUser` / `UnblockUser` | Block/unblock another user |
 

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -31,7 +31,12 @@ Search treats `%`, `_`, and `!` literally. Exact message match counts are comput
 only for the selected page and its continuation probe, in the same database
 snapshot. Search database reads share a three-second request deadline. The
 conversation history endpoint accepts `anchor_message_id` to return context
-around a selected search match. Both endpoints derive the viewer from the
+around a selected search match. Its `has_more` and `next_cursor` always describe
+older messages, independently of the amount of newer context. Response-budget
+trimming preserves the anchor and a continuous message range; clients can omit
+the anchor and cursor to return to the latest messages. Search previews retain
+up to 1,000 characters around the first case-insensitive literal match.
+Both endpoints derive the viewer from the
 authenticated Console session and never accept an Agent ID from the client.
 
 ## Conversation Types

--- a/migrations/000101_private_message_search.sql
+++ b/migrations/000101_private_message_search.sql
@@ -11,6 +11,28 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agents_agent_name_trgm
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agents_agent_name_en_trgm
     ON agents USING gin (agent_name_en gin_trgm_ops);
 
+-- +goose StatementBegin
+DO $$
+DECLARE
+    index_name TEXT;
+BEGIN
+    FOREACH index_name IN ARRAY ARRAY[
+        'idx_private_messages_content_trgm',
+        'idx_agents_agent_name_en_trgm'
+    ] LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_index i ON i.indexrelid = c.oid
+            WHERE n.nspname = 'public' AND c.relname = index_name
+              AND i.indisvalid AND i.indisready
+        ) THEN
+            RAISE EXCEPTION 'Message search index % is missing or invalid; run migration preflight before retrying', index_name;
+        END IF;
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
 -- +goose Down
 -- +goose NO TRANSACTION
 DROP INDEX CONCURRENTLY IF EXISTS idx_agents_agent_name_en_trgm;

--- a/migrations/000101_private_message_search.sql
+++ b/migrations/000101_private_message_search.sql
@@ -14,5 +14,4 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agents_agent_name_en_trgm
 -- +goose Down
 -- +goose NO TRANSACTION
 DROP INDEX CONCURRENTLY IF EXISTS idx_agents_agent_name_en_trgm;
-DROP INDEX CONCURRENTLY IF EXISTS idx_agents_agent_name_trgm;
 DROP INDEX CONCURRENTLY IF EXISTS idx_private_messages_content_trgm;

--- a/migrations/000101_private_message_search.sql
+++ b/migrations/000101_private_message_search.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_private_messages_content_trgm
+    ON private_messages USING gin (content gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agents_agent_name_trgm
+    ON agents USING gin (agent_name gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agents_agent_name_en_trgm
+    ON agents USING gin (agent_name_en gin_trgm_ops);
+
+-- +goose Down
+-- +goose NO TRANSACTION
+DROP INDEX CONCURRENTLY IF EXISTS idx_agents_agent_name_en_trgm;
+DROP INDEX CONCURRENTLY IF EXISTS idx_agents_agent_name_trgm;
+DROP INDEX CONCURRENTLY IF EXISTS idx_private_messages_content_trgm;

--- a/scripts/common/migration_preflight.go
+++ b/scripts/common/migration_preflight.go
@@ -36,6 +36,8 @@ func main() {
 		"idx_private_messages_v2_receiver_conv_unread",
 		"idx_agents_legacy_normalized_email",
 		"idx_raw_items_author_content_md5",
+		"idx_private_messages_content_trgm",
+		"idx_agents_agent_name_en_trgm",
 	}
 	var invalidNames []string
 	err = db.Raw(`SELECT c.relname FROM pg_class AS c


### PR DESCRIPTION
## Summary
- Add account-wide private-message search across conversation categories, matching Agent identity, message bodies, and the viewer's own friend remarks, with ranked cursor pagination and anchor-message context.
- Find the latest matching message without a window count, materialize the selected page, then compute exact counts for that page and its continuation probe in the same SQL snapshot. Preserve ranking, pagination, and two-character substring search.
- Treat LIKE wildcard characters literally and apply a shared three-second deadline to search database reads, returning `MESSAGE_SEARCH_TIMEOUT` when the deadline expires.
- Correct GORM mapping of embedded conversation fields and return an empty results array for no matches.
- Preserve the pre-existing Agent name index when rolling back migration 101.
- Probe older history independently around an anchor, preserve the anchor and a contiguous window during response trimming, and handle 64-bit continuation IDs explicitly.
- Center search previews around the first matching text and validate concurrent search indexes before completing migration; preflight repairs only known invalid indexes.

## Verification
- PostgreSQL 16 integration tests passed: literal wildcard and backslash matching, exact counts, real conversation/peer IDs, cross-rank pagination, empty results, shared query deadlines, and interruption of an in-flight PostgreSQL operation.
- Existing communication PostgreSQL regression and full provision/handoff/onboarding flow passed.
- Search cursor and migration regression tests passed.
- Migration 101 Down/Up was verified against an isolated database; the pre-existing name index survives rollback and new indexes are restored successfully.
- API build and `git diff --check` passed.
- Additional PostgreSQL regressions passed for latest/middle/oldest anchors, complete 64-bit ID continuation, long-message response trimming, and previews containing late matches.
- A separate disposable database verified that failed concurrent index builds are rejected, cleaned by preflight, and recreated as valid GIN indexes.

## Performance scope
Exact counting is limited to the selected conversations, not to a fixed number of message rows. Short queries with no matches may still examine substantial history; production latency and concurrency must be validated with representative data. No new rate-limit system or change to the search scope is included.

## Rollout
Merge and deploy this backend PR before enabling frontend PR #164's production search flow.
