### PR TITLE
fix(console): expose encounter add-friend visibility

### DIFF
--- a/api/consolev2/home_handlers_postgres_test.go
+++ b/api/consolev2/home_handlers_postgres_test.go
@@ -524,6 +524,21 @@ func testConsoleCountrySources(t *testing.T, db *gorm.DB, svc *Service, h *serve
 	if !ok || len(encounters) != 1 || encounters[0].(map[string]interface{})["country_code"] != "SG" {
 		t.Fatalf("Today encounters=%#v", data["encounters"])
 	}
+	if encounters[0].(map[string]interface{})["show_add_friend"] != true {
+		t.Fatalf("Today encounters should default to allowing friend requests: %#v", encounters)
+	}
+	for _, visible := range []bool{false, true} {
+		exec(`INSERT INTO agent_settings (agent_id, show_add_friend) VALUES (?, ?)
+			ON CONFLICT (agent_id) DO UPDATE SET show_add_friend = EXCLUDED.show_add_friend`, peerID, visible)
+		settingStatus, settingPayload, _ := performJSON(t, h, http.MethodGet, "/api/v2/console/today", map[string]interface{}{}, cookie)
+		if settingStatus != http.StatusOK {
+			t.Fatalf("Today setting status=%d payload=%#v", settingStatus, settingPayload)
+		}
+		settingEncounters := responseData(t, settingPayload)["encounters"].([]interface{})
+		if len(settingEncounters) != 1 || settingEncounters[0].(map[string]interface{})["show_add_friend"] != visible {
+			t.Fatalf("Today encounters should respect show_add_friend=%v: %#v", visible, settingEncounters)
+		}
+	}
 	contexts := data["agent_contexts"].(map[string]interface{})
 	if contexts[strconv.FormatInt(peerID, 10)].(map[string]interface{})["country_code"] != "SG" {
 		t.Fatalf("Today contexts=%#v", contexts)

--- a/api/consolev2/today_handlers.go
+++ b/api/consolev2/today_handlers.go
@@ -23,6 +23,7 @@ const (
 )
 
 type todayEncounter struct {
+	ShowAddFriend    bool   `gorm:"column:show_add_friend" json:"show_add_friend"`
 	PeerAgentID      int64  `gorm:"column:peer_agent_id" json:"peer_agent_id,string"`
 	LastInteraction  int64  `gorm:"column:last_interaction_at" json:"last_interaction_at"`
 	InteractionCount int64  `gorm:"column:interaction_count" json:"interaction_count"`
@@ -469,9 +470,11 @@ func (s *Service) getToday(_ context.Context, c *app.RequestContext) {
 		)
 		SELECT grouped.peer_agent_id, grouped.last_interaction_at, grouped.interaction_count,
 			COALESCE(card.private_card->>'geo', '') AS country_code,
+			COALESCE(settings.show_add_friend, true) AS show_add_friend,
 			COUNT(*) OVER() AS total_count
 		FROM grouped
 		LEFT JOIN agent_cards card ON card.agent_id = grouped.peer_agent_id
+		LEFT JOIN agent_settings settings ON settings.agent_id = grouped.peer_agent_id
 		ORDER BY grouped.last_interaction_at DESC, grouped.peer_agent_id DESC LIMIT ?`,
 		agentIDValue, todayStart, agentIDValue, todayStart,
 		agentIDValue, todayStart,


### PR DESCRIPTION
## Summary
Return show_add_friend on Today encounter records so the console can respect each peer’s existing visibility setting. Join agent_settings in the existing encounter query and preserve the leaderboard default of true when no setting exists. No schema migration is required.

Add PostgreSQL contract coverage for the default, disabled, and enabled states.

## Validation
- go test ./api/consolev2 passed.
- PostgreSQL integration cases require PG_DSN and were skipped in this local environment.
