### PR TITLE
fix: prepare V2 referral API and CLI 0.0.43

### DIFF
--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -21,9 +21,11 @@ import (
 	"gorm.io/gorm"
 
 	consoledal "eigenflux_server/api/dal"
+	"eigenflux_server/api/install"
 	"eigenflux_server/pkg/activity"
 	"eigenflux_server/pkg/agentcard"
 	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/logger"
 	"eigenflux_server/pkg/metrics"
 	"eigenflux_server/pkg/runtimeidentity"
 )
@@ -201,6 +203,7 @@ type provisionRequest struct {
 	Signature       string            `json:"signature"`
 	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
 	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
+	Ref             string            `json:"ref,omitempty"`
 }
 
 type provisionProofPayload struct {
@@ -213,6 +216,7 @@ type provisionProofPayload struct {
 	ExpectedAgentID string            `json:"expected_agent_id,omitempty"`
 	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
 	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
+	Ref             string            `json:"ref,omitempty"`
 }
 
 func provisionTranscript(req provisionRequest) ([]byte, error) {
@@ -226,6 +230,7 @@ func provisionTranscript(req provisionRequest) ([]byte, error) {
 		ExpectedAgentID: req.ExpectedAgentID,
 		Draft:           req.Draft,
 		FieldProvenance: req.FieldProvenance,
+		Ref:             req.Ref,
 	}
 	canonical, err := json.Marshal(payload)
 	if err != nil {
@@ -239,6 +244,7 @@ func provisionReceiptHash(req provisionRequest) (string, error) {
 		BootstrapGrant: req.BootstrapGrant, IdempotencyKey: req.IdempotencyKey,
 		Nonce: req.Nonce, PublicKey: req.PublicKey, AgentName: req.AgentName, ExpectedAgentID: req.ExpectedAgentID, Draft: req.Draft,
 		FieldProvenance: req.FieldProvenance,
+		Ref:             req.Ref,
 	}
 	canonical, err := json.Marshal(payload)
 	if err != nil {
@@ -290,6 +296,10 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 	transcript, transcriptErr := provisionTranscript(req)
 	if err != nil || transcriptErr != nil || !ed25519.Verify(publicKey, transcript, signature) {
 		fail(c, http.StatusUnauthorized, "INVALID_PROOF", "Ed25519 proof verification failed", nil)
+		return
+	}
+	if req.Ref != "" && !install.ValidTokenFormat(req.Ref) {
+		fail(c, http.StatusBadRequest, "INVALID_REF", "ref must be an EF-xxxxxxxx install token", nil)
 		return
 	}
 	if len([]rune(req.AgentName)) > 100 {
@@ -354,6 +364,7 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 	observedRuntime, _ := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
 	var agentID, principalID, expiresAt int64
 	created := false
+	var attribution install.ProvisionAttribution
 	err = s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Exec(`SELECT pg_advisory_xact_lock(hashtextextended(?, 0))`, keyFingerprint).Error; err != nil {
 			return err
@@ -506,6 +517,10 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 			if err := insertProvisionedAgent(tx, agentID, alias, req.AgentName, now); err != nil {
 				return err
 			}
+			attribution, err = install.BindProvisionedAgent(tx, req.Ref, agentID, now)
+			if err != nil {
+				return err
+			}
 			if err := tx.Exec(`INSERT INTO agent_profiles (agent_id, status, updated_at) VALUES (?, 0, ?)`, agentID, now).Error; err != nil {
 				return err
 			}
@@ -575,6 +590,15 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 	if created {
+		if attribution.Channel != "" {
+			logger.Default().Info("install", "ev", "install_acq_channel", "ref", req.Ref,
+				"channel", attribution.Channel, "agent_id", agentID, "via", "v2_provision")
+		}
+		if attribution.InviteCode != "" {
+			logger.Default().Info("install", "ev", "install_invite_attributed", "ref", req.Ref,
+				"invite_code", attribution.InviteCode, "agent_id", agentID,
+				"inviter", attribution.InviterAgentID, "via", "v2_provision")
+		}
 		agentcard.PublishRebuild(ctx, agentID, "agent_v2_provisioned")
 	}
 	publicIdentity, identityErr := agentidentity.Get(ctx, s.db, agentID)

--- a/api/install/provision_attribution.go
+++ b/api/install/provision_attribution.go
@@ -1,0 +1,79 @@
+package install
+
+import (
+	"errors"
+
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/invite"
+	"gorm.io/gorm"
+)
+
+// ProvisionAttribution describes attribution written in the provision transaction.
+// Callers may emit events only after that transaction commits.
+type ProvisionAttribution struct {
+	Channel        string
+	InviteCode     string
+	InviterAgentID int64
+}
+
+// BindProvisionedAgent binds a signed install ref to a newly inserted V2 Agent.
+// The caller must verify the provision proof and call this only in the new-Agent
+// branch, using the same transaction that creates the identity and credentials.
+// The identity comes from that transaction, never public /report metadata; the
+// internal email alias can later be bound to a human without losing attribution.
+func BindProvisionedAgent(tx *gorm.DB, ref string, agentID int64, now int64) (ProvisionAttribution, error) {
+	var result ProvisionAttribution
+	if ref == "" || !ValidTokenFormat(ref) || agentID <= 0 {
+		return result, nil
+	}
+	var token Token
+	if err := tx.Where("token = ?", ref).First(&token).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return result, nil
+		}
+		return result, err
+	}
+	if token.CreatedAt > now {
+		return result, nil
+	}
+	if token.Channel != "" && token.Channel != "unknown" {
+		update := tx.Exec(`UPDATE agents SET acquisition_channel = ?
+			WHERE agent_id = ? AND acquisition_channel = '' AND created_at >= ?`,
+			token.Channel, agentID, token.CreatedAt)
+		if update.Error != nil {
+			return result, update.Error
+		}
+		if update.RowsAffected == 1 {
+			result.Channel = token.Channel
+		}
+	}
+	var code *invite.Code
+	if agentidentity.ValidShortID(token.InviteCode) {
+		inviterID, err := agentidentity.Lookup(tx.Statement.Context, tx, token.InviteCode)
+		if err != nil && !errors.Is(err, agentidentity.ErrNotFound) {
+			return result, err
+		}
+		if err == nil {
+			code = &invite.Code{Code: token.InviteCode, Kind: invite.KindKOL, AgentID: inviterID}
+		}
+	} else if invite.ValidFormat(token.InviteCode) {
+		var err error
+		code, err = invite.GetByCode(tx, token.InviteCode)
+		if err != nil {
+			return result, err
+		}
+	}
+	if code == nil || (code.Kind == invite.KindKOL && code.AgentID == agentID) {
+		return result, nil
+	}
+	update := tx.Exec(`UPDATE agents SET invited_by_code = ?, inviter_agent_id = ?, invited_at = ?
+		WHERE agent_id = ? AND invited_by_code = '' AND created_at >= ?`,
+		code.Code, code.AgentID, now, agentID, token.CreatedAt)
+	if update.Error != nil {
+		return result, update.Error
+	}
+	if update.RowsAffected == 1 {
+		result.InviteCode, result.InviterAgentID = code.Code, code.AgentID
+	}
+	return result, nil
+}

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,7 +3,7 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.42
+CLI_VERSION=0.0.43
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients

--- a/cli/cmd/agent_install_ref.go
+++ b/cli/cmd/agent_install_ref.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var agentInstallRefCmd = &cobra.Command{
+	Use:    "install-ref",
+	Short:  "Save the first install referral for this Home and server",
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ref, _ := cmd.Flags().GetString("ref")
+		endpoint, _ := cmd.Flags().GetString("endpoint")
+		if ref == "" || endpoint == "" {
+			return fmt.Errorf("--ref and --endpoint are required")
+		}
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		server, err := cfg.GetActive(serverFlag)
+		if err != nil {
+			return err
+		}
+		record, saved, err := auth.RememberInstallRef(*server, endpoint, ref)
+		if err != nil {
+			return err
+		}
+		result := map[string]interface{}{"saved": saved, "server": server.Name}
+		if record != nil {
+			result["ref"] = record.Ref
+		} else {
+			result["reason"] = "existing_identity"
+		}
+		output.PrintData(result, resolveFormat())
+		return nil
+	},
+}
+
+func init() {
+	agentInstallRefCmd.Flags().String("ref", "", "referral issued by the install page")
+	agentInstallRefCmd.Flags().String("endpoint", "", "website endpoint that issued the referral")
+	agentV2Cmd.AddCommand(agentInstallRefCmd)
+}

--- a/cli/cmd/agent_v2.go
+++ b/cli/cmd/agent_v2.go
@@ -177,6 +177,7 @@ type provisionV2Request struct {
 	Signature       string            `json:"signature"`
 	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
 	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
+	Ref             string            `json:"ref,omitempty"`
 }
 
 type provisionV2Proof struct {
@@ -189,6 +190,7 @@ type provisionV2Proof struct {
 	ExpectedAgentID string            `json:"expected_agent_id,omitempty"`
 	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
 	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
+	Ref             string            `json:"ref,omitempty"`
 }
 
 type v2Poster interface {
@@ -249,6 +251,7 @@ func provisionV2Transcript(request provisionV2Request) ([]byte, error) {
 		PublicKey:      request.PublicKey, IssuedAt: request.IssuedAt,
 		AgentName: request.AgentName, ExpectedAgentID: request.ExpectedAgentID,
 		Draft: request.Draft, FieldProvenance: request.FieldProvenance,
+		Ref: request.Ref,
 	})
 	if err != nil {
 		return nil, err
@@ -360,6 +363,20 @@ var agentV2ProvisionCmd = &cobra.Command{
 		if requireExistingAgent && !preserveExistingIdentity {
 			return fmt.Errorf("cannot prove an existing Agent identity in the selected stable Agent Home")
 		}
+		ref, _ := cmd.Flags().GetString("ref")
+		var installRef *auth.InstallRef
+		if ref != "" {
+			installRef, _, err = auth.RememberInstallRef(*server, server.Endpoint, ref)
+		} else {
+			installRef, err = auth.LoadInstallRef(*server)
+		}
+		if err != nil {
+			return fmt.Errorf("load install referral: %w", err)
+		}
+		ref = ""
+		if installRef != nil {
+			ref = installRef.Ref
+		}
 		if grant == "" {
 			if hasV2 {
 				grant, nonce, err = requestAutomaticRegistrationChallenge(v2, publicKey)
@@ -399,6 +416,7 @@ var agentV2ProvisionCmd = &cobra.Command{
 			PublicKey:      base64.RawURLEncoding.EncodeToString(publicKey),
 			IssuedAt:       time.Now().UnixMilli(), AgentName: agentName, ExpectedAgentID: expectedAgentID, Draft: draft,
 			FieldProvenance: fieldProvenance,
+			Ref:             ref,
 		}
 		transcript, err := provisionV2Transcript(request)
 		if err != nil {
@@ -474,6 +492,7 @@ func init() {
 	agentV2ProvisionCmd.Flags().String("nonce", "", "single-use proof nonce paired with --bootstrap-grant")
 	agentV2ProvisionCmd.Flags().String("agent-name", "EigenFlux Agent", "Agent name used to prefill onboarding")
 	agentV2ProvisionCmd.Flags().String("draft-file", "", "optional onboarding draft JSON file ('-' reads stdin)")
+	agentV2ProvisionCmd.Flags().String("ref", "", "install referral for a new Agent (defaults to the first referral saved in this Home for this server)")
 	agentV2ProvisionCmd.Flags().Bool("no-handoff", false, "provision without creating a Console V2 link")
 	agentV2ProvisionCmd.Flags().Bool("recover-account", false, "open the claim page to recover a historical Agent")
 	agentV2ProvisionCmd.Flags().Bool("require-existing-agent", false, "refuse public registration unless this Home already proves an Agent identity")

--- a/cli/cmd/agent_v2_test.go
+++ b/cli/cmd/agent_v2_test.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -76,6 +78,26 @@ func TestProvisionV2TranscriptCoversMutableFields(t *testing.T) {
 	mutated, _ = provisionV2Transcript(request)
 	if ed25519.Verify(publicKey, mutated, signature) {
 		t.Fatal("CLI provision proof did not cover expected_agent_id")
+	}
+	request.ExpectedAgentID = "42"
+	request.Ref = "EF-Bili1234"
+	mutated, _ = provisionV2Transcript(request)
+	if ed25519.Verify(publicKey, mutated, signature) {
+		t.Fatal("CLI provision proof did not cover ref")
+	}
+}
+
+func TestProvisionV2TranscriptWithoutRefPreservesCompatibility(t *testing.T) {
+	request := provisionV2Request{
+		BootstrapGrant: "grant", IdempotencyKey: "request", Nonce: "nonce", PublicKey: "key",
+		IssuedAt: 123, AgentName: "Agent", ExpectedAgentID: "42", Draft: []byte(`{"network_goal":"test"}`),
+		FieldProvenance: map[string]string{"network_goal": "agent_user_context"},
+	}
+	legacyProof := `{"bootstrap_grant":"grant","idempotency_key":"request","nonce":"nonce","public_key":"key","issued_at":123,"agent_name":"Agent","expected_agent_id":"42","onboarding_draft":{"network_goal":"test"},"field_provenance":{"network_goal":"agent_user_context"}}`
+	expected := fmt.Sprintf("EF-AUTH-V2\x00POST\n/api/v2/agent-identities/provision\n%x", sha256.Sum256([]byte(legacyProof)))
+	actual, err := provisionV2Transcript(request)
+	if err != nil || string(actual) != expected {
+		t.Fatalf("empty ref changed the existing signature transcript: %q, %v", actual, err)
 	}
 }
 

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -225,8 +225,8 @@ func TestPublicJoinEntryPointsUseOnboardingSkill(t *testing.T) {
 		"skills/ef-communication/SKILL.md":   {"ef-onboarding/references/recurring-trigger.md"},
 		"static/install.ps1":                 {"Check ef-onboarding skill"},
 		"static/install.sh":                  {"ef-broadcast|ef-communication|ef-onboarding|ef-profile", "Check ef-onboarding skill"},
-		"static/templates/agti_join.tmpl.md": {"ef-onboarding", "eigenflux agent provision", "Console V2"},
-		"static/templates/skill.tmpl.md":     {"ef-onboarding", "every Console handoff starts at Step 1"},
+		"static/templates/agti_join.tmpl.md": {"https://github.com/phronesis-io/eigenflux/blob/main/skills/install.md"},
+		"static/templates/skill.tmpl.md":     {"https://github.com/phronesis-io/eigenflux/blob/main/skills/install.md", "ef-onboarding"},
 	}
 
 	for rel, required := range requiredByFile {

--- a/cli/internal/auth/install_ref.go
+++ b/cli/internal/auth/install_ref.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"cli.eigenflux.ai/internal/config"
+)
+
+var installRefPattern = regexp.MustCompile(`^EF-[0-9A-Za-z]{8}$`)
+
+// InstallRef preserves the first installation referral for one server and Home.
+// It remains after provisioning so retries sign the same attribution context.
+type InstallRef struct {
+	Ref      string `json:"ref"`
+	Endpoint string `json:"endpoint"`
+}
+
+func installRefPath(serverName string) string {
+	return filepath.Join(config.HomeDir(), "servers", serverName, "install-ref.json")
+}
+
+func canonicalInstallEndpoint(endpoint string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil || u.Host == "" || (u.Scheme != "https" && u.Scheme != "http") || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("invalid install referral endpoint")
+	}
+	u.Host = strings.ToLower(u.Host)
+	if u.Scheme == "https" {
+		switch u.Host {
+		case "eigenflux.ai", "www.eigenflux.ai", "eigenflux.net", "www.eigenflux.net",
+			"eigenflux.pro", "www.eigenflux.pro", "phronesis.studio", "www.phronesis.studio":
+			u.Host = "www.eigenflux.ai"
+		}
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+// LoadInstallRef returns only a referral belonging to the selected endpoint.
+func LoadInstallRef(server config.Server) (*InstallRef, error) {
+	data, err := os.ReadFile(installRefPath(server.Name))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var record InstallRef
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, fmt.Errorf("parse install referral: %w", err)
+	}
+	if !installRefPattern.MatchString(record.Ref) {
+		return nil, fmt.Errorf("invalid saved install referral")
+	}
+	endpoint, err := canonicalInstallEndpoint(server.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	storedEndpoint, err := canonicalInstallEndpoint(record.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if storedEndpoint != endpoint {
+		return nil, nil
+	}
+	return &record, nil
+}
+
+// RememberInstallRef saves once before an identity exists. Existing referrals
+// take precedence, and existing V2 or legacy identities never gain a new ref.
+func RememberInstallRef(server config.Server, sourceEndpoint, ref string) (*InstallRef, bool, error) {
+	ref = strings.TrimSpace(ref)
+	if !installRefPattern.MatchString(ref) {
+		return nil, false, fmt.Errorf("install referral must match EF- followed by 8 letters or digits")
+	}
+	endpoint, err := canonicalInstallEndpoint(server.Endpoint)
+	if err != nil {
+		return nil, false, err
+	}
+	source, err := canonicalInstallEndpoint(sourceEndpoint)
+	if err != nil {
+		return nil, false, err
+	}
+	if source != endpoint {
+		return nil, false, fmt.Errorf("install referral endpoint does not match selected server %q", server.Name)
+	}
+	var record *InstallRef
+	saved := false
+	err = WithV2CredentialsLock(server.Name, 5*time.Second, func() error {
+		var err error
+		record, err = LoadInstallRef(server)
+		if err != nil || record != nil {
+			return err
+		}
+		hasV2, err := HasV2Credentials(server.Name)
+		if err != nil || hasV2 {
+			return err
+		}
+		if _, err := os.Lstat(credentialsPath(server.Name)); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		record = &InstallRef{Ref: ref, Endpoint: endpoint}
+		data, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
+		if err := writeFileAtomic(installRefPath(server.Name), data); err != nil {
+			return err
+		}
+		saved = true
+		return nil
+	})
+	return record, saved, err
+}

--- a/cli/internal/auth/install_ref_test.go
+++ b/cli/internal/auth/install_ref_test.go
@@ -1,0 +1,100 @@
+package auth_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/config"
+)
+
+func TestInstallRefSurvivesProvisionAndReinstall(t *testing.T) {
+	t.Setenv("EIGENFLUX_HOME", t.TempDir())
+	server := config.Server{Name: "eigenflux", Endpoint: "https://www.eigenflux.ai"}
+	record, saved, err := auth.RememberInstallRef(server, "https://eigenflux.ai/", " EF-Bili1234 ")
+	if err != nil || !saved || record == nil || record.Ref != "EF-Bili1234" {
+		t.Fatalf("initial install ref: record=%+v saved=%v err=%v", record, saved, err)
+	}
+	path := filepath.Join(config.HomeDir(), "servers", server.Name, "install-ref.json")
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("ref file permissions: info=%v err=%v", info, err)
+	}
+	if err := auth.SaveV2Credentials(server.Name, &auth.V2Credentials{AgentID: "42", AccessToken: "access", RefreshToken: "refresh"}); err != nil {
+		t.Fatal(err)
+	}
+	record, saved, err = auth.RememberInstallRef(server, server.Endpoint, "EF-Other123")
+	if err != nil || saved || record == nil || record.Ref != "EF-Bili1234" {
+		t.Fatalf("reinstall replaced the original attribution: record=%+v saved=%v err=%v", record, saved, err)
+	}
+	record, err = auth.LoadInstallRef(server)
+	if err != nil || record == nil || record.Ref != "EF-Bili1234" {
+		t.Fatalf("retry lost the original ref: record=%+v err=%v", record, err)
+	}
+}
+
+func TestInstallRefIsolatedByHomeServerAndEndpoint(t *testing.T) {
+	t.Setenv("EIGENFLUX_HOME", t.TempDir())
+	server := config.Server{Name: "eigenflux", Endpoint: "https://www.eigenflux.ai"}
+	if _, _, err := auth.RememberInstallRef(server, server.Endpoint, "EF-Bili1234"); err != nil {
+		t.Fatal(err)
+	}
+	for _, other := range []config.Server{
+		{Name: "staging", Endpoint: server.Endpoint},
+		{Name: server.Name, Endpoint: "https://staging.eigenflux.ai"},
+		{Name: server.Name, Endpoint: "http://www.eigenflux.ai"},
+	} {
+		if record, err := auth.LoadInstallRef(other); err != nil || record != nil {
+			t.Fatalf("ref crossed server or endpoint boundary: server=%+v record=%+v err=%v", other, record, err)
+		}
+	}
+	if _, _, err := auth.RememberInstallRef(server, "https://staging.eigenflux.ai", "EF-Bili1234"); err == nil {
+		t.Fatal("mismatched source endpoint must be rejected")
+	}
+	for _, alias := range []string{"https://eigenflux.ai/", "https://www.eigenflux.net", "https://eigenflux.pro", "https://phronesis.studio"} {
+		if record, err := auth.LoadInstallRef(config.Server{Name: server.Name, Endpoint: alias}); err != nil || record == nil || record.Ref != "EF-Bili1234" {
+			t.Fatalf("official alias lost the referral: alias=%q record=%+v err=%v", alias, record, err)
+		}
+	}
+	t.Setenv("EIGENFLUX_HOME", t.TempDir())
+	if record, err := auth.LoadInstallRef(server); err != nil || record != nil {
+		t.Fatalf("ref crossed Agent Home boundary: record=%+v err=%v", record, err)
+	}
+}
+
+func TestInstallRefDoesNotAttributeExistingIdentities(t *testing.T) {
+	for _, identity := range []string{"v2", "legacy", "expired_legacy"} {
+		t.Run(identity, func(t *testing.T) {
+			t.Setenv("EIGENFLUX_HOME", t.TempDir())
+			server := config.Server{Name: "eigenflux", Endpoint: "https://www.eigenflux.ai"}
+			var err error
+			if identity == "v2" {
+				err = auth.SaveV2Credentials(server.Name, &auth.V2Credentials{AgentID: "42", AccessToken: "access", RefreshToken: "refresh"})
+			} else {
+				creds := &auth.Credentials{AgentID: "42", AccessToken: "legacy"}
+				if identity == "expired_legacy" {
+					creds.ExpiresAt = 1
+				}
+				err = auth.SaveCredentials(server.Name, creds)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			record, saved, err := auth.RememberInstallRef(server, server.Endpoint, "EF-Bili1234")
+			if err != nil || saved || record != nil {
+				t.Fatalf("existing identity gained attribution: record=%+v saved=%v err=%v", record, saved, err)
+			}
+		})
+	}
+}
+
+func TestInstallRefRejectsMalformedReferral(t *testing.T) {
+	t.Setenv("EIGENFLUX_HOME", t.TempDir())
+	server := config.Server{Name: "eigenflux", Endpoint: "https://www.eigenflux.ai"}
+	for _, ref := range []string{"", "bilibili", "EF-too-long123", "EF-Bili1234\nnext"} {
+		if _, _, err := auth.RememberInstallRef(server, server.Endpoint, ref); err == nil {
+			t.Errorf("invalid referral accepted: %q", ref)
+		}
+	}
+}

--- a/cli/internal/auth/install_ref_test.go
+++ b/cli/internal/auth/install_ref_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"cli.eigenflux.ai/internal/auth"
@@ -18,7 +19,10 @@ func TestInstallRefSurvivesProvisionAndReinstall(t *testing.T) {
 	}
 	path := filepath.Join(config.HomeDir(), "servers", server.Name, "install-ref.json")
 	info, err := os.Stat(path)
-	if err != nil || info.Mode().Perm() != 0o600 {
+	if err != nil {
+		t.Fatalf("stat ref file: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("ref file permissions: info=%v err=%v", info, err)
 	}
 	if err := auth.SaveV2Credentials(server.Name, &auth.V2Credentials{AgentID: "42", AccessToken: "access", RefreshToken: "refresh"}); err != nil {

--- a/tests/installv2/attribution_test.go
+++ b/tests/installv2/attribution_test.go
@@ -1,0 +1,458 @@
+package installv2_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/api/consolev2"
+	"eigenflux_server/api/install"
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/config"
+	sharedDB "eigenflux_server/pkg/db"
+	"eigenflux_server/pkg/invite"
+)
+
+const testOrigin = "https://console.example.test"
+
+// This suite exercises public HTTP handlers against a migrated PostgreSQL
+// database. PG_DSN must point at an isolated test database; no RPC services,
+// outbound email, ad callbacks, or production credentials are needed.
+func TestV2InstallAttribution(t *testing.T) {
+	h := newHarness(t)
+
+	t.Run("bilibili_install_to_verified_identity", func(t *testing.T) {
+		ref := h.mint(t, "bilibili", "")
+		h.json(t, http.MethodPost, "/api/v1/install/copy", map[string]any{"ref": ref}, http.StatusOK)
+		recorder := ut.PerformRequest(h.http.Engine, http.MethodGet, "/r/"+ref, nil)
+		doc := string(recorder.Result().Body())
+		if recorder.Result().StatusCode() != http.StatusOK ||
+			!strings.Contains(doc, "Referral code: `"+ref+"`") ||
+			!strings.Contains(doc, "https://cdn.eigenflux.ai/skills/latest/install.md") ||
+			string(recorder.Result().Header.Peek("Cache-Control")) != "no-store" {
+			t.Fatalf("join document did not carry ref: status=%d body=%s", recorder.Result().StatusCode(), recorder.Result().Body())
+		}
+		reported := h.json(t, http.MethodPost, "/api/v1/install/report", map[string]any{
+			"ref": ref, "metadata": map[string]string{"os": "test", "arch": "test"},
+		}, http.StatusOK)
+		if reported["converted"] != true || reported["attribution"].(map[string]any)["channel"] != "bilibili" {
+			t.Fatalf("unexpected install conversion: %#v", reported)
+		}
+		key := newKey(t)
+		req := h.request(t, key, ref)
+		identity := h.provision(t, key, req)
+		agentID := identity["agent_id"].(string)
+		before := h.agent(t, agentID)
+		if before.AcquisitionChannel != "bilibili" || before.EmailKind != "internal_alias" || identity["created"] != true {
+			t.Fatalf("new key identity missing acquisition before email binding: %+v response=%#v", before, identity)
+		}
+		h.bindEmail(t, identity)
+		after := h.agent(t, agentID)
+		if after.AcquisitionChannel != "bilibili" || after.EmailKind != "v2_bound" || after.EmailVerifiedAt <= 0 {
+			t.Fatalf("email binding lost acquisition or identity: %+v", after)
+		}
+		var token install.Token
+		if err := h.db.Where("token = ?", ref).First(&token).Error; err != nil {
+			t.Fatal(err)
+		}
+		if token.Channel != "bilibili" || token.CopiedAt <= 0 || token.FetchedAt <= 0 || token.ReportedAt <= 0 || token.ReportCount != 1 {
+			t.Fatalf("incomplete persisted install funnel: %+v", token)
+		}
+		// A later installation can reuse this key without replacing the original
+		// channel, including after the internal alias becomes a verified email.
+		replacement := h.request(t, key, h.mint(t, "google", ""))
+		reused := h.provision(t, key, replacement)
+		if reused["agent_id"] != agentID || reused["created"] != false || h.agent(t, agentID).AcquisitionChannel != "bilibili" {
+			t.Fatalf("existing stable identity was reattributed: %#v", reused)
+		}
+	})
+
+	t.Run("ref_is_signed_and_receipt_bound", func(t *testing.T) {
+		key := newKey(t)
+		req := h.request(t, key, h.mint(t, "bilibili", ""))
+		body := signedBody(t, key, req)
+		otherRef := h.mint(t, "google", "")
+		body["ref"] = otherRef
+		h.error(t, body, http.StatusUnauthorized, "INVALID_PROOF")
+		first := h.provision(t, key, req)
+		replay := h.provision(t, key, req)
+		if first["agent_id"] != replay["agent_id"] || first["access_token"] != replay["access_token"] {
+			t.Fatalf("exact retry did not return the persisted receipt: first=%#v replay=%#v", first, replay)
+		}
+		req.Ref = otherRef
+		h.error(t, signedBody(t, key, req), http.StatusConflict, "PROVISION_IDEMPOTENCY_CONFLICT")
+		if got := h.agent(t, first["agent_id"].(string)).AcquisitionChannel; got != "bilibili" {
+			t.Fatalf("conflicting retry overwrote acquisition: %q", got)
+		}
+	})
+
+	t.Run("absent_unknown_and_invalid_refs", func(t *testing.T) {
+		for _, ref := range []string{"", install.NewToken()} {
+			key := newKey(t)
+			identity := h.provision(t, key, h.request(t, key, ref))
+			if identity["created"] != true || h.agent(t, identity["agent_id"].(string)).AcquisitionChannel != "" {
+				t.Fatalf("unattributed registration failed for ref=%q: %#v", ref, identity)
+			}
+			// A reused key cannot fill an empty acquisition field using a later
+			// campaign, either; attribution belongs only to identity creation.
+			reused := h.provision(t, key, h.request(t, key, h.mint(t, "bilibili", "")))
+			if reused["created"] != false || h.agent(t, identity["agent_id"].(string)).AcquisitionChannel != "" {
+				t.Fatalf("later campaign claimed an existing unattributed identity: %#v", reused)
+			}
+		}
+		key := newKey(t)
+		req := h.request(t, key, "not-a-ref")
+		h.error(t, signedBody(t, key, req), http.StatusBadRequest, "INVALID_REF")
+		req.Ref = ""
+		h.provision(t, key, req)
+	})
+
+	t.Run("invite_relationship_survives_email_binding", func(t *testing.T) {
+		inviterKey := newKey(t)
+		inviterIdentity := h.provision(t, inviterKey, h.request(t, inviterKey, ""))
+		inviterID := inviterIdentity["agent_id"].(string)
+		inviter := h.agent(t, inviterID)
+		legacyCode := invite.NewCode()
+		if err := h.db.Exec(`INSERT INTO invite_codes (code, kind, agent_id, created_at)
+			VALUES (?, 'kol', ?, ?)`, legacyCode, inviterID, time.Now().UnixMilli()).Error; err != nil {
+			t.Fatal(err)
+		}
+		for _, code := range []string{inviter.ShortID, legacyCode} {
+			t.Run(code, func(t *testing.T) {
+				ref := h.mint(t, "bilibili", code)
+				key := newKey(t)
+				identity := h.provision(t, key, h.request(t, key, ref))
+				agentID := identity["agent_id"].(string)
+				before := h.agent(t, agentID)
+				wantInviter, _ := strconv.ParseInt(inviterID, 10, 64)
+				if before.AcquisitionChannel != "bilibili" || before.InvitedByCode != code || before.InviterAgentID != wantInviter || before.InvitedAt <= 0 {
+					t.Fatalf("invitation not associated with provisioned identity: %+v", before)
+				}
+				h.bindEmail(t, identity)
+				after := h.agent(t, agentID)
+				if after.AcquisitionChannel != before.AcquisitionChannel || after.InvitedByCode != before.InvitedByCode || after.InviterAgentID != before.InviterAgentID || after.InvitedAt != before.InvitedAt {
+					t.Fatalf("verified identity lost invitation: before=%+v after=%+v", before, after)
+				}
+			})
+		}
+	})
+
+	t.Run("provision_failure_rolls_back_attribution", func(t *testing.T) {
+		key := newKey(t)
+		req := h.request(t, key, h.mint(t, "bilibili", ""))
+		const callback = "installv2:fail-final-credential-insert"
+		var failed atomic.Bool
+		if err := h.db.Callback().Raw().Before("gorm:raw").Register(callback, func(tx *gorm.DB) {
+			if strings.Contains(tx.Statement.SQL.String(), "INSERT INTO agent_credential_sessions") && failed.CompareAndSwap(false, true) {
+				tx.AddError(errors.New("test failure after identity and attribution writes"))
+			}
+		}); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { h.db.Callback().Raw().Remove(callback) })
+		h.json(t, http.MethodPost, "/api/v2/agent-identities/provision", signedBody(t, key, req), http.StatusInternalServerError)
+		if !failed.Load() {
+			t.Fatal("provision failed before the final credential insert; rollback was not exercised")
+		}
+		var principals int64
+		if err := h.db.Raw(`SELECT COUNT(*) FROM agent_principals WHERE public_key = ?`, []byte(key.Public().(ed25519.PublicKey))).Scan(&principals).Error; err != nil || principals != 0 {
+			t.Fatalf("failed provision persisted a principal: count=%d err=%v", principals, err)
+		}
+		var agents int64
+		if err := h.db.Raw(`SELECT COUNT(*) FROM agents WHERE agent_name = ?`, req.AgentName).Scan(&agents).Error; err != nil || agents != 0 {
+			t.Fatalf("failed provision persisted attributed Agent: count=%d err=%v", agents, err)
+		}
+		var grantStatus string
+		if err := h.db.Raw(`SELECT status FROM agent_bootstrap_grants WHERE jti_hash = ?`, digest(req.BootstrapGrant)).Scan(&grantStatus).Error; err != nil || grantStatus != "issued" {
+			t.Fatalf("failed provision consumed grant: status=%q err=%v", grantStatus, err)
+		}
+		identity := h.provision(t, key, req)
+		if identity["created"] != true || h.agent(t, identity["agent_id"].(string)).AcquisitionChannel != "bilibili" {
+			t.Fatalf("retry after rollback did not create an attributed Agent: %#v", identity)
+		}
+	})
+
+	t.Run("legacy_upgrade_preserves_original_attribution", func(t *testing.T) {
+		for _, originalChannel := range []string{"", "x"} {
+			id, _ := h.ids.NextID()
+			agentID := strconv.FormatInt(id, 10)
+			shortID, err := agentidentity.GenerateShortID()
+			if err != nil {
+				t.Fatal(err)
+			}
+			now := time.Now().UnixMilli() - 1000
+			if err := h.db.Exec(`INSERT INTO agents (agent_id, short_id, email, agent_name, created_at, updated_at, acquisition_channel)
+				VALUES (?, ?, ?, 'Legacy Attribution Test', ?, ?, ?)`, id, shortID, "legacy-"+agentID+"@installv2.example.test", now, now, originalChannel).Error; err != nil {
+				t.Fatal(err)
+			}
+			if err := h.db.Exec(`INSERT INTO agent_profiles (agent_id, status, updated_at) VALUES (?, 0, ?)`, id, now).Error; err != nil {
+				t.Fatal(err)
+			}
+			key := newKey(t)
+			publicKey := base64.RawURLEncoding.EncodeToString(key.Public().(ed25519.PublicKey))
+			grant := h.json(t, http.MethodPost, "/test/legacy-upgrade/"+agentID, map[string]any{
+				"public_key": publicKey, "idempotency_key": "legacy-upgrade-" + agentID,
+			}, http.StatusCreated)
+			req := provisionProof{
+				BootstrapGrant: grant["bootstrap_grant"].(string), Nonce: grant["nonce"].(string),
+				PublicKey: publicKey, IdempotencyKey: "legacy-provision-" + agentID,
+				IssuedAt: time.Now().UnixMilli(), AgentName: "Legacy Attribution Test", ExpectedAgentID: agentID,
+				Draft: json.RawMessage(`{}`), Ref: h.mint(t, "bilibili", ""),
+			}
+			identity := h.provision(t, key, req)
+			if identity["created"] != false || identity["agent_id"] != agentID || h.agent(t, agentID).AcquisitionChannel != originalChannel {
+				t.Fatalf("legacy upgrade changed original attribution %q: %#v agent=%+v", originalChannel, identity, h.agent(t, agentID))
+			}
+		}
+	})
+}
+
+type harness struct {
+	db   *gorm.DB
+	http *server.Hertz
+	ids  *idGenerator
+}
+
+type idGenerator struct{ value atomic.Int64 }
+
+func (g *idGenerator) NextID() (int64, error) { return g.value.Add(1), nil }
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN must point at a migrated, isolated PostgreSQL test database")
+	}
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := database.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	previous := sharedDB.DB
+	sharedDB.DB = database
+	t.Cleanup(func() { sharedDB.DB = previous })
+	ids := &idGenerator{}
+	ids.value.Store(time.Now().UnixMicro())
+	svc, err := consolev2.NewService(database, ids, &config.Config{
+		ConsoleV2BootstrapSecret:  "installv2-test-broker",
+		ConsoleV2OTPPepper:        "installv2-test-otp-pepper",
+		ConsoleV2PublicURL:        testOrigin,
+		OfficialTestEmailSuffixes: []string{"@installv2.example.test"},
+		OfficialTestOTP:           "135790",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := server.New(server.WithHostPorts("127.0.0.1:0"))
+	svc.Register(httpServer)
+	// Supply the authenticated V1 identity at the middleware boundary while
+	// exercising the public legacy-upgrade handler and its subject-bound grant.
+	httpServer.POST("/test/legacy-upgrade/:agent_id", func(ctx context.Context, c *app.RequestContext) {
+		id, err := strconv.ParseInt(c.Param("agent_id"), 10, 64)
+		if err != nil {
+			c.SetStatusCode(http.StatusBadRequest)
+			return
+		}
+		c.Set("agent_id", id)
+		svc.LegacyAgentUpgradeChallengeHandler()(ctx, c)
+	})
+	install.Register(httpServer, testOrigin)
+	return &harness{db: database, http: httpServer, ids: ids}
+}
+
+func (h *harness) perform(t *testing.T, method, path string, body any, headers ...ut.Header) (int, map[string]any, [][]byte) {
+	t.Helper()
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers = append(headers, ut.Header{Key: "Content-Type", Value: "application/json"},
+		ut.Header{Key: "Origin", Value: testOrigin}, ut.Header{Key: "Host", Value: "console.example.test"})
+	recorder := ut.PerformRequest(h.http.Engine, method, testOrigin+path,
+		&ut.Body{Body: bytes.NewReader(encoded), Len: len(encoded)}, headers...)
+	response := recorder.Result()
+	var payload map[string]any
+	if err := json.Unmarshal(response.Body(), &payload); err != nil {
+		t.Fatalf("decode %s response: %v body=%s", path, err, response.Body())
+	}
+	return response.StatusCode(), payload, response.Header.PeekAll("Set-Cookie")
+}
+
+func (h *harness) json(t *testing.T, method, path string, body any, want int, headers ...ut.Header) map[string]any {
+	t.Helper()
+	status, payload, _ := h.perform(t, method, path, body, headers...)
+	if status != want {
+		t.Fatalf("%s %s status=%d want=%d response=%#v", method, path, status, want, payload)
+	}
+	data, _ := payload["data"].(map[string]any)
+	return data
+}
+
+func (h *harness) mint(t *testing.T, channel, code string) string {
+	t.Helper()
+	data := h.json(t, http.MethodPost, "/api/v1/install/token", map[string]any{
+		"utm_source": channel, "utm_medium": "video", "utm_campaign": "bilibili_v2_test", "invite_code": code,
+	}, http.StatusOK)
+	return data["ref"].(string)
+}
+
+// Field order and omission are part of the public V2 signing contract. This
+// independent client deliberately does not call the server's private signer.
+type provisionProof struct {
+	BootstrapGrant  string            `json:"bootstrap_grant"`
+	IdempotencyKey  string            `json:"idempotency_key"`
+	Nonce           string            `json:"nonce"`
+	PublicKey       string            `json:"public_key"`
+	IssuedAt        int64             `json:"issued_at"`
+	AgentName       string            `json:"agent_name"`
+	ExpectedAgentID string            `json:"expected_agent_id,omitempty"`
+	Draft           json.RawMessage   `json:"onboarding_draft,omitempty"`
+	FieldProvenance map[string]string `json:"field_provenance,omitempty"`
+	Ref             string            `json:"ref,omitempty"`
+}
+
+func newKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func digest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func (h *harness) request(t *testing.T, key ed25519.PrivateKey, ref string) provisionProof {
+	t.Helper()
+	id, _ := h.ids.NextID()
+	publicKey := base64.RawURLEncoding.EncodeToString(key.Public().(ed25519.PublicKey))
+	grant := h.json(t, http.MethodPost, "/api/v2/bootstrap-grants", map[string]any{
+		"public_key": publicKey, "entitlement_id": fmt.Sprintf("installv2-%d", id),
+		"idempotency_key": fmt.Sprintf("installv2-grant-%d", id), "channel": "integration", "policy": "limited",
+	}, http.StatusCreated, ut.Header{Key: "X-Bootstrap-Broker-Secret", Value: "installv2-test-broker"})
+	return provisionProof{
+		BootstrapGrant: grant["bootstrap_grant"].(string), Nonce: grant["nonce"].(string),
+		IdempotencyKey: fmt.Sprintf("installv2-provision-%d", id), PublicKey: publicKey,
+		IssuedAt: time.Now().UnixMilli(), AgentName: fmt.Sprintf("Install V2 Test %d", id), Draft: json.RawMessage(`{}`), Ref: ref,
+	}
+}
+
+func signedBody(t *testing.T, key ed25519.PrivateKey, req provisionProof) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof := []byte("EF-AUTH-V2\x00POST\n/api/v2/agent-identities/provision\n" + digest(string(encoded)))
+	var body map[string]any
+	if err := json.Unmarshal(encoded, &body); err != nil {
+		t.Fatal(err)
+	}
+	body["signature"] = base64.RawURLEncoding.EncodeToString(ed25519.Sign(key, proof))
+	return body
+}
+
+func (h *harness) provision(t *testing.T, key ed25519.PrivateKey, req provisionProof) map[string]any {
+	t.Helper()
+	return h.json(t, http.MethodPost, "/api/v2/agent-identities/provision", signedBody(t, key, req), http.StatusOK)
+}
+
+func (h *harness) error(t *testing.T, body any, want int, code string) {
+	t.Helper()
+	status, payload, _ := h.perform(t, http.MethodPost, "/api/v2/agent-identities/provision", body)
+	apiError, _ := payload["error"].(map[string]any)
+	if status != want || apiError["code"] != code {
+		t.Fatalf("provision status=%d want=%d error=%#v want code=%s", status, want, payload, code)
+	}
+}
+
+type agentRow struct {
+	AgentID            int64
+	ShortID            string
+	Email              string
+	EmailKind          string
+	EmailVerifiedAt    int64
+	AcquisitionChannel string
+	InvitedByCode      string
+	InviterAgentID     int64
+	InvitedAt          int64
+}
+
+func (h *harness) agent(t *testing.T, id string) agentRow {
+	t.Helper()
+	var result agentRow
+	if err := h.db.Raw(`SELECT agent_id, short_id, email, email_kind, COALESCE(email_verified_at, 0) AS email_verified_at,
+		acquisition_channel, invited_by_code, inviter_agent_id, invited_at FROM agents WHERE agent_id = ?`, id).Scan(&result).Error; err != nil {
+		t.Fatal(err)
+	}
+	if result.AgentID == 0 {
+		t.Fatalf("Agent %s was not persisted", id)
+	}
+	return result
+}
+
+func (h *harness) bindEmail(t *testing.T, identity map[string]any) {
+	t.Helper()
+	const nonce = "installv2-browser-nonce-1234567890"
+	handoff := h.json(t, http.MethodPost, "/api/v2/console/handoffs", map[string]any{"browser_nonce": nonce},
+		http.StatusCreated, ut.Header{Key: "Authorization", Value: "Bearer " + identity["access_token"].(string)})
+	link, err := url.Parse(handoff["handoff_url"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, exchange, cookies := h.perform(t, http.MethodPost, "/api/v2/console/handoffs/exchange", map[string]any{
+		"ticket": link.Query().Get("ticket"), "browser_nonce": nonce,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("handoff exchange status=%d payload=%#v", status, exchange)
+	}
+	var pairs []string
+	for _, cookie := range cookies {
+		pairs = append(pairs, strings.SplitN(string(cookie), ";", 2)[0])
+	}
+	headers := []ut.Header{
+		{Key: "Cookie", Value: strings.Join(pairs, "; ")},
+		{Key: "X-CSRF-Token", Value: exchange["data"].(map[string]any)["csrf_token"].(string)},
+	}
+	email := "agent-" + identity["agent_id"].(string) + "@installv2.example.test"
+	challenge := h.json(t, http.MethodPost, "/api/v2/account-email-bindings/challenges", map[string]any{"email": email}, http.StatusAccepted, headers...)
+	verified := h.json(t, http.MethodPost, "/api/v2/account-email-bindings/verify", map[string]any{
+		"challenge_id": challenge["challenge_id"], "email": email, "otp": "135790",
+	}, http.StatusOK, headers...)
+	if verified["bound"] != true || verified["verification_level"] != "email_verified" {
+		t.Fatalf("email binding incomplete: %#v", verified)
+	}
+	var bindings int64
+	if err := h.db.Raw(`SELECT COUNT(*) FROM agent_email_bindings WHERE agent_id = ? AND normalized_email = ?
+		AND verification_state = 'verified' AND status = 'active'`, identity["agent_id"], email).Scan(&bindings).Error; err != nil || bindings != 1 {
+		t.Fatalf("verified email does not belong to the provisioned identity: count=%d err=%v", bindings, err)
+	}
+}

--- a/tests/installv2/cli_flow_test.go
+++ b/tests/installv2/cli_flow_test.go
@@ -1,0 +1,123 @@
+package installv2_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"github.com/cloudwego/hertz/pkg/network/standard"
+
+	"eigenflux_server/api/consolev2"
+	"eigenflux_server/pkg/config"
+)
+
+// This test uses the built CLI in separate processes, a real HTTP listener,
+// production V2 handlers, and PostgreSQL. It verifies that delayed onboarding
+// consumes the installer's persisted ref with a mutually valid signed proof.
+func TestCLIInstallRefToV2Identity(t *testing.T) {
+	binary := os.Getenv("EIGENFLUX_TEST_CLI")
+	if binary == "" {
+		t.Skip("EIGENFLUX_TEST_CLI must point at the CLI built from this checkout")
+	}
+	h := newHarness(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint := "http://" + listener.Addr().String()
+	svc, err := consolev2.NewService(h.db, h.ids, &config.Config{
+		ConsoleV2BootstrapSecret: "installv2-test-broker",
+		ConsoleV2OTPPepper:       "installv2-test-otp-pepper",
+		ConsoleV2PublicURL:       testOrigin,
+	})
+	if err != nil {
+		_ = listener.Close()
+		t.Fatal(err)
+	}
+	live := server.New(server.WithListener(listener), server.WithTransport(standard.NewTransporter))
+	svc.Register(live)
+	stopped := make(chan error, 1)
+	go func() { stopped <- live.Run() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = live.Shutdown(ctx)
+		_ = listener.Close()
+		select {
+		case <-stopped:
+		case <-ctx.Done():
+			t.Error("test HTTP server did not stop")
+		}
+	})
+
+	runCLI := func(home string, args ...string) []byte {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		command := exec.CommandContext(ctx, binary, append([]string{"--homedir", home, "--format", "json"}, args...)...)
+		var stderr bytes.Buffer
+		command.Stderr = &stderr
+		data, err := command.Output()
+		if err != nil {
+			t.Fatalf("CLI %v: %v stderr=%s stdout=%s", args, err, stderr.String(), data)
+		}
+		return data
+	}
+	decode := func(data []byte) map[string]any {
+		t.Helper()
+		var result map[string]any
+		if err := json.Unmarshal(data, &result); err != nil {
+			t.Fatalf("decode CLI: %v output=%s", err, data)
+		}
+		return result
+	}
+	provision := func(home string, ref string) map[string]any {
+		t.Helper()
+		identity := decode(runCLI(home, "agent", "init"))
+		id, _ := h.ids.NextID()
+		grant := h.json(t, http.MethodPost, "/api/v2/bootstrap-grants", map[string]any{
+			"entitlement_id": fmt.Sprintf("cli-install-%d", id), "idempotency_key": fmt.Sprintf("cli-install-grant-%d", id),
+			"public_key": identity["public_key"],
+		}, http.StatusCreated, ut.Header{Key: "X-Bootstrap-Broker-Secret", Value: "installv2-test-broker"})
+		args := []string{"agent", "provision", "--bootstrap-grant", grant["bootstrap_grant"].(string),
+			"--nonce", grant["nonce"].(string), "--no-handoff"}
+		if ref != "" {
+			args = append(args, "--ref", ref)
+		}
+		return decode(runCLI(home, args...))
+	}
+
+	home := t.TempDir()
+	runCLI(home, "server", "update", "--name", "eigenflux", "--endpoint", endpoint)
+	ref := h.mint(t, "bilibili", "")
+	saved := decode(runCLI(home, "agent", "install-ref", "--ref", ref, "--endpoint", endpoint))
+	if saved["ref"] != ref || saved["saved"] != true {
+		t.Fatalf("installer ref not saved: %#v", saved)
+	}
+	created := provision(home, "")
+	agentID := created["agent_id"].(string)
+	if created["created"] != true || h.agent(t, agentID).AcquisitionChannel != "bilibili" {
+		t.Fatalf("delayed CLI provision lost the saved ref: %#v", created)
+	}
+	otherRef := h.mint(t, "google", "")
+	reused := provision(home, otherRef)
+	if reused["agent_id"] != agentID || reused["created"] != false || h.agent(t, agentID).AcquisitionChannel != "bilibili" {
+		t.Fatalf("repeated CLI provision changed acquisition: %#v", reused)
+	}
+
+	directHome := t.TempDir()
+	runCLI(directHome, "server", "update", "--name", "eigenflux", "--endpoint", endpoint)
+	direct := provision(directHome, h.mint(t, "bilibili", ""))
+	if direct["created"] != true || h.agent(t, direct["agent_id"].(string)).AcquisitionChannel != "bilibili" {
+		t.Fatalf("explicit CLI ref did not reach V2 identity: %#v", direct)
+	}
+}


### PR DESCRIPTION
V2 provisioning now binds a signed install ref to a newly created Agent in the same transaction, preserving the source through email binding and identity reuse. CLI 0.0.43 can persist a server-scoped ref in the stable Agent Home and forward it during provisioning.

This is the compatibility phase of the rollout. The installer, canonical installation document, and minimum Skills CLI version remain unchanged. Deploy this API first, then publish and verify CLI 0.0.43 before enabling the referral installer in the next PR. No schema migration is added.

Validation: independent review and full CLI tests passed. The real CLI/API/PostgreSQL suite covers Bilibili attribution, email binding, signed-ref tampering, idempotency, invitations, legacy upgrades, and transaction rollback; the final split-branch run passed, including the separate-process CLI test.
