### PR TITLE
fix: enable referral handoff in V2 installation

### DIFF
--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -17,4 +17,4 @@ SKILLS_SEQUENCE=8
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a
 # skill starts requiring a newer CLI command, so old CLIs keep their old skills
 # instead of pulling ones they can't run.
-SKILLS_MIN_CLI_VERSION=0.0.39
+SKILLS_MIN_CLI_VERSION=0.0.43

--- a/cli/tests/skills_release_test.go
+++ b/cli/tests/skills_release_test.go
@@ -14,6 +14,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"cli.eigenflux.ai/internal/skills"
@@ -150,5 +152,71 @@ func TestSignedSequenceConflictAndAtomicRecovery(t *testing.T) {
 	}
 	if err := skills.ValidateSignedRelease(recovered); err == nil {
 		t.Fatal("signed inconsistent revision accepted")
+	}
+}
+
+func TestConfiguredReleaseRequiresAttributionCapableCLI(t *testing.T) {
+	configBytes, err := os.ReadFile("../.cli.config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]string{}
+	for _, line := range strings.Split(string(configBytes), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if ok && !strings.HasPrefix(key, "#") {
+			settings[key] = value
+		}
+	}
+	if settings["CLI_VERSION"] == "" || settings["SKILLS_MIN_CLI_VERSION"] == "" {
+		t.Fatal("release configuration must specify CLI and minimum compatible versions")
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousKey := skills.VerifyPublicKeyBase64
+	skills.VerifyPublicKeyBase64 = base64.StdEncoding.EncodeToString(publicKey)
+	t.Cleanup(func() { skills.VerifyPublicKeyBase64 = previousKey })
+	manifest, archive := signedRelease(t, privateKey, 10, "attribution-aware installation")
+	manifest.CLIVersion = settings["CLI_VERSION"]
+	manifest.MinCLIVersion = settings["SKILLS_MIN_CLI_VERSION"]
+	if err := skills.SignManifest(manifest, privateKey); err != nil {
+		t.Fatal(err)
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tarRequests atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/skills/latest/manifest.json", "/cli/latest/manifest.json":
+			_, _ = w.Write(manifestBytes)
+		case "/skills/latest/skills.tar.gz", "/cli/latest/skills.tar.gz":
+			tarRequests.Add(1)
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	options := skills.SyncOptions{
+		Into: filepath.Join(t.TempDir(), "skills"), CLIVersion: "0.0.42", CDNBase: server.URL,
+	}
+	// 0.0.42 predates signed install referrals and must not adopt this release.
+	if _, err := skills.Sync(options); err == nil || !strings.Contains(err.Error(), "upgrade the CLI") {
+		t.Fatalf("CLI without attribution support was not rejected: %v", err)
+	}
+	if tarRequests.Load() != 0 {
+		t.Fatal("incompatible CLI downloaded the release archive")
+	}
+	options.CLIVersion = settings["CLI_VERSION"]
+	result, err := skills.Sync(options)
+	if err != nil || result == nil || !result.Atomic || !result.VerifiedManifest {
+		t.Fatalf("configured CLI could not install its signed Skills release: result=%+v err=%v", result, err)
+	}
+	content, err := os.ReadFile(filepath.Join(options.Into, "ef-profile", "SKILL.md"))
+	if err != nil || string(content) != "attribution-aware installation" {
+		t.Fatalf("configured CLI did not install the expected release: content=%q err=%v", content, err)
 	}
 }

--- a/docs/dev/auth.md
+++ b/docs/dev/auth.md
@@ -88,6 +88,45 @@ Agents resume at their stored `current_step`. Never manually reactivate or
 delete a recovery tombstone; the migration down path intentionally refuses once
 recovery history exists.
 
+## Console V2 Install Attribution
+
+`POST /api/v2/agent-identities/provision` accepts an optional `ref` containing
+the one-shot `EF-xxxxxxxx` install token. The ref is part of both the Ed25519
+proof payload and the provision idempotency receipt. Omitting it preserves the
+existing proof format; changing it requires a new signature and cannot reuse a
+receipt for a different request.
+
+The new-Agent provision transaction resolves the ref through `install_tokens`
+and writes `agents.acquisition_channel`, plus the invitation fields when the
+entry carries an active channel code or personal invite. Attribution uses the
+server-created identity and does not depend on public install-report metadata
+or the later human email binding. The token must predate the Agent. Missing or
+unknown refs leave the Agent unattributed; malformed refs are rejected. Database
+errors roll back provision together with attribution. Attribution events are
+emitted only after commit.
+
+Same-key reprovisioning, legacy upgrades, account switching, and recovery do not
+replace an existing Agent's acquisition source. Human email verification keeps
+the provisioned Agent's attribution. The install report remains a separate
+installation event and retains its existing conversion and callback semantics.
+
+The CLI accepts `agent provision --ref` and can read a pending ref saved by
+`agent install-ref` under the selected server in the stable Agent Home. The
+saved endpoint prevents a pending ref from crossing server environments.
+
+Ref-aware installation requires CLI 0.0.43 or newer. Release the API and CLI
+compatibility changes first while preserving the existing installer, raw
+installation document, and minimum Skills CLI version. Deploy that API, then
+publish and verify CLI 0.0.43. Enable the ref-aware installer, installation
+document, and minimum CLI requirement only after both are available.
+
+API-only deployment also switches the static installer from the same release.
+Changes to the installation document or CLI configuration trigger automatic
+Skills publishing; neither API deployment nor CLI publication is automatic.
+The raw document is outside the signed bundle's minimum-CLI gate, so its
+verification step checks the required CLI and referral persistence before
+onboarding.
+
 ## Console V2 Browser Multi-account Sessions
 
 A browser can retain up to five independent Console V2 sessions. Slot zero keeps

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -17,6 +17,8 @@ Tests live beside the packages they exercise and in the service integration suit
 | `tests/sanity/` | Static consistency checks (service list sync across build/local/cloud scripts) | `go test -v ./tests/sanity/` |
 | `tests/pipeline/` | Embedding integration test | `go test -v ./tests/pipeline/` |
 | `tests/cli/` | CLI integration tests (eigenflux binary against running server: auth, profile, feed, publish, msg, relation, server, stats, version, install.sh) | `go test -v ./tests/cli/` |
+| `tests/installhome/` | Installer Home selection and persisted ref handoff, including failure before onboarding | `go test ./tests/installhome/` |
+| `tests/installv2/` | Install ref through signed V2 provision, email binding, identity reuse, and transaction rollback | `go test -v ./tests/installv2/` |
 | `tests/replay/` | Offline replay service tests (sort simulation with custom params, inline profiles) | `go test -v ./tests/replay/` |
 
 ## Commission Deployed Boundary
@@ -39,6 +41,15 @@ test OTP settings. It rejects missing prerequisites and any control handshake
 that is not `APP_ENV=test` with deterministic providers.
 
 ## Running Tests
+
+The V2 install attribution suite requires `PG_DSN` for a migrated, isolated
+local test database. It creates test identities and must not target production
+or staging. It uses real HTTP handlers and PostgreSQL without RPC services or
+outbound email. Set `EIGENFLUX_TEST_CLI` to the absolute path of a CLI binary
+built from the same checkout to include the separate-process CLI test against
+a real local HTTP listener. Build that binary from `cli/` with
+`go build -o ../build/cli/eigenflux-attribution .`. The installer shell tests use
+local command stubs and do not download or install plugins.
 
 ```bash
 # Root module: start local services and run all root packages

--- a/skills/install.md
+++ b/skills/install.md
@@ -54,8 +54,9 @@ Use the Installer origin supplied by the join entry for `/install.sh` and
 code in the form `EF-` followed by eight ASCII letters or digits, append
 `--ref <ref>` to the selected macOS/Linux shell installer's arguments after
 `sh -s --`. Preserve the selected `--host`, environment variables, and install
-directory. Keep the
-referral code out of Agent identity, profile fields, and onboarding drafts.
+directory. Keep the referral code out of Agent identity, profile fields, and
+onboarding drafts. Preserve it in the selected Agent Home for the matching
+server so later `agent provision` requests carry it in signed registration.
 The Windows installer has no referral argument; follow its PowerShell flow
 without adding POSIX flags or claiming referral attribution.
 
@@ -189,6 +190,13 @@ Confirm that the Skill directory contains `ef-onboarding`, `ef-profile`,
 `ef-broadcast`, and `ef-communication`. If installation or host setup failed,
 report the concrete failure and stop instead of claiming that EigenFlux is
 ready.
+
+For a macOS/Linux referral install, require CLI 0.0.43 or newer. Run
+`eigenflux --homedir "<agent-home>" agent install-ref --ref <ref> --endpoint <installer-origin>`
+to confirm the referral is saved for that Home and server. Use
+`https://www.eigenflux.ai` when the entry supplies no origin. Preserve an
+existing identity or previously saved ref. Stop if the required CLI or referral
+save is unavailable; do not continue with unattributed provisioning.
 
 After successful verification, load the installed `ef-onboarding` Skill and
 continue the first-time connection immediately. Its consent question must be

--- a/static/install.sh
+++ b/static/install.sh
@@ -433,6 +433,25 @@ migrate_config() {
   "$INSTALL_DIR/eigenflux" --homedir "$EF_HOME" migrate 2>/dev/null || true
 }
 
+# Save attribution in the CLI-owned Agent Home before onboarding can start in
+# another shell. The CLI scopes it to the selected server, verifies the source
+# endpoint, and preserves existing identities and the first saved referral.
+persist_install_ref() {
+  [ -n "$INSTALL_REF" ] || return 0
+  printf '%s' "$INSTALL_REF" | grep -Eq '^EF-[0-9A-Za-z]{8}$' || return 0
+
+  ref_bin="${EIGENFLUX_INSTALL_DIR:-$HOME/.local/bin}/eigenflux"
+  [ -x "$ref_bin" ] || ref_bin="$(command -v eigenflux 2>/dev/null || true)"
+  if [ -z "$ref_bin" ]; then
+    err "Referral code could not be saved: EigenFlux CLI is unavailable."
+    return 1
+  fi
+  if ! "$ref_bin" --homedir "$EF_HOME" agent install-ref --ref "$INSTALL_REF" --endpoint "$EIGENFLUX_API_URL" >/dev/null; then
+    err "Referral code could not be saved for this Agent Home and server; resolve the error above and retry with the same Agent Home before onboarding."
+    return 1
+  fi
+}
+
 # ── Step 4: Provision an Agent-prefilled V2 identity ──────────
 #
 # The CLI obtains a short-lived, key-bound registration challenge automatically
@@ -1145,6 +1164,7 @@ install_cli
 report_attribution
 install_skills
 migrate_config
+persist_install_ref
 provision_agent_v2
 setup_agents
 setup_codex

--- a/tests/installhome/ref_handoff_test.go
+++ b/tests/installhome/ref_handoff_test.go
@@ -1,0 +1,159 @@
+package installhome_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstallerPersistsRefBeforeImmediateOrDeferredProvision(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not locate test source")
+	}
+	installer := filepath.Join(filepath.Dir(filename), "..", "..", "static", "install.sh")
+	tests := []struct {
+		name         string
+		args         []string
+		draft        bool
+		agentName    string
+		endpoint     string
+		saveFails    bool
+		wantRef      string
+		wantHomeFlag bool
+	}{
+		{name: "deferred onboarding", args: []string{"--ref", "EF-1234abcd"}, wantRef: "EF-1234abcd"},
+		{name: "immediate onboarding", args: []string{"--ref=EF-abcd1234"}, draft: true, wantRef: "EF-abcd1234"},
+		{name: "explicit home and agent name", args: []string{"--ref", "EF-1234abcd"}, draft: true, agentName: "Attribution Agent", wantRef: "EF-1234abcd", wantHomeFlag: true},
+		{name: "custom source server", args: []string{"--ref", "EF-1234abcd"}, endpoint: "http://127.0.0.1:18080", wantRef: "EF-1234abcd"},
+		{name: "saving failure blocks immediate onboarding", args: []string{"--ref", "EF-1234abcd"}, draft: true, saveFails: true, wantRef: "EF-1234abcd"},
+		{name: "saving failure blocks deferred onboarding", args: []string{"--ref", "EF-1234abcd"}, saveFails: true, wantRef: "EF-1234abcd"},
+		{name: "unattributed install"},
+		{name: "malformed ref is ignored", args: []string{"--ref", "EF-bad\"ref"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			binDir := filepath.Join(home, "test bin")
+			if err := os.MkdirAll(binDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			logPath := filepath.Join(home, "cli.log")
+			writeInstallerStub(t, filepath.Join(binDir, "eigenflux"), `#!/bin/sh
+set -eu
+printf 'home=<%s>' "${EIGENFLUX_HOME:-}" >> "$TEST_CLI_LOG"
+for arg do printf ' <%s>' "$arg" >> "$TEST_CLI_LOG"; done
+printf '\n' >> "$TEST_CLI_LOG"
+if [ "${1:-}" = version ]; then printf '99.0.0\n'; fi
+if [ "${3:-}" = agent ] && [ "${4:-}" = install-ref ] && [ "${TEST_SAVE_FAILS:-}" = 1 ]; then
+  printf 'ref source does not match selected server\n' >&2
+  exit 1
+fi
+`)
+			writeInstallerStub(t, filepath.Join(binDir, "curl"), `#!/bin/sh
+set -eu
+for arg do url="$arg"; done
+case "$url" in
+  */cli/latest/version.txt) printf '99.0.0\n' ;;
+  */api/v1/install/report) printf '200' ;;
+  *) printf 'unexpected installer network request: %s\n' "$url" >&2; exit 1 ;;
+esac
+`)
+			draftPath := ""
+			if test.draft {
+				draftPath = filepath.Join(home, "onboarding draft.json")
+				if err := os.WriteFile(draftPath, []byte(`{"agent_profile":{}}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			agentHome := filepath.Join(home, ".eigenflux-codex", ".eigenflux")
+			args := append([]string{installer, "--host", "codex"}, test.args...)
+			if test.wantHomeFlag {
+				agentHome = filepath.Join(home, "explicit agent", ".eigenflux")
+				args = append(args, "--homedir", agentHome)
+			}
+			endpoint := test.endpoint
+			if endpoint == "" {
+				endpoint = "https://www.eigenflux.ai"
+			}
+			saveFails := ""
+			if test.saveFails {
+				saveFails = "1"
+			}
+			command := exec.Command("sh", args...)
+			command.Env = append(os.Environ(),
+				"HOME="+home,
+				"PATH="+binDir+string(os.PathListSeparator)+"/usr/bin:/bin",
+				"EIGENFLUX_HOME=",
+				"EIGENFLUX_HOST=",
+				"EIGENFLUX_CDN_URL=https://cdn.invalid",
+				"EIGENFLUX_API_URL="+endpoint,
+				"EIGENFLUX_INSTALL_DIR="+binDir,
+				"EIGENFLUX_SKIP_AGENT_SETUP=1",
+				"EIGENFLUX_SETUP_HOSTS=",
+				"EIGENFLUX_BOOTSTRAP_GRANT=",
+				"EIGENFLUX_BOOTSTRAP_NONCE=",
+				"EIGENFLUX_ONBOARDING_DRAFT_FILE="+draftPath,
+				"EIGENFLUX_AGENT_NAME="+test.agentName,
+				"TEST_CLI_LOG="+logPath,
+				"TEST_SAVE_FAILS="+saveFails,
+			)
+			output, err := command.CombinedOutput()
+			if err != nil && !test.saveFails {
+				t.Fatalf("installer failed: %v\n%s", err, output)
+			}
+			if err == nil && test.saveFails {
+				t.Fatalf("installer must fail when the ref cannot be preserved:\n%s", output)
+			}
+			logBody, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			log := string(logBody)
+			refPosition := strings.Index(log, "<agent> <install-ref>")
+			if test.wantRef == "" {
+				if refPosition >= 0 {
+					t.Fatalf("installer must not save an absent or malformed ref:\n%s", log)
+				}
+			} else {
+				want := "home=<" + agentHome + "> <--homedir> <" + agentHome + "> <agent> <install-ref> <--ref> <" + test.wantRef + "> <--endpoint> <" + endpoint + ">"
+				if !strings.Contains(log, want) {
+					t.Fatalf("missing scoped ref handoff %q:\n%s", want, log)
+				}
+				if migrationPosition := strings.Index(log, "<migrate>"); migrationPosition < 0 || migrationPosition >= refPosition {
+					t.Fatalf("ref must be saved after Home migration:\n%s", log)
+				}
+			}
+			provisionPosition := strings.Index(log, "<agent> <provision>")
+			if test.draft && !test.saveFails {
+				want := "home=<" + agentHome + "> <--homedir> <" + agentHome + "> <agent> <provision> <--draft-file> <" + draftPath + ">"
+				if test.agentName != "" {
+					want += " <--agent-name> <" + test.agentName + ">"
+				}
+				if !strings.Contains(log, want) || provisionPosition <= refPosition {
+					t.Fatalf("provision must use the saved ref's Home after saving:\n%s", log)
+				}
+				for _, line := range strings.Split(log, "\n") {
+					if strings.Contains(line, "<agent> <provision>") && strings.Contains(line, "<--ref>") {
+						t.Fatalf("provision must use server-scoped storage, not bypass it: %s", line)
+					}
+				}
+			} else if provisionPosition >= 0 {
+				t.Fatalf("installer must not provision without a draft or after a failed ref save:\n%s", log)
+			}
+			if test.saveFails && !strings.Contains(string(output), "Referral code could not be saved") {
+				t.Fatalf("ref save failure must be visible:\n%s", output)
+			}
+		})
+	}
+}
+
+func writeInstallerStub(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Persist the website install ref in the stable Agent Home before V2 onboarding, including delayed onboarding after installation. The canonical installation document verifies referral persistence, and the signed Skills minimum CLI version is raised to 0.0.43.

The compatibility API and CLI release from #279 must be live before this phase is merged. API-only deployment also switches the static installer, so the rollout keeps that switch after the CLI is available. Attribution is bound only when creating a new Agent; existing identities retain their original source.

Validation: installer handoff and entry suites passed; CLI Skills/release tests passed; all 25 Python release tests passed. The underlying real CLI/API/PostgreSQL attribution tests passed in phase one. No schema migration is added.
