### PR TITLE
fix: unify runtime reporting and Agent activity across V1 and V2

### DIFF
--- a/.github/workflows/cli-auth-cross-platform.yml
+++ b/.github/workflows/cli-auth-cross-platform.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     paths:
       - 'cli/internal/auth/**'
+      - 'cli/internal/profilestate/**'
+      - 'cli/internal/client/**'
+      - 'cli/internal/config/**'
+      - 'cli/cmd/**'
+      - 'cli/.cli.config'
+      - 'skills/**'
       - 'cli/go.mod'
       - 'cli/go.sum'
       - '.github/workflows/cli-auth-cross-platform.yml'
@@ -11,6 +17,12 @@ on:
     branches: [main]
     paths:
       - 'cli/internal/auth/**'
+      - 'cli/internal/profilestate/**'
+      - 'cli/internal/client/**'
+      - 'cli/internal/config/**'
+      - 'cli/cmd/**'
+      - 'cli/.cli.config'
+      - 'skills/**'
       - 'cli/go.mod'
       - 'cli/go.sum'
       - '.github/workflows/cli-auth-cross-platform.yml'
@@ -37,6 +49,8 @@ jobs:
           cache-dependency-path: cli/go.sum
       - name: Test identity and credential storage
         run: go test ./internal/auth -count=1
+      - name: Test runtime identity persistence and automatic reporting
+        run: go test -count=1 ./internal/profilestate ./internal/client ./internal/config ./cmd
       - name: Build Windows test binary
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/postgres-contracts.yml
+++ b/.github/workflows/postgres-contracts.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'api/consolev2/**'
+      - 'api/dal/**'
+      - 'api/middleware/**'
+      - 'pkg/reqinfo/**'
+      - 'pkg/runtimeidentity/**'
       - 'api/handler_gen/eigenflux/api/**'
       - 'api/install/**'
       - 'contracts/**'
@@ -19,6 +23,10 @@ on:
     branches: [main]
     paths:
       - 'api/consolev2/**'
+      - 'api/dal/**'
+      - 'api/middleware/**'
+      - 'pkg/reqinfo/**'
+      - 'pkg/runtimeidentity/**'
       - 'api/handler_gen/eigenflux/api/**'
       - 'api/install/**'
       - 'contracts/**'
@@ -66,10 +74,12 @@ jobs:
         run: go test -count=1 ./migrations
       - name: Verify PostgreSQL retention and identity semantics
         run: go test -count=1 ./pkg/consolev2retention ./pkg/agentidentity ./pkg/agentcard
+      - name: Verify runtime observation and request identity
+        run: go test -count=1 ./api/dal ./api/middleware ./pkg/reqinfo ./pkg/runtimeidentity
       - name: Verify short-ID install attribution
         run: go test -count=1 ./api/install -run '^TestPostgresShortIDInviteAttribution$'
       - name: Verify Console V2 PostgreSQL flow and races
-        run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*)'
+        run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*|RuntimeObservationPostgresHTTP)'
       - name: Verify broadcast detail ownership and reader permissions
         run: go test -count=1 ./api/handler_gen/eigenflux/api -run 'Test(PostgresBroadcastDetail.*|GetItemAggregateStats|BroadcastCountryCode)'
       - name: Verify Attention schema and golden corpus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@ Read the relevant module doc before modifying that area:
 
 # IMPORTANT
 
+## Agent Runtime Fields
+
+- Agent Card `runtime` and the Home Discovery `runtime` alias are deprecated compatibility fields. Do not add new consumers or use them as Agent product identity.
+- Use `runtime_name` and `runtime_version` for the reported product; use `runtime_mode` (Card) or `mode` (settings) for integration mode. Carry these fields through new response DTOs instead of copying legacy `runtime`.
+- Keep unknown product or mode values unknown. Never infer a product from a mode, default it to OpenClaw, or use a CLI/plugin version as the product version.
+- Preserve the deprecated wire field until its consumers migrate. This deprecation does not apply to runtime leases, heartbeat routes, `runtime_state`, or `runtime_instance_id`.
+- Follow [the runtime field contract](docs/dev/api_endpoints.md#agent-card-runtime-identity).
+
 ## Production Deployment
 
 `aliap` and `/data/git/eigenflux` are deployment-only. They are never a development workspace or a source of truth.
@@ -86,7 +94,7 @@ After each code change, check if documentation needs updating, especially README
 - Never comment out old code — delete it completely
 - Never leave comments explaining what old code used to be
 - Rely on version control to trace history
-- Don't leave dead code, deprecated markers, or unused imports
+- Don't leave dead code or unused imports. Preserve explicit compatibility deprecations until their consumers migrate.
 
 ## Agent skills
 

--- a/api/consolev2/auth_handlers.go
+++ b/api/consolev2/auth_handlers.go
@@ -27,6 +27,7 @@ import (
 	"eigenflux_server/pkg/agentidentity"
 	"eigenflux_server/pkg/logger"
 	"eigenflux_server/pkg/metrics"
+	"eigenflux_server/pkg/reqinfo"
 	"eigenflux_server/pkg/runtimeidentity"
 )
 
@@ -265,6 +266,7 @@ func normalizeDeviceName(value string) (string, bool) {
 }
 
 func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
+	ctx = reqinfo.WithRequestStart(ctx)
 	var req provisionRequest
 	if err := decodeBody(c, &req); err != nil {
 		fail(c, http.StatusBadRequest, "INVALID_REQUEST", err.Error(), nil)
@@ -609,11 +611,19 @@ func (s *Service) provision(ctx context.Context, c *app.RequestContext) {
 	// Provision is the first authenticated request in Console V2 onboarding.
 	// Persist its validated, self-reported product identity synchronously so the
 	// claim page can name the actual runtime before the first settings heartbeat.
-	cliVersion := strings.TrimSpace(string(c.GetHeader("X-CLI-Ver")))
-	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName, cliVersion); err != nil {
+	cliVersion := string(c.GetHeader("X-CLI-Ver"))
+	if err := consoledal.UpdateHandoffClientIdentity(s.db.WithContext(ctx), agentID, observedRuntime.Name, observedRuntime.Version, deviceName, cliVersion, string(c.GetHeader("X-Client-Mode"))); err != nil {
+		if errors.Is(err, consoledal.ErrRuntimeReportSuperseded) {
+			logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "provision", "outcome", "stale")
+			fail(c, http.StatusConflict, "RUNTIME_REPORT_SUPERSEDED", "newer runtime report exists; retry provision", nil)
+			return
+		}
+		logger.Ctx(ctx).Warn("agent_runtime_report", "agent_id", agentID, "source", "provision", "outcome", "failed")
 		fail(c, http.StatusInternalServerError, "PROVISION_CLIENT_REPORT_FAILED", "could not record Agent client identity", nil)
 		return
 	}
+	logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "provision", "outcome", "applied")
+	agentcard.PublishRebuild(ctx, agentID, "runtime_update")
 	if created {
 		activity.PublishAgentJoined(ctx, agentID)
 	}
@@ -1023,7 +1033,8 @@ type createHandoffRequest struct {
 	ClientCapabilities []string `json:"client_capabilities,omitempty"`
 }
 
-func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
+func (s *Service) createHandoff(ctx context.Context, c *app.RequestContext) {
+	ctx = reqinfo.WithRequestStart(ctx)
 	agentID, ok := agentID(c)
 	principalValue, principalOK := c.Get("principal_id")
 	principalID, principalTypeOK := principalValue.(int64)
@@ -1053,11 +1064,19 @@ func (s *Service) createHandoff(_ context.Context, c *app.RequestContext) {
 		fail(c, http.StatusBadRequest, "INVALID_DEVICE_NAME", "device name is invalid", nil)
 		return
 	}
-	cliVersion := strings.TrimSpace(string(c.GetHeader("X-CLI-Ver")))
-	if err := consoledal.UpdateHandoffClientIdentity(s.db, agentID, observedRuntime.Name, observedRuntime.Version, deviceName, cliVersion); err != nil {
+	cliVersion := string(c.GetHeader("X-CLI-Ver"))
+	if err := consoledal.UpdateHandoffClientIdentity(s.db.WithContext(ctx), agentID, observedRuntime.Name, observedRuntime.Version, deviceName, cliVersion, string(c.GetHeader("X-Client-Mode"))); err != nil {
+		if errors.Is(err, consoledal.ErrRuntimeReportSuperseded) {
+			logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "handoff", "outcome", "stale")
+			fail(c, http.StatusConflict, "RUNTIME_REPORT_SUPERSEDED", "newer runtime report exists; retry handoff", nil)
+			return
+		}
+		logger.Ctx(ctx).Warn("agent_runtime_report", "agent_id", agentID, "source", "handoff", "outcome", "failed")
 		fail(c, http.StatusInternalServerError, "HANDOFF_CLIENT_REPORT_FAILED", "could not record Console client identity", nil)
 		return
 	}
+	logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "handoff", "outcome", "applied")
+	agentcard.PublishRebuild(ctx, agentID, "runtime_update")
 	ticket, err := randomToken("efht_", 32)
 	if err != nil {
 		fail(c, http.StatusInternalServerError, "TOKEN_GENERATION_FAILED", "could not create handoff", nil)

--- a/api/consolev2/home_discovery_handlers.go
+++ b/api/consolev2/home_discovery_handlers.go
@@ -30,23 +30,25 @@ type homeDiscoveryMetric struct {
 }
 
 type homeDiscoveryAgent struct {
-	RuleKey          string              `json:"rule_key"`
-	AgentID          string              `json:"agent_id"`
-	ShortID          string              `json:"short_id"`
-	SharePath        string              `json:"share_path"`
-	AgentName        string              `json:"agent_name"`
-	AgentNameEn      string              `json:"agent_name_en,omitempty"`
-	CountryCode      string              `json:"country_code,omitempty"`
-	AgentDescription string              `json:"agent_description,omitempty"`
-	HumanDescription string              `json:"human_description,omitempty"`
-	Capabilities     []string            `json:"capabilities,omitempty"`
-	Runtime          string              `json:"runtime,omitempty"`
-	IsFriend         bool                `json:"is_friend"`
-	RequestPending   bool                `json:"friend_request_pending"`
-	ShowAddFriend    bool                `json:"show_add_friend"`
-	IsSelf           bool                `json:"is_self"`
-	JoinedAt         int64               `json:"joined_at"`
-	Metric           homeDiscoveryMetric `json:"metric"`
+	RuleKey          string   `json:"rule_key"`
+	AgentID          string   `json:"agent_id"`
+	ShortID          string   `json:"short_id"`
+	SharePath        string   `json:"share_path"`
+	AgentName        string   `json:"agent_name"`
+	AgentNameEn      string   `json:"agent_name_en,omitempty"`
+	CountryCode      string   `json:"country_code,omitempty"`
+	AgentDescription string   `json:"agent_description,omitempty"`
+	HumanDescription string   `json:"human_description,omitempty"`
+	Capabilities     []string `json:"capabilities,omitempty"`
+	// Deprecated: legacy Card runtime alias; migrate this DTO and its consumers
+	// to runtime_name/runtime_version and runtime_mode for product/mode display.
+	Runtime        string              `json:"runtime,omitempty"`
+	IsFriend       bool                `json:"is_friend"`
+	RequestPending bool                `json:"friend_request_pending"`
+	ShowAddFriend  bool                `json:"show_add_friend"`
+	IsSelf         bool                `json:"is_self"`
+	JoinedAt       int64               `json:"joined_at"`
+	Metric         homeDiscoveryMetric `json:"metric"`
 }
 
 type homeDiscoveryResponse struct {

--- a/api/consolev2/home_discovery_handlers.go
+++ b/api/consolev2/home_discovery_handlers.go
@@ -43,6 +43,9 @@ type homeDiscoveryAgent struct {
 	// Deprecated: legacy Card runtime alias; migrate this DTO and its consumers
 	// to runtime_name/runtime_version and runtime_mode for product/mode display.
 	Runtime        string              `json:"runtime,omitempty"`
+	RuntimeName    string              `json:"runtime_name,omitempty"`
+	RuntimeVersion string              `json:"runtime_version,omitempty"`
+	RuntimeMode    string              `json:"runtime_mode,omitempty"`
 	IsFriend       bool                `json:"is_friend"`
 	RequestPending bool                `json:"friend_request_pending"`
 	ShowAddFriend  bool                `json:"show_add_friend"`
@@ -404,7 +407,7 @@ func (s *Service) hydrateHomeDiscovery(ctx context.Context, selected []homeDisco
 			SharePath: "/agent/" + identity.ShortID, AgentName: identity.AgentName, AgentNameEn: identity.AgentNameEn,
 			CountryCode: homeDiscoveryCountryCode(identity.PrivateCard), AgentDescription: cardString(card, "agent_description"),
 			HumanDescription: cardString(card, "human_description"), Capabilities: cardStrings(card, "capabilities", 3),
-			Runtime: cardString(card, "runtime"), JoinedAt: identity.CreatedAt,
+			Runtime: cardString(card, "runtime"), RuntimeName: cardString(card, "runtime_name"), RuntimeVersion: cardString(card, "runtime_version"), RuntimeMode: cardString(card, "runtime_mode"), JoinedAt: identity.CreatedAt,
 			Metric: homeDiscoveryMetric{Key: rule.MetricKey, Value: candidate.Primary, Secondary: candidate.Secondary, Dimension: candidate.Dimension},
 		})
 	}

--- a/api/consolev2/runtime_observation_postgres_test.go
+++ b/api/consolev2/runtime_observation_postgres_test.go
@@ -1,0 +1,323 @@
+package consolev2
+
+import (
+	"bytes"
+	"context"
+	"eigenflux_server/pkg/reqinfo"
+	"fmt"
+	"github.com/cloudwego/hertz/pkg/app"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"eigenflux_server/api/clients"
+	"eigenflux_server/api/dal"
+	apihandler "eigenflux_server/api/handler_gen/eigenflux/api"
+	"eigenflux_server/api/middleware"
+	authrpc "eigenflux_server/kitex_gen/eigenflux/auth"
+	"eigenflux_server/kitex_gen/eigenflux/auth/authservice"
+	"eigenflux_server/kitex_gen/eigenflux/base"
+	feedrpc "eigenflux_server/kitex_gen/eigenflux/feed"
+	"eigenflux_server/kitex_gen/eigenflux/feed/feedservice"
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/config"
+	sharedDB "eigenflux_server/pkg/db"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"github.com/cloudwego/kitex/client/callopt"
+	redis "github.com/redis/go-redis/v9"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type runtimeEmptyFeed struct {
+	feedservice.Client
+	code int32
+}
+
+func (f *runtimeEmptyFeed) FetchFeed(context.Context, *feedrpc.FetchFeedReq, ...callopt.Option) (*feedrpc.FetchFeedResp, error) {
+	return &feedrpc.FetchFeedResp{BaseResp: &base.BaseResp{Code: f.code}}, nil
+}
+
+type runtimeAuthClient struct {
+	authservice.Client
+	agentID int64
+}
+
+func (f *runtimeAuthClient) ValidateSession(context.Context, *authrpc.ValidateSessionReq, ...callopt.Option) (*authrpc.ValidateSessionResp, error) {
+	return &authrpc.ValidateSessionResp{AgentId: f.agentID, BaseResp: &base.BaseResp{Code: 0}}, nil
+}
+
+func TestRuntimeObservationPostgresHTTP(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN required for runtime HTTP/PostgreSQL contracts")
+	}
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorDB := sharedDB.DB
+	sharedDB.DB = database
+	t.Cleanup(func() { sharedDB.DB = priorDB })
+	id := time.Now().UnixNano()
+	now := time.Now().UnixMilli()
+	if err := database.Exec(`INSERT INTO agents (agent_id,email,agent_name,bio,created_at,updated_at,identity_state) VALUES (?,?,'Runtime HTTP','',?,?,'active')`, id, fmt.Sprintf("runtime-http-%d@example.test", id), now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Exec("DELETE FROM agents WHERE agent_id = ?", id) })
+	var principalID int64
+	if err := database.Raw(`INSERT INTO agent_principals (agent_id,key_type,key_fingerprint,public_key,key_version,status,created_at,last_seen_at) VALUES (?,'ed25519-v1',?,decode(repeat('42',32),'hex'),1,'active',?,?) RETURNING principal_id`, id, fmt.Sprintf("runtime-http-%d", id), now, now).Scan(&principalID).Error; err != nil {
+		t.Fatal(err)
+	}
+	token := fmt.Sprintf("efv2a_runtime_http_%d", id)
+	if err := database.Exec(`INSERT INTO agent_credential_sessions (principal_id,family_id,access_token_hash,refresh_token_hash,audience,scopes,issued_at,expires_at,absolute_expires_at,last_seen_at) VALUES (?,?,?,?,'agent_v2',ARRAY['feed:read','commands:claim','settings:read','settings:write'],?,?,?,?)`, principalID, fmt.Sprintf("runtime-family-%d", id), hashString(token), hashString(token+"refresh"), now, now+3600000, now+7200000, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Exec(`INSERT INTO agent_context_revisions (agent_id,revision,compiled_context,schema_version,generated_at) VALUES (?,1,'{}'::jsonb,1,?)`, id, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Exec(`INSERT INTO agent_onboarding_v2 (agent_id,state,current_step,revision,active_context_revision,completed_at,created_at,updated_at) VALUES (?,'completed',5,1,1,?,?,?)`, id, now, now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Create(&dal.AgentSettings{AgentID: id, AgentCreatedAtMs: now}).Error; err != nil {
+		t.Fatal(err)
+	}
+	cache := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: cache.Addr()})
+	t.Cleanup(func() { rdb.Close() })
+	svc, err := NewService(database, &fixedIDGenerator{id: id + 100}, &config.Config{EnableFeedV2: true, EnableControlChannelV2: true, ConsoleV2BootstrapSecret: "runtime-test", ConsoleV2OTPPepper: "runtime-test", ConsoleV2PublicURL: "https://console.example.test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.redisClient = rdb
+	svc.SetFeedClient(&runtimeEmptyFeed{})
+	h := server.New(server.WithHostPorts("127.0.0.1:0"))
+	svc.Register(h)
+	auth := ut.Header{Key: "Authorization", Value: "Bearer " + token}
+	read := func() dal.AgentSettings {
+		t.Helper()
+		var row dal.AgentSettings
+		if err := database.First(&row, "agent_id = ?", id).Error; err != nil {
+			t.Fatal(err)
+		}
+		return row
+	}
+	call := func(method, path string, body interface{}, headers ...ut.Header) (int, map[string]interface{}) {
+		t.Helper()
+		headers = append(headers, auth)
+		status, payload, _ := performJSON(t, h, method, path, body, headers...)
+		return status, payload
+	}
+	for _, path := range []string{"/api/v2/feed", "/api/v2/runtime/heartbeat", "/api/v2/agent-settings/heartbeat-compatibility"} {
+		t.Run(path, func(t *testing.T) {
+			if err := database.Model(&dal.AgentSettings{}).Where("agent_id = ?", id).UpdateColumns(map[string]interface{}{"runtime_name": "", "runtime_version": "", "runtime_reported_at": 0, "last_activity_at": 0, "mode": ""}).Error; err != nil {
+				t.Fatal(err)
+			}
+			method := http.MethodPost
+			body := map[string]interface{}{}
+			if path == "/api/v2/runtime/heartbeat" {
+				body["runtime_instance_id"] = "runtime-test"
+				body["capabilities"] = []string{}
+			}
+			if path == "/api/v2/agent-settings/heartbeat-compatibility" {
+				method = http.MethodPut
+				body["heartbeat_contract_version"] = "eigenflux_heartbeat.v1"
+				body["skill_revision"] = "runtime-test"
+			}
+			status, payload := call(method, path, body, ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.5.4"}, ut.Header{Key: "X-Client-Mode", Value: "skill"}, ut.Header{Key: "X-CLI-Ver", Value: "0.0.44"})
+			if status != 200 {
+				t.Fatalf("status=%d payload=%+v", status, payload)
+			}
+			row := read()
+			if row.RuntimeName != "workbuddy" || row.RuntimeVersion != "5.5.4" || row.Mode != "skill" || row.LastActivityAt <= 0 {
+				t.Fatalf("route did not persist metadata/activity: %+v", row)
+			}
+		})
+	}
+
+	t.Run("authenticated command claim and completion templates", func(t *testing.T) {
+		if err := database.Exec("UPDATE agent_runtime_leases SET context_revision_applied=1 WHERE agent_id=?", id).Error; err != nil {
+			t.Fatal(err)
+		}
+		var commandID int64
+		if err := database.Raw(`INSERT INTO agent_commands (agent_id,command_type,payload,payload_hash,required_context_revision,status,idempotency_key,created_at) VALUES (?,'human_instruction','{}'::jsonb,'runtime-test',1,'pending','runtime-observation-test',?) RETURNING command_id`, id, now).Scan(&commandID).Error; err != nil {
+			t.Fatal(err)
+		}
+		resetActivity := func() {
+			t.Helper()
+			if err := database.Model(&dal.AgentSettings{}).Where("agent_id = ?", id).UpdateColumn("last_activity_at", 0).Error; err != nil {
+				t.Fatal(err)
+			}
+		}
+		resetActivity()
+		status, payload := call(http.MethodPost, fmt.Sprintf("/api/v2/agent-commands/%d/claim", commandID), map[string]interface{}{"runtime_instance_id": "runtime-test", "applied_context_revision": 1})
+		if status != 200 {
+			t.Fatalf("claim status=%d payload=%+v", status, payload)
+		}
+		if row := read(); row.LastActivityAt <= 0 {
+			t.Fatalf("command claim did not record activity: %+v", row)
+		}
+		proof := responseData(t, payload)
+		resetActivity()
+		status, payload = call(http.MethodPost, fmt.Sprintf("/api/v2/agent-commands/%d/complete", commandID), map[string]interface{}{"runtime_instance_id": "runtime-test", "claim_epoch": proof["claim_epoch"], "claim_token": proof["claim_token"], "status": "completed", "result": map[string]interface{}{}})
+		if status != 200 {
+			t.Fatalf("completion status=%d payload=%+v", status, payload)
+		}
+		if row := read(); row.LastActivityAt <= 0 {
+			t.Fatalf("command completion did not record activity: %+v", row)
+		}
+	})
+	t.Run("V1 authenticated Feed", func(t *testing.T) {
+		previousAuth, previousFeed := clients.AuthClient, clients.FeedClient
+		defer func() { clients.AuthClient = previousAuth; clients.FeedClient = previousFeed }()
+		clients.AuthClient = &runtimeAuthClient{agentID: id}
+		feed := &runtimeEmptyFeed{}
+		clients.FeedClient = feed
+		h.GET("/api/v1/items/feed", middleware.ClientInfoMiddleware(), middleware.AuthMiddleware(), apihandler.Feed)
+		if err := database.Model(&dal.AgentSettings{}).Where("agent_id = ?", id).UpdateColumns(map[string]interface{}{"runtime_reported_at": 0, "last_activity_at": 0}).Error; err != nil {
+			t.Fatal(err)
+		}
+		headers := []ut.Header{{Key: "Authorization", Value: "Bearer local-test"}, {Key: "X-CLI-Ver", Value: "0.0.44"}, {Key: "X-Client-Host", Value: "workbuddy/5.5.4"}, {Key: "X-Client-Mode", Value: "skill"}}
+		response := ut.PerformRequest(h.Engine, http.MethodGet, "/api/v1/items/feed?action=load_more", nil, headers...).Result()
+		if response.StatusCode() != 200 {
+			t.Fatalf("V1 status=%d", response.StatusCode())
+		}
+		before := read()
+		if before.LastActivityAt <= 0 || before.RuntimeName != "workbuddy" {
+			t.Fatalf("V1 successful Feed not observed: %+v", before)
+		}
+		feed.code = 123
+		headers[2].Value = "openclaw/old"
+		response = ut.PerformRequest(h.Engine, http.MethodGet, "/api/v1/items/feed?action=load_more", nil, headers...).Result()
+		if response.StatusCode() != 200 {
+			t.Fatalf("V1 business failure must test HTTP200: %d", response.StatusCode())
+		}
+		after := read()
+		if after.RuntimeName != before.RuntimeName || after.RuntimeReportedAt != before.RuntimeReportedAt || after.LastActivityAt != before.LastActivityAt {
+			t.Fatalf("V1 business failure mutated identity: %+v", after)
+		}
+	})
+	t.Run("Discovery structured product projection", func(t *testing.T) {
+		shortID, err := agentidentity.GenerateShortID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := database.Exec("UPDATE agents SET short_id=? WHERE agent_id=?", shortID, id).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := database.Exec(`INSERT INTO agent_cards (agent_id,public_card,private_card,schema_version,source_version,rebuild_fence,card_version,public_card_version,generated_at,public_card_generated_at) VALUES (?,'{"runtime":"plugin","runtime_name":"workbuddy","runtime_version":"5.5.4","runtime_mode":"skill"}'::jsonb,'{}'::jsonb,5,1,0,1,1,?,?)`, id, now, now).Error; err != nil {
+			t.Fatal(err)
+		}
+		rules := []homeDiscoveryRule{{Key: "active", Rows: []homeDiscoveryCandidateRow{{AgentID: id}}}}
+		rows, err := svc.hydrateHomeDiscovery(context.Background(), rules)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 || rows[0].RuntimeName != "workbuddy" || rows[0].RuntimeVersion != "5.5.4" || rows[0].RuntimeMode != "skill" || rows[0].Runtime != "plugin" {
+			t.Fatalf("Discovery lost independent product fields: %+v", rows)
+		}
+		if err := database.Exec(`UPDATE agent_cards SET public_card='{"runtime":"plugin"}'::jsonb WHERE agent_id=?`, id).Error; err != nil {
+			t.Fatal(err)
+		}
+		rows, err = svc.hydrateHomeDiscovery(context.Background(), rules)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 || rows[0].RuntimeName != "" || rows[0].RuntimeMode != "" {
+			t.Fatalf("Discovery invented facts from legacy runtime: %+v", rows)
+		}
+	})
+
+	t.Run("optional malformed metadata does not fail HTTP report", func(t *testing.T) {
+		if err := database.Model(&dal.AgentSettings{}).Where("agent_id = ?", id).UpdateColumns(map[string]interface{}{"runtime_reported_at": 0, "last_activity_at": 0, "cli_version": "0.0.44", "model": "known-model"}).Error; err != nil {
+			t.Fatal(err)
+		}
+		for _, request := range []struct{ method, path string }{{http.MethodPost, "/api/v2/feed"}, {http.MethodPut, "/api/v2/agent-settings"}} {
+			status, payload := call(request.method, request.path, map[string]interface{}{}, ut.Header{Key: "X-Client-Host", Value: "workbuddy/5.5.4"}, ut.Header{Key: "X-Client-Mode", Value: "skill"}, ut.Header{Key: "X-CLI-Ver", Value: strings.Repeat("v", 33)}, ut.Header{Key: "X-Client-Model", Value: strings.Repeat("m", 129)})
+			if status != 200 {
+				t.Fatalf("oversized optional metadata failed %s: status=%d payload=%+v", request.path, status, payload)
+			}
+			row := read()
+			if row.RuntimeName != "workbuddy" || row.Mode != "skill" || row.LastActivityAt <= 0 || row.CLIVersion != "0.0.44" || row.Model != "known-model" {
+				t.Fatalf("valid HTTP facts lost or optional metadata truncated: %+v", row)
+			}
+		}
+	})
+	t.Run("entry time survives blocked authentication", func(t *testing.T) {
+		for index, handler := range []app.HandlerFunc{apihandler.PutMySettings, svc.createHandoff} {
+			if err := database.Model(&dal.AgentSettings{}).Where("agent_id = ?", id).UpdateColumn("runtime_reported_at", 0).Error; err != nil {
+				t.Fatal(err)
+			}
+			entered := make(chan int64, 1)
+			release := make(chan struct{})
+			done := make(chan int, 1)
+			block := func(ctx context.Context, c *app.RequestContext) {
+				entered <- reqinfo.RequestStartedAt(ctx)
+				<-release
+				c.Next(ctx)
+			}
+			path := fmt.Sprintf("/runtime-entry-test/%d", index)
+			h.PUT(path, middleware.ClientInfoMiddleware(), block, svc.agentAuth("settings:write"), handler)
+			body := []byte(`{"mode":"plugin"}`)
+			if index == 1 {
+				body = []byte(`{"browser_nonce":"01234567890123456789012345678901"}`)
+			}
+			go func() {
+				response := ut.PerformRequest(h.Engine, http.MethodPut, path, &ut.Body{Body: bytes.NewReader(body), Len: len(body)}, auth, ut.Header{Key: "Content-Type", Value: "application/json"}, ut.Header{Key: "X-Client-Host", Value: "openclaw/old"}, ut.Header{Key: "X-Client-Mode", Value: "plugin"}).Result()
+				done <- response.StatusCode()
+			}()
+			entry := <-entered
+			if entry <= 0 {
+				close(release)
+				<-done
+				t.Fatal("request timestamp was not captured before auth")
+			}
+			_, err := dal.ObserveRuntime(database, id, dal.RuntimeObservation{Host: "workbuddy/5.5.4", Mode: "skill", ObservedAt: entry + 1, Explicit: true})
+			if err != nil {
+				close(release)
+				<-done
+				t.Fatal(err)
+			}
+			// The old request reaches its handler after the newer explicit report.
+			time.Sleep(5 * time.Millisecond)
+			close(release)
+			if status := <-done; status != 409 {
+				t.Fatalf("delayed explicit request %d status=%d, want409", index, status)
+			}
+			row := read()
+			if row.RuntimeName != "workbuddy" || row.Mode != "skill" || row.RuntimeReportedAt != entry+1 {
+				t.Fatalf("delayed request crossed entry fence: %+v", row)
+			}
+		}
+	})
+	before := read()
+	status, payload := call(http.MethodGet, "/api/v2/agent-settings", map[string]interface{}{}, ut.Header{Key: "X-Client-Host", Value: "codex/old"}, ut.Header{Key: "X-Client-Mode", Value: "plugin"})
+	if status != 200 {
+		t.Fatalf("read status=%d payload=%+v", status, payload)
+	}
+	after := read()
+	if after.RuntimeName != before.RuntimeName || after.LastActivityAt != before.LastActivityAt || after.RuntimeReportedAt != before.RuntimeReportedAt {
+		t.Fatalf("settings read altered observation: before=%+v after=%+v", before, after)
+	}
+	status, payload = call(http.MethodPut, "/api/v2/agent-settings", map[string]interface{}{"mode": "skill"}, ut.Header{Key: "X-Client-Host", Value: "workbuddy"}, ut.Header{Key: "X-Client-Mode", Value: "plugin"})
+	if status != 200 {
+		t.Fatalf("settings status=%d payload=%+v", status, payload)
+	}
+	after = read()
+	if after.RuntimeVersion != "" || after.Mode != "skill" || after.LastActivityAt != before.LastActivityAt {
+		t.Fatalf("explicit settings facts/active boundary failed: %+v", after)
+	}
+	before = after
+	status, payload = call(http.MethodPost, "/api/v2/runtime/heartbeat", map[string]interface{}{"runtime_instance_id": ""}, ut.Header{Key: "X-Client-Host", Value: "codex"})
+	if status != 400 {
+		t.Fatalf("invalid heartbeat status=%d payload=%+v", status, payload)
+	}
+	after = read()
+	if after.RuntimeName != before.RuntimeName || after.LastActivityAt != before.LastActivityAt {
+		t.Fatalf("failed heartbeat changed observation: %+v", after)
+	}
+}

--- a/api/consolev2/service.go
+++ b/api/consolev2/service.go
@@ -37,6 +37,7 @@ import (
 	"eigenflux_server/pkg/agentcard"
 	"eigenflux_server/pkg/config"
 	mailservice "eigenflux_server/pkg/email"
+	"eigenflux_server/pkg/reqinfo"
 )
 
 const (
@@ -582,6 +583,8 @@ func (s *Service) agentAuth(requiredScope string) app.HandlerFunc {
 
 func (s *Service) agentAuthAny(requiredScopes ...string) app.HandlerFunc {
 	return func(ctx context.Context, c *app.RequestContext) {
+		ctx = reqinfo.WithRequestStart(ctx)
+		requestStartedAt := reqinfo.RequestStartedAt(ctx)
 		header := string(c.GetHeader("Authorization"))
 		if !strings.HasPrefix(header, "Bearer efv2a_") {
 			fail(c, http.StatusUnauthorized, "AGENT_AUTH_REQUIRED", "missing or invalid Agent V2 bearer token", nil)
@@ -617,6 +620,7 @@ func (s *Service) agentAuthAny(requiredScopes ...string) app.HandlerFunc {
 		c.Set("agent_credential_session_id", principal.SessionID)
 		go agentcard.TouchLastActive(context.Background(), s.redisClient, principal.AgentID)
 		c.Next(ctx)
+		middleware.ObserveSuccessfulAgentRequest(ctx, c, s.db, principal.AgentID, requestStartedAt, false)
 	}
 }
 

--- a/api/dal/console.go
+++ b/api/dal/console.go
@@ -56,6 +56,7 @@ type AgentSettings struct {
 	RuntimeName            string `gorm:"column:runtime_name"`
 	RuntimeVersion         string `gorm:"column:runtime_version"`
 	RuntimeReportedAt      int64  `gorm:"column:runtime_reported_at"`
+	LastActivityAt         int64  `gorm:"column:last_activity_at;not null;default:0"`
 	Model                  string `gorm:"column:model"`
 	// CLIVersion is the EigenFlux CLI version (X-CLI-Ver), reported by every
 	// runtime — plugin or CLI-direct — and shown on the dashboard runtime card.
@@ -117,6 +118,7 @@ func UpdateAgentReported(db *gorm.DB, agentID int64, feedPref, mode, lang *strin
 			return fmt.Errorf("mode must be plugin or skill")
 		}
 		vals["mode"] = *mode
+		vals["runtime_reported_at"] = time.Now().UnixMilli()
 		if *mode == "skill" {
 			// A CLI-direct skill report is authoritative for the current runtime;
 			// clear a plugin host left by an older heartbeat so the public Card
@@ -170,14 +172,14 @@ func UpdateAgentReportedSettings(db *gorm.DB, agentID int64, feedPref, mode, lan
 }
 
 // UpdateHeartbeatCompatibility records evidence from a successful Heartbeat
-// plan. The CLI version comes from authenticated request metadata.
+// plan. CLI identity is merged separately by the authenticated request observer
+// so a delayed compatibility request cannot bypass the runtime ordering fence.
 func UpdateHeartbeatCompatibility(db *gorm.DB, agentID int64, cliVersion, contractVersion, skillRevision string) error {
 	if _, err := GetSettings(db, agentID); err != nil {
 		return err
 	}
 	now := time.Now().UnixMilli()
 	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).Updates(map[string]interface{}{
-		"cli_version":                cliVersion,
 		"heartbeat_contract_version": contractVersion,
 		"skill_revision":             skillRevision,
 		"heartbeat_reported_at":      now,
@@ -185,79 +187,59 @@ func UpdateHeartbeatCompatibility(db *gorm.DB, agentID int64, cliVersion, contra
 	}).Error
 }
 
-// UpdateDerivedRuntimeIfNotSuperseded persists request-derived runtime metadata
-// unless a newer explicit runtime report has committed since this request
-// started. It remains asynchronous and adds no read to the feed response path.
-// This prevents a delayed feed goroutine from overwriting an explicit
-// `settings push` that switched Agent products after the feed was received.
-// The persisted metadata includes the mode, raw host string (X-Client-Host), model
-// (X-Client-Model), and the CLI version (X-CLI-Ver), all for display. An empty
-// model or cliVer leaves that column untouched so a request that omits the
-// header never clobbers a previously reported value.
+// UpdateDerivedRuntimeIfNotSuperseded merges validated request metadata through
+// the same fence used by explicit reports. Callers must supply an observed mode;
+// a product name is never evidence of integration mode.
 func UpdateDerivedRuntimeIfNotSuperseded(db *gorm.DB, agentID int64, mode, host, runtimeName, runtimeVersion, model, cliVer string, requestStartedAt int64) (bool, error) {
-	if _, err := GetSettings(db, agentID); err != nil { // ensures row exists
-		return false, err
+	if runtimeName != "" {
+		host = runtimeName
+		if runtimeVersion != "" {
+			host += "/" + runtimeVersion
+		}
 	}
-	vals := map[string]interface{}{
-		"mode":            mode,
-		"client_host":     host,
-		"runtime_name":    runtimeName,
-		"runtime_version": runtimeVersion,
-		"updated_at":      time.Now().UnixMilli(),
-	}
-	if model != "" {
-		vals["model"] = model
-	}
-	if cliVer != "" {
-		vals["cli_version"] = cliVer
-	}
-	result := db.Model(&AgentSettings{}).
-		Where("agent_id = ? AND runtime_reported_at < ?", agentID, requestStartedAt).
-		Updates(vals)
-	return result.RowsAffected > 0, result.Error
+	result, err := ObserveRuntime(db, agentID, RuntimeObservation{Host: host, Mode: mode, Model: model, CLIVersion: cliVer, ObservedAt: requestStartedAt})
+	return result.IdentityChanged, err
 }
 
-// UpdateRuntimeIdentity persists a validated self-reported Agent product
-// identity. It is independent from mode: Jarvis/Hermes/WorkBuddy may run in
-// skill mode, while OpenClaw/Claude Code/Codex commonly run as plugins.
+// UpdateRuntimeIdentity persists an explicit product report independently of mode.
 func UpdateRuntimeIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion string) error {
 	if runtimeName == "" {
 		return nil
 	}
-	if _, err := GetSettings(db, agentID); err != nil {
-		return err
+	host := runtimeName
+	if runtimeVersion != "" {
+		host += "/" + runtimeVersion
 	}
-	now := time.Now().UnixMilli()
-	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).
-		Updates(map[string]interface{}{
-			"runtime_name":        runtimeName,
-			"runtime_version":     runtimeVersion,
-			"runtime_reported_at": now,
-			"updated_at":          now,
-		}).Error
+	_, err := ObserveRuntime(db, agentID, RuntimeObservation{Host: host, Explicit: true})
+	return err
 }
 
-// UpdateHandoffClientIdentity records the computer that generated a Console
-// handoff and, when present, the current Agent product and CLI identity in one write.
-func UpdateHandoffClientIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion, deviceName, cliVersion string) error {
-	vals := map[string]interface{}{}
-	now := time.Now().UnixMilli()
-	if runtimeName != "" {
-		vals["runtime_name"] = runtimeName
-		vals["runtime_version"] = runtimeVersion
-		vals["runtime_reported_at"] = now
+// UpdateHandoffClientIdentity records the authenticated computer and optional
+// product/mode facts before onboarding gates can block regular settings reports.
+func UpdateHandoffClientIdentity(db *gorm.DB, agentID int64, runtimeName, runtimeVersion, deviceName, cliVersion string, reportedMode ...string) error {
+	host := runtimeName
+	if runtimeVersion != "" {
+		host += "/" + runtimeVersion
 	}
-	if cliVersion != "" {
-		vals["cli_version"] = cliVersion
+	mode := ""
+	if len(reportedMode) > 0 && (reportedMode[0] == "plugin" || reportedMode[0] == "skill") {
+		mode = reportedMode[0]
 	}
-	// The provision/handoff represents the current computer. Clear a stale value
-	// when an older CLI cannot report it instead of displaying another machine.
-	vals["device_name"] = deviceName
-	if _, err := GetSettings(db, agentID); err != nil {
-		return err
-	}
-	vals["updated_at"] = now
-	return db.Model(&AgentSettings{}).Where("agent_id = ?", agentID).Updates(vals).Error
+	return db.Transaction(func(tx *gorm.DB) error {
+		result, err := ObserveRuntime(tx, agentID, RuntimeObservation{Host: host, Mode: mode, CLIVersion: cliVersion, Explicit: true})
+		if err != nil {
+			return err
+		}
+		if result.Outcome == "stale" {
+			return ErrRuntimeReportSuperseded
+		}
+		if _, err := GetSettings(tx, agentID); err != nil {
+			return err
+		}
+		return tx.Model(&AgentSettings{}).Where("agent_id = ?", agentID).Updates(map[string]interface{}{
+			"device_name": deviceName, "updated_at": time.Now().UnixMilli(),
+		}).Error
+	})
 }
 
 // UpdateAgentModel persists the agent's reported runtime model (X-Client-Model).

--- a/api/dal/runtime_observation.go
+++ b/api/dal/runtime_observation.go
@@ -1,0 +1,147 @@
+package dal
+
+import (
+	"eigenflux_server/pkg/reqinfo"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"eigenflux_server/pkg/runtimeidentity"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var ErrRuntimeReportSuperseded = errors.New("runtime report superseded")
+
+// boundedObservationText discards invalid optional metadata independently, so
+// one malformed header cannot roll back otherwise valid product/activity facts.
+func boundedObservationText(value string, maxBytes int) string {
+	if len(value) > maxBytes || !utf8.ValidString(value) || strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+// RuntimeObservation contains facts from an authenticated Agent request. Mode is
+// independent of Host. Explicit reports may declare the product version unknown;
+// passive requests that omit a version retain the known version of that product.
+type RuntimeObservation struct {
+	Host       string
+	Mode       string
+	Model      string
+	CLIVersion string
+	ObservedAt int64
+	Explicit   bool
+	Active     bool
+}
+
+type RuntimeObservationResult struct {
+	Outcome         string
+	IdentityChanged bool
+	ActivityChanged bool
+}
+
+// ObserveRuntime serializes metadata merges against explicit reports. A request
+// timestamp is captured before running its handler, so delayed work cannot undo
+// a newer report (including a mode-only report). Activity writes are bounded to
+// one per minute per Agent unless metadata already needs a write.
+func ObserveRuntime(db *gorm.DB, agentID int64, obs RuntimeObservation) (RuntimeObservationResult, error) {
+	result := RuntimeObservationResult{Outcome: "unchanged"}
+	if obs.Mode != "" && obs.Mode != "plugin" && obs.Mode != "skill" {
+		return result, fmt.Errorf("mode must be plugin or skill")
+	}
+	obs.CLIVersion = boundedObservationText(obs.CLIVersion, 32)
+	obs.Model = boundedObservationText(obs.Model, 128)
+	// Product parts have independent VARCHAR(64) bounds; the legacy host is TEXT.
+	obs.Host = boundedObservationText(obs.Host, 129)
+	identity, hasIdentity := runtimeidentity.Parse(obs.Host)
+	hasMetadata := hasIdentity || obs.Mode != "" || obs.Model != "" || obs.CLIVersion != ""
+	if !hasMetadata && !obs.Active {
+		return result, nil
+	}
+	if obs.ObservedAt == 0 {
+		obs.ObservedAt = reqinfo.RequestStartedAt(db.Statement.Context)
+	}
+	if obs.ObservedAt == 0 {
+		obs.ObservedAt = time.Now().UnixMilli()
+	}
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if _, err := GetSettings(tx, agentID); err != nil {
+			return err
+		}
+		var cur AgentSettings
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&cur, "agent_id = ?", agentID).Error; err != nil {
+			return err
+		}
+		vals := map[string]interface{}{}
+		stale := obs.ObservedAt < cur.RuntimeReportedAt || (!obs.Explicit && obs.ObservedAt == cur.RuntimeReportedAt)
+		if hasMetadata && !stale {
+			set := func(key, previous, next string) {
+				if previous != next {
+					vals[key] = next
+					result.IdentityChanged = true
+				}
+			}
+			mode := cur.Mode
+			if obs.Mode != "" {
+				mode = obs.Mode
+				set("mode", cur.Mode, mode)
+			}
+			if hasIdentity {
+				version := identity.Version
+				if !obs.Explicit && version == "" && identity.Name == cur.RuntimeName {
+					version = cur.RuntimeVersion
+				}
+				set("runtime_name", cur.RuntimeName, identity.Name)
+				set("runtime_version", cur.RuntimeVersion, version)
+				// Keep the legacy host projection coherent without deriving mode from it.
+				host := ""
+				if mode == "plugin" {
+					host = identity.Name
+					if version != "" {
+						host += "/" + version
+					}
+				}
+				set("client_host", cur.ClientHost, host)
+			} else if obs.Mode == "skill" {
+				set("client_host", cur.ClientHost, "")
+			}
+			if obs.Model != "" {
+				set("model", cur.Model, obs.Model)
+			}
+			if obs.CLIVersion != "" {
+				set("cli_version", cur.CLIVersion, obs.CLIVersion)
+			}
+			// Explicit reports always advance the fence, even when only mode was sent
+			// or the same identity was reported again. Passive unchanged polls coalesce.
+			if obs.Explicit || result.IdentityChanged || obs.ObservedAt-cur.RuntimeReportedAt >= time.Minute.Milliseconds() {
+				fence := obs.ObservedAt
+				if obs.Explicit && fence <= cur.RuntimeReportedAt {
+					fence = cur.RuntimeReportedAt + 1
+				}
+				vals["runtime_reported_at"] = fence
+			}
+		} else if hasMetadata && stale {
+			result.Outcome = "stale"
+		}
+		if obs.Active && obs.ObservedAt > cur.LastActivityAt && (result.IdentityChanged || cur.LastActivityAt == 0 || obs.ObservedAt-cur.LastActivityAt >= time.Minute.Milliseconds()) {
+			vals["last_activity_at"] = obs.ObservedAt
+			result.ActivityChanged = true
+		}
+		if len(vals) == 0 {
+			return nil
+		}
+		if result.IdentityChanged {
+			vals["updated_at"] = time.Now().UnixMilli()
+			result.Outcome = "updated"
+		}
+		return tx.Model(&AgentSettings{}).Where("agent_id = ?", agentID).UpdateColumns(vals).Error
+	})
+	if err != nil {
+		result = RuntimeObservationResult{Outcome: "failed"}
+	}
+	return result, err
+}

--- a/api/dal/runtime_observation_postgres_test.go
+++ b/api/dal/runtime_observation_postgres_test.go
@@ -1,0 +1,162 @@
+package dal
+
+import (
+	"context"
+	"eigenflux_server/pkg/reqinfo"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestRuntimeObservationPostgresConcurrentFence(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN required for real PostgreSQL row-lock contract")
+	}
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := time.Now().UnixNano()
+	now := time.Now().UnixMilli()
+	if err := database.Exec(`INSERT INTO agents (agent_id,email,agent_name,bio,created_at,updated_at) VALUES (?,?,'Runtime fence','',?,?)`, id, fmt.Sprintf("runtime-fence-%d@example.test", id), now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Exec("DELETE FROM agents WHERE agent_id = ?", id) })
+	if _, err := ObserveRuntime(database, id, RuntimeObservation{Host: "openclaw/old", Mode: "plugin", ObservedAt: 100}); err != nil {
+		t.Fatal(err)
+	}
+	// Hold an explicit transaction open while a delayed passive request contends
+	// for the same row. PostgreSQL must re-read the committed fence after waiting.
+	tx := database.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	defer tx.Rollback()
+	if _, err := ObserveRuntime(tx, id, RuntimeObservation{Mode: "skill", ObservedAt: 500, Explicit: true}); err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		r, e := ObserveRuntime(database, id, RuntimeObservation{Host: "openclaw/old", Mode: "plugin", ObservedAt: 400})
+		if e == nil && r.Outcome != "stale" {
+			e = fmt.Errorf("delayed request result=%+v", r)
+		}
+		done <- e
+	}()
+	<-started
+	select {
+	case err := <-done:
+		t.Fatalf("observation did not wait for explicit transaction: %v", err)
+	case <-time.After(40 * time.Millisecond):
+	}
+	if err := tx.Commit().Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	errors := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := ObserveRuntime(database, id, RuntimeObservation{Active: true, ObservedAt: int64(100000 + i*60000)})
+			errors <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	var row AgentSettings
+	if err := database.First(&row, "agent_id = ?", id).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.Mode != "skill" || row.ClientHost != "" || row.RuntimeReportedAt != 500 || row.LastActivityAt != 640000 {
+		t.Fatalf("concurrent observation corrupted identity/activity: %+v", row)
+	}
+}
+
+func TestRuntimeObservationPostgresRejectsMalformedOptionalMetadata(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN required for PostgreSQL metadata column limits")
+	}
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := time.Now().UnixNano()
+	now := time.Now().UnixMilli()
+	if err := database.Exec(`INSERT INTO agents (agent_id,email,agent_name,bio,created_at,updated_at) VALUES (?,?,'Runtime bounds','',?,?)`, id, fmt.Sprintf("runtime-bounds-%d@example.test", id), now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Exec("DELETE FROM agents WHERE agent_id = ?", id) })
+	if _, err := ObserveRuntime(database, id, RuntimeObservation{Host: "codex", CLIVersion: "0.0.44", Model: "known-model", ObservedAt: 100}); err != nil {
+		t.Fatal(err)
+	}
+	for index, malformed := range []string{strings.Repeat("v", 33), strings.Repeat("v", 128), "0.0.\x0044", "0.0.44\t"} {
+		timestamp := int64(200000 + index*60000)
+		result, err := ObserveRuntime(database, id, RuntimeObservation{Host: "workbuddy/5.5.4", Mode: "skill", CLIVersion: malformed, Model: strings.Repeat("m", 129), ObservedAt: timestamp, Active: true})
+		if err != nil {
+			t.Fatalf("optional invalid header rolled back valid facts: %v", err)
+		}
+		var row AgentSettings
+		if err := database.First(&row, "agent_id = ?", id).Error; err != nil {
+			t.Fatal(err)
+		}
+		if row.RuntimeName != "workbuddy" || row.Mode != "skill" || row.LastActivityAt != timestamp || row.CLIVersion != "0.0.44" || row.Model != "known-model" {
+			t.Fatalf("valid facts lost or invalid metadata stored: result=%+v row=%+v", result, row)
+		}
+	}
+}
+
+func TestRuntimeObservationPostgresHandoffUsesEntryFence(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN required for PostgreSQL handoff entry fence")
+	}
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := time.Now().UnixNano()
+	now := time.Now().UnixMilli()
+	if err := database.Exec(`INSERT INTO agents (agent_id,email,agent_name,bio,created_at,updated_at) VALUES (?,?,'Runtime handoff fence','',?,?)`, id, fmt.Sprintf("runtime-entry-%d@example.test", id), now, now).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Exec("DELETE FROM agents WHERE agent_id = ?", id) })
+	entry := reqinfo.WithRequestStart(context.Background())
+	latest := reqinfo.RequestStartedAt(entry) + 100
+	if _, err := ObserveRuntime(database, id, RuntimeObservation{Host: "workbuddy/5.5.4", Mode: "skill", ObservedAt: latest, Explicit: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Model(&AgentSettings{}).Where("agent_id = ?", id).UpdateColumn("device_name", "current-device").Error; err != nil {
+		t.Fatal(err)
+	}
+	err = UpdateHandoffClientIdentity(database.WithContext(entry), id, "openclaw", "old", "old-device", "0.0.42", "plugin")
+	if !errors.Is(err, ErrRuntimeReportSuperseded) {
+		t.Fatalf("delayed handoff error=%v, want superseded", err)
+	}
+	var row AgentSettings
+	if err := database.First(&row, "agent_id = ?", id).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.RuntimeName != "workbuddy" || row.Mode != "skill" || row.RuntimeReportedAt != latest || row.DeviceName != "current-device" {
+		t.Fatalf("old handoff overwrote newer report: %+v", row)
+	}
+}

--- a/api/dal/runtime_observation_test.go
+++ b/api/dal/runtime_observation_test.go
@@ -1,0 +1,119 @@
+package dal
+
+import (
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func observationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.AutoMigrate(&AgentSettings{}); err != nil {
+		t.Fatal(err)
+	}
+	return database
+}
+
+func TestRuntimeObservationFactsAndFence(t *testing.T) {
+	database := observationDB(t)
+	const id int64 = 101
+	observe := func(obs RuntimeObservation) RuntimeObservationResult {
+		t.Helper()
+		result, err := ObserveRuntime(database, id, obs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	read := func() AgentSettings {
+		t.Helper()
+		var row AgentSettings
+		if err := database.First(&row, "agent_id = ?", id).Error; err != nil {
+			t.Fatal(err)
+		}
+		return row
+	}
+	observe(RuntimeObservation{Host: "openclaw/0.0.39", ObservedAt: 100, Active: true})
+	if row := read(); row.Mode != "" || row.RuntimeName != "openclaw" || row.LastActivityAt != 100 {
+		t.Fatalf("host must not imply mode: %+v", row)
+	}
+	observe(RuntimeObservation{Host: "openclaw", Mode: "plugin", ObservedAt: 200})
+	if row := read(); row.RuntimeVersion != "0.0.39" || row.Mode != "plugin" {
+		t.Fatalf("passive bare host must preserve version: %+v", row)
+	}
+	observe(RuntimeObservation{Host: "openclaw", Mode: "plugin", ObservedAt: 300, Explicit: true})
+	if row := read(); row.RuntimeVersion != "" || row.ClientHost != "openclaw" {
+		t.Fatalf("explicit bare host must clear fake version: %+v", row)
+	}
+	observe(RuntimeObservation{Mode: "skill", ObservedAt: 400, Explicit: true})
+	result := observe(RuntimeObservation{Host: "openclaw/old", Mode: "plugin", ObservedAt: 350, Active: true})
+	if row := read(); result.Outcome != "stale" || row.Mode != "skill" || row.ClientHost != "" || row.RuntimeReportedAt != 400 {
+		t.Fatalf("mode-only fence lost: result=%+v row=%+v", result, row)
+	}
+	observe(RuntimeObservation{Host: "workbuddy", ObservedAt: 500})
+	if row := read(); row.RuntimeName != "workbuddy" || row.RuntimeVersion != "" || row.Mode != "skill" {
+		t.Fatalf("independent product merge failed: %+v", row)
+	}
+	observe(RuntimeObservation{Host: "terminal", ObservedAt: 600})
+	if row := read(); row.RuntimeName != "workbuddy" || row.RuntimeReportedAt != 500 {
+		t.Fatalf("unknown host changed identity: %+v", row)
+	}
+}
+
+func TestRuntimeActivityCoalescesWithoutChangingSettingsTimestamp(t *testing.T) {
+	database := observationDB(t)
+	initial := AgentSettings{AgentID: 102, RuntimeName: "codex", RuntimeVersion: "1.2", UpdatedAt: 123, LastActivityAt: 100000}
+	if err := database.Create(&initial).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, ts := range []int64{99999, 100001, 130000, 160000, 159000} {
+		if _, err := ObserveRuntime(database, 102, RuntimeObservation{Active: true, ObservedAt: ts}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var row AgentSettings
+	if err := database.First(&row, "agent_id = ?", 102).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.LastActivityAt != 160000 || row.UpdatedAt != 123 || row.RuntimeName != "codex" || row.RuntimeVersion != "1.2" {
+		t.Fatalf("activity regressed or changed settings: %+v", row)
+	}
+}
+
+func TestHandoffReportsModeBeforeOnboarding(t *testing.T) {
+	database := observationDB(t)
+	if err := UpdateHandoffClientIdentity(database, 103, "workbuddy", "", "machine", "0.0.44", "skill"); err != nil {
+		t.Fatal(err)
+	}
+	var row AgentSettings
+	if err := database.First(&row, "agent_id = ?", 103).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.Mode != "skill" || row.RuntimeName != "workbuddy" || row.RuntimeReportedAt <= 0 || row.LastActivityAt != 0 {
+		t.Fatalf("handoff report failed: %+v", row)
+	}
+}
+
+func TestCompatibilityReportCannotBypassRuntimeFence(t *testing.T) {
+	database := observationDB(t)
+	if _, err := ObserveRuntime(database, 104, RuntimeObservation{Host: "workbuddy", CLIVersion: "0.0.44", ObservedAt: 500, Explicit: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateHeartbeatCompatibility(database, 104, "0.0.42", "eigenflux_heartbeat.v1", "current"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ObserveRuntime(database, 104, RuntimeObservation{CLIVersion: "0.0.42", ObservedAt: 400}); err != nil {
+		t.Fatal(err)
+	}
+	var row AgentSettings
+	if err := database.First(&row, "agent_id = ?", 104).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.CLIVersion != "0.0.44" || row.RuntimeReportedAt != 500 {
+		t.Fatalf("compatibility report bypassed fence: %+v", row)
+	}
+}

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -723,7 +723,6 @@ func Publish(ctx context.Context, c *app.RequestContext) {
 // @Failure 401 {object} BaseResp
 // @Router /api/v1/items/feed [get]
 func Feed(ctx context.Context, c *app.RequestContext) {
-	requestStartedAt := time.Now().UnixMilli()
 	var req apimodel.FeedReq
 	if !bindOrBadRequest(c, &req) {
 		return
@@ -838,62 +837,6 @@ func Feed(ctx context.Context, c *app.RequestContext) {
 	writeJSON(c, http.StatusOK, 0, "success", feedPayload)
 	ackNotifications(agentID, pendingNotifications)
 	activity.PublishFeedPull(ctx, agentID, len(resp.Items))
-
-	// Persist observability fields derived from request headers. Two independent
-	// axes, both refreshed here off the feed pull every runtime makes:
-	//   - runtime mode/host from X-Client-Host: host plugins launch the CLI with
-	//     EIGENFLUX_HOST set ("openclaw/<ver>", "claude-code/<ver>", …), so any
-	//     non-default host means a plugin runtime — no agent-side report needed.
-	//     Bare-CLI runtimes send the "terminal" default; skill runtimes keep
-	//     reporting mode via `settings push --mode skill` (heartbeat template).
-	//   - cli_version from X-CLI-Ver: sent by every runtime, plugin or
-	//     CLI-direct, and shown on the dashboard runtime card.
-	ci := reqinfo.ClientFromContext(ctx)
-	identity, hasIdentity := runtimeidentity.Parse(ci.Host)
-	cliVer, model := ci.CLIVer, ci.Model
-	if hasIdentity || cliVer != "" {
-		go func(agentID int64, identity runtimeidentity.Identity, hasIdentity bool, cliVer, model string, requestStartedAt int64) {
-			cur, gerr := consoledal.GetSettings(db.DB, agentID)
-			if gerr != nil {
-				return
-			}
-			// Fill-only for mode/host: never override an explicitly reported mode
-			// — a skill runtime may set a custom EIGENFLUX_HOST (e.g. "jarvis")
-			// and its heartbeat-reported "skill" must win. A CLI-direct runtime
-			// (terminal host) leaves mode/client_host as-is and only refreshes
-			// cli_version. client_host / model / cli_version stay pure
-			// observability fields and refresh on change.
-			mode, newHost := cur.Mode, cur.ClientHost
-			runtimeName, runtimeVersion := cur.RuntimeName, cur.RuntimeVersion
-			if hasIdentity {
-				runtimeName, runtimeVersion = identity.Name, identity.Version
-			}
-			if identity.IsPlugin {
-				if mode == "" {
-					mode = "plugin"
-				}
-				newHost = identity.Name
-				if identity.Version != "" {
-					newHost += "/" + identity.Version
-				}
-			}
-			if cur.Mode == mode && cur.ClientHost == newHost &&
-				cur.RuntimeName == runtimeName && cur.RuntimeVersion == runtimeVersion &&
-				(model == "" || cur.Model == model) &&
-				(cliVer == "" || cur.CLIVersion == cliVer) {
-				return
-			}
-			updated, uerr := consoledal.UpdateDerivedRuntimeIfNotSuperseded(db.DB, agentID, mode, newHost, runtimeName, runtimeVersion, model, cliVer, requestStartedAt)
-			if uerr != nil {
-				logger.Default().Warn("derived runtime write failed", "agentID", agentID, "err", uerr)
-				return
-			}
-			if !updated {
-				return
-			}
-			agentcard.PublishRebuild(context.Background(), agentID, "runtime_update")
-		}(agentID, identity, hasIdentity, cliVer, model, requestStartedAt)
-	}
 }
 
 func applyFeedItemProvenance(item map[string]interface{}, feedItem *feedrpc.FeedItem) {
@@ -3277,6 +3220,7 @@ func ConsoleGetSettings(ctx context.Context, c *app.RequestContext) {
 		"cli_version":              settings.CLIVersion,
 		"lang":                     settings.Lang,
 		"last_sync_at":             lastSyncAt,
+		"last_activity_at":         settings.LastActivityAt,
 		"created_at":               createdAt,
 	})
 }
@@ -3346,6 +3290,7 @@ func GetMySettings(ctx context.Context, c *app.RequestContext) {
 		"mode":                     settings.Mode,
 		"runtime_name":             settings.RuntimeName,
 		"runtime_version":          settings.RuntimeVersion,
+		"last_activity_at":         settings.LastActivityAt,
 		"lang":                     settings.Lang,
 		"updated_at":               settings.UpdatedAt,
 	})
@@ -3378,10 +3323,18 @@ func (body *agentSettingsWriteRequest) discardLegacySecurityBoundary() {
 // wire compatibility and remain writable only through versioned Agent context.
 // @router /api/v1/agents/me/settings [PUT]
 func PutMySettings(ctx context.Context, c *app.RequestContext) {
+	ctx = reqinfo.WithRequestStart(ctx)
+	requestStartedAt := reqinfo.RequestStartedAt(ctx)
 	agentID, ok := currentAgentID(c)
 	if !ok {
 		return
 	}
+	defer func() {
+		identity, hasIdentity := runtimeidentity.Parse(string(c.GetHeader("X-Client-Host")))
+		logger.Ctx(ctx).Info("agent_settings_response", "agent_id", agentID, "http_status", c.Response.StatusCode(),
+			"host_present", hasIdentity, "runtime_name", identity.Name, "cli_present", len(c.GetHeader("X-CLI-Ver")) > 0,
+			"plugin_version", reqinfo.SafePluginVersion(string(c.GetHeader("X-Client-Plugin-Version"))))
+	}()
 	var body agentSettingsWriteRequest
 	raw, _ := c.Body()
 	if err := json.Unmarshal(raw, &body); err != nil {
@@ -3398,26 +3351,41 @@ func PutMySettings(ctx context.Context, c *app.RequestContext) {
 	}
 	body.discardLegacySecurityBoundary()
 	clientInfo := reqinfo.ClientFromContext(ctx)
-	model := clientInfo.Model
-	identity, hasIdentity := runtimeidentity.Parse(clientInfo.Host)
-	if err := db.DB.Transaction(func(tx *gorm.DB) error {
-		if err := consoledal.UpdateAgentReportedSettings(tx, agentID, body.FeedDeliveryPreference, body.Mode, body.Lang, body.FeedPollInterval, body.FeedPollIntervalUserSet, body.OfficialPMOptout); err != nil {
-			return err
-		}
-		// Persist X-Client-Model in the same transaction. The CLI records its
-		// local "reported" snapshot only after this endpoint succeeds, so a
-		// model failure must roll the settings write back and remain retryable.
-		if err := consoledal.UpdateAgentModel(tx, agentID, model); err != nil {
-			return err
-		}
-		if hasIdentity {
-			return consoledal.UpdateRuntimeIdentity(tx, agentID, identity.Name, identity.Version)
-		}
-		return nil
-	}); err != nil {
-		writeJSON(c, http.StatusInternalServerError, 500, err.Error(), nil)
+	mode := clientInfo.Mode
+	if body.Mode != nil {
+		mode = *body.Mode
+	}
+	if mode != "" && mode != "plugin" && mode != "skill" {
+		logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "settings", "outcome", "invalid_mode")
+		writeJSON(c, http.StatusBadRequest, 400, "mode must be plugin or skill", nil)
 		return
 	}
+	var observation consoledal.RuntimeObservationResult
+	if err := db.DB.Transaction(func(tx *gorm.DB) error {
+		var err error
+		observation, err = consoledal.ObserveRuntime(tx, agentID, consoledal.RuntimeObservation{
+			Host: clientInfo.Host, Mode: mode, Model: clientInfo.Model, CLIVersion: clientInfo.CLIVer,
+			ObservedAt: requestStartedAt, Explicit: true,
+		})
+		if err != nil {
+			return err
+		}
+		if observation.Outcome == "stale" {
+			return errors.New("runtime report superseded")
+		}
+		return consoledal.UpdateAgentReportedSettings(tx, agentID, body.FeedDeliveryPreference, nil, body.Lang, body.FeedPollInterval, body.FeedPollIntervalUserSet, body.OfficialPMOptout)
+	}); err != nil {
+		if observation.Outcome == "stale" {
+			logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "settings", "outcome", "stale")
+			writeJSON(c, http.StatusConflict, 409, "newer runtime report exists; retry settings report", nil)
+			return
+		}
+		logger.Ctx(ctx).Warn("agent_runtime_report", "agent_id", agentID, "source", "settings", "outcome", "failed")
+		writeJSON(c, http.StatusInternalServerError, 500, "settings report failed", nil)
+		return
+	}
+	logger.Ctx(ctx).Info("agent_runtime_report", "agent_id", agentID, "source", "settings", "outcome", observation.Outcome, "mode", mode)
+
 	agentcard.PublishRebuild(ctx, agentID, "settings_update")
 	writeJSON(c, http.StatusOK, 0, "success", nil)
 }

--- a/api/middleware/agent_observation.go
+++ b/api/middleware/agent_observation.go
@@ -1,0 +1,115 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"eigenflux_server/api/dal"
+	"eigenflux_server/pkg/agentcard"
+	"eigenflux_server/pkg/logger"
+	"eigenflux_server/pkg/reqinfo"
+	"eigenflux_server/pkg/runtimeidentity"
+	"github.com/cloudwego/hertz/pkg/app"
+	"gorm.io/gorm"
+)
+
+// agentActivityRoute is an explicit allowlist of actions initiated by Agents.
+// Console views, metadata reads, passive delivery, and server events are absent.
+func agentActivityRoute(method, path string) bool {
+	switch method {
+	case http.MethodGet:
+		switch path {
+		case "/api/v1/items/feed", "/api/v1/pm/fetch", "/api/v2/pm/fetch", "/api/v2/pm/messages":
+			return true
+		}
+	case http.MethodPost:
+		switch path {
+		case "/api/v1/items/publish", "/api/v1/items/feedback", "/api/v1/items/events",
+			"/api/v1/pm/send", "/api/v1/pm/close", "/api/v1/pm/topic-status",
+			"/api/v1/relations/apply", "/api/v1/relations/handle", "/api/v1/relations/unfriend", "/api/v1/relations/block", "/api/v1/relations/unblock", "/api/v1/relations/remark",
+			"/api/v2/feed", "/api/v2/feed/feedback", "/api/v2/feed/events:batch", "/api/v2/runtime/heartbeat", "/api/v2/notifications/ack",
+			"/api/v2/broadcasts", "/api/v2/items/publish", "/api/v2/items/feedback", "/api/v2/items/events",
+			"/api/v2/pm/messages", "/api/v2/pm/send", "/api/v2/pm/close", "/api/v2/pm/conversations/close", "/api/v2/pm/conversations/topic-status",
+			"/api/v2/relations/apply", "/api/v2/relations/handle", "/api/v2/relations/unfriend", "/api/v2/relations/block", "/api/v2/relations/unblock", "/api/v2/relations/remark",
+			"/api/v2/relations/friend-requests", "/api/v2/relations/friend-requests/handle", "/api/v2/relations/friends/unfriend", "/api/v2/relations/friends/block", "/api/v2/relations/friends/unblock", "/api/v2/relations/friends/remark",
+			"/api/v2/agent-attention-items/prefill", "/api/v2/agent-attention-items:publish", "/api/v2/agent-attention-items/:attention_id/respond", "/api/v2/agent-attention-items/:attention_id/dismiss",
+			"/api/v2/agent-commands/:command_id/claim", "/api/v2/agent-commands/:command_id/complete", "/api/v2/agent-context/intent-actions":
+			return true
+		}
+	case http.MethodDelete:
+		switch path {
+		case "/api/v1/agents/items/:item_id", "/api/v2/broadcasts/:item_id", "/api/v2/agents/items/:item_id", "/api/v2/agent-context/intent-actions/:intent_id":
+			return true
+		}
+	case http.MethodPut:
+		switch path {
+		case "/api/v2/agent-settings/heartbeat-compatibility", "/api/v1/agents/profile", "/api/v1/agents/me/profile/fields", "/api/v2/agent-profile/fields",
+			"/api/v2/agent-context/network-goal", "/api/v2/agent-context/intent-actions/:intent_id", "/api/v2/agent-context/security-boundary":
+			return true
+		}
+	}
+	return false
+}
+
+func successfulAgentResponse(c *app.RequestContext) bool {
+	if c.Response.StatusCode() < 200 || c.Response.StatusCode() >= 300 {
+		return false
+	}
+	var envelope struct {
+		Code  *int            `json:"code"`
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(c.Response.Body(), &envelope); err != nil {
+		return false
+	}
+	return (envelope.Code == nil || *envelope.Code == 0) && (len(envelope.Error) == 0 || string(envelope.Error) == "null")
+}
+
+// ObserveSuccessfulAgentRequest runs only after Agent authentication and a
+// successful allowlisted handler. V1 credentials are shared with the old
+// Console, so that compatibility path additionally requires CLI metadata and
+// excludes browser requests. Identity/settings reads never refresh activity.
+func ObserveSuccessfulAgentRequest(ctx context.Context, c *app.RequestContext, database *gorm.DB, agentID, startedAt int64, legacy bool) {
+	path := c.FullPath()
+	if path == "" {
+		path = string(c.Path())
+	}
+	if database == nil || !agentActivityRoute(string(c.Method()), path) || !successfulAgentResponse(c) {
+		return
+	}
+	if legacy && (len(c.GetHeader("X-CLI-Ver")) == 0 || len(c.GetHeader("Origin")) > 0 || len(c.GetHeader("Sec-Fetch-Site")) > 0) {
+		return
+	}
+	header := func(name string) string {
+		value := string(c.GetHeader(name))
+		limit := 128
+		if name == "X-Client-Host" {
+			limit = 129
+		}
+		if len(value) > limit {
+			return ""
+		}
+		return value
+	}
+	obs := dal.RuntimeObservation{Host: header("X-Client-Host"), Mode: header("X-Client-Mode"), Model: header("X-Client-Model"), CLIVersion: header("X-CLI-Ver"), ObservedAt: startedAt, Active: true}
+	if obs.Mode != "plugin" && obs.Mode != "skill" {
+		obs.Mode = ""
+	}
+	observationCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	result, err := dal.ObserveRuntime(database.WithContext(observationCtx), agentID, obs)
+	identity, hasHost := runtimeidentity.Parse(obs.Host)
+	// Only parsed product names and enum values are logged, never raw headers,
+	// client IDs, request bodies, or credentials. Business failures never enter here.
+	fields := []interface{}{"agent_id", agentID, "source", path, "outcome", result.Outcome, "host_present", hasHost, "runtime_name", identity.Name, "mode", obs.Mode, "cli_present", obs.CLIVersion != "", "plugin_version", reqinfo.SafePluginVersion(header("X-Client-Plugin-Version"))}
+	if err != nil {
+		logger.Ctx(ctx).Warn("agent_runtime_observation", fields...)
+		return
+	}
+	if result.IdentityChanged {
+		agentcard.PublishRebuild(ctx, agentID, "runtime_update")
+	}
+	logger.Ctx(ctx).Info("agent_runtime_observation", fields...)
+}

--- a/api/middleware/agent_observation_test.go
+++ b/api/middleware/agent_observation_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"eigenflux_server/api/dal"
+	"github.com/cloudwego/hertz/pkg/app"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestAgentObservationSuccessAndReadBoundaries(t *testing.T) {
+	tests := []struct {
+		name, method, path, body, origin, cli string
+		status                                int
+		legacy, want                          bool
+	}{
+		{name: "V2 feed", method: "POST", path: "/api/v2/feed", body: `{"data":{"items":[]}}`, status: 200, want: true},
+		{name: "heartbeat", method: "POST", path: "/api/v2/runtime/heartbeat", body: `{"data":{}}`, status: 200, want: true},
+		{name: "broadcast", method: "POST", path: "/api/v2/broadcasts", body: `{"code":0}`, status: 200, want: true},
+		{name: "message", method: "POST", path: "/api/v2/pm/messages", body: `{"code":0}`, status: 200, want: true},
+		{name: "Attention response", method: "POST", path: "/api/v2/agent-attention-items/:attention_id/respond", body: `{"data":{}}`, status: 200, want: true},
+		{name: "command completion", method: "POST", path: "/api/v2/agent-commands/:command_id/complete", body: `{"data":{}}`, status: 200, want: true},
+		{name: "feed events", method: "POST", path: "/api/v2/feed/events:batch", body: `{"code":0}`, status: 200, want: true},
+		{name: "broadcast deletion", method: "DELETE", path: "/api/v2/broadcasts/:item_id", body: `{"code":0}`, status: 200, want: true},
+		{name: "unfriend", method: "POST", path: "/api/v2/relations/friends/unfriend", body: `{"code":0}`, status: 200, want: true},
+		{name: "Console Attention response", method: "POST", path: "/api/v2/console/attention-items/:attention_id/respond", body: `{"data":{}}`, status: 200},
+		{name: "business failure", method: "POST", path: "/api/v2/feed", body: `{"code":500}`, status: 200},
+		{name: "V2 failure", method: "POST", path: "/api/v2/feed", body: `{"error":{"code":"FAILED"}}`, status: 200},
+		{name: "HTTP failure", method: "POST", path: "/api/v2/feed", body: `{"code":0}`, status: 500},
+		{name: "profile read", method: "GET", path: "/api/v2/agent-profile", body: `{"data":{}}`, status: 200},
+		{name: "settings read", method: "GET", path: "/api/v2/agent-settings", body: `{"data":{}}`, status: 200},
+		{name: "console view", method: "GET", path: "/api/v2/console/today", body: `{"data":{}}`, status: 200},
+		{name: "legacy browser", method: "GET", path: "/api/v1/items/feed", body: `{"code":0}`, cli: "0.0.42", origin: "https://console.eigenflux.ai", legacy: true, status: 200},
+		{name: "legacy unknown caller", method: "GET", path: "/api/v1/items/feed", body: `{"code":0}`, legacy: true, status: 200},
+		{name: "legacy CLI", method: "GET", path: "/api/v1/items/feed", body: `{"code":0}`, cli: "0.0.42", legacy: true, status: 200, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := database.AutoMigrate(&dal.AgentSettings{}); err != nil {
+				t.Fatal(err)
+			}
+			c := app.NewContext(0)
+			c.Request.SetMethod(tt.method)
+			c.Request.SetRequestURI(tt.path)
+			c.Request.Header.Set("X-Client-Host", "workbuddy/5.5")
+			c.Request.Header.Set("X-Client-Mode", "skill")
+			if tt.cli != "" {
+				c.Request.Header.Set("X-CLI-Ver", tt.cli)
+			}
+			if tt.origin != "" {
+				c.Request.Header.Set("Origin", tt.origin)
+			}
+			c.Response.SetStatusCode(tt.status)
+			c.Response.SetBodyString(tt.body)
+			ObserveSuccessfulAgentRequest(context.Background(), c, database, 101, 100000, tt.legacy)
+			var rows []dal.AgentSettings
+			if err := database.Find(&rows).Error; err != nil {
+				t.Fatal(err)
+			}
+			if !tt.want {
+				if len(rows) != 0 {
+					t.Fatalf("non-Agent activity changed settings: %+v", rows)
+				}
+				return
+			}
+			if len(rows) != 1 || rows[0].RuntimeName != "workbuddy" || rows[0].Mode != "skill" || rows[0].LastActivityAt != 100000 {
+				t.Fatalf("successful activity was not observed: %+v", rows)
+			}
+		})
+	}
+}

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -12,6 +12,7 @@ import (
 	"eigenflux_server/api/clients"
 	auth "eigenflux_server/kitex_gen/eigenflux/auth"
 	"eigenflux_server/pkg/agentcard"
+	"eigenflux_server/pkg/db"
 	"eigenflux_server/pkg/mq"
 	"eigenflux_server/pkg/reqinfo"
 )
@@ -36,6 +37,8 @@ func SetBlockedAgentEmails(emails []string) {
 
 func AuthMiddleware() app.HandlerFunc {
 	return func(ctx context.Context, c *app.RequestContext) {
+		ctx = reqinfo.WithRequestStart(ctx)
+		requestStartedAt := reqinfo.RequestStartedAt(ctx)
 		header := string(c.GetHeader("Authorization"))
 		if header == "" {
 			c.JSON(http.StatusUnauthorized, map[string]interface{}{
@@ -90,5 +93,6 @@ func AuthMiddleware() app.HandlerFunc {
 			ctx = metainfo.WithPersistentValue(ctx, reqinfo.KeyEmail, *resp.Email)
 		}
 		c.Next(ctx)
+		ObserveSuccessfulAgentRequest(ctx, c, db.DB, resp.AgentId, requestStartedAt, true)
 	}
 }

--- a/api/middleware/clientinfo.go
+++ b/api/middleware/clientinfo.go
@@ -13,6 +13,7 @@ import (
 
 func ClientInfoMiddleware() app.HandlerFunc {
 	return func(ctx context.Context, c *app.RequestContext) {
+		ctx = reqinfo.WithRequestStart(ctx)
 		if v := c.GetHeader("X-Skill-Ver"); len(v) > 0 {
 			ver := string(v)
 			num := parseVersionNum(ver)
@@ -39,6 +40,7 @@ func ClientInfoMiddleware() app.HandlerFunc {
 			{"X-Client-Lang", "client_lang", reqinfo.KeyClientLang},
 			{"X-Client-Host", "client_host", reqinfo.KeyClientHost},
 			{"X-Client-Channel", "client_channel", reqinfo.KeyClientChannel},
+			{"X-Client-Mode", "client_mode", reqinfo.KeyClientMode},
 			{"X-Client-ID", "client_id", reqinfo.KeyClientID},
 			{"X-Client-Model", "client_model", reqinfo.KeyClientModel},
 			{"X-Bio-Source", "bio_source", reqinfo.KeyBioSource},
@@ -46,8 +48,15 @@ func ClientInfoMiddleware() app.HandlerFunc {
 		} {
 			if v := c.GetHeader(h.header); len(v) > 0 {
 				val := string(v)
-				if len(val) > 128 {
-					val = val[:128]
+				limit := 128
+				if h.header == "X-Client-Host" {
+					limit = 129
+				}
+				if len(val) > limit {
+					if h.header == "X-Client-Host" || h.header == "X-Client-Model" {
+						continue
+					}
+					val = val[:limit]
 				}
 				c.Set(h.key, val)
 				ctx = metainfo.WithPersistentValue(ctx, h.ctxKey, val)

--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,12 +3,12 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.44
+CLI_VERSION=0.0.45
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients
 # actually compare, this is just a human-facing label.)
-SKILLS_REVISION=18
+SKILLS_REVISION=19
 
 # Local build sequence only. Production releases allocate max(signed R2 history)+1
 # inside the serialized Release Skills workflow; this value never selects a release.
@@ -17,4 +17,4 @@ SKILLS_SEQUENCE=8
 # Minimum CLI version that may adopt the current skills bundle. Bump ONLY when a
 # skill starts requiring a newer CLI command, so old CLIs keep their old skills
 # instead of pulling ones they can't run.
-SKILLS_MIN_CLI_VERSION=0.0.43
+SKILLS_MIN_CLI_VERSION=0.0.45

--- a/cli/cmd/agent_v2.go
+++ b/cli/cmd/agent_v2.go
@@ -314,6 +314,9 @@ var agentV2ProvisionCmd = &cobra.Command{
 		noHandoff, _ := cmd.Flags().GetBool("no-handoff")
 		recoverAccount, _ := cmd.Flags().GetBool("recover-account")
 		requireExistingAgent, _ := cmd.Flags().GetBool("require-existing-agent")
+		mode, _ := cmd.Flags().GetString("mode")
+		runtimeName, _ := cmd.Flags().GetString("runtime-name")
+		runtimeVersion, _ := cmd.Flags().GetString("runtime-version")
 		if strings.TrimSpace(agentName) == "" {
 			agentName = "EigenFlux Agent"
 		}
@@ -325,11 +328,15 @@ var agentV2ProvisionCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		meta, err := configureRuntimeIdentity(cfg, server.Name, mode, runtimeName, runtimeVersion)
+		if err != nil {
+			return err
+		}
 		publicKey, privateKey, _, err := auth.LoadOrCreateIdentity(server.Name)
 		if err != nil {
 			return err
 		}
-		v2 := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", "", version, clientMeta)
+		v2 := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", "", version, meta)
 		expectedAgentID := ""
 		preserveExistingIdentity := false
 		var legacyCredentials *auth.Credentials
@@ -381,7 +388,7 @@ var agentV2ProvisionCmd = &cobra.Command{
 			if hasV2 {
 				grant, nonce, err = requestAutomaticRegistrationChallenge(v2, publicKey)
 			} else if legacyCredentials != nil && legacyCredentials.AccessToken != "" {
-				legacy := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v1", legacyCredentials.AccessToken, version, clientMeta)
+				legacy := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v1", legacyCredentials.AccessToken, version, meta)
 				var challengeAgentID string
 				grant, nonce, challengeAgentID, err = requestLegacyAgentUpgradeChallenge(legacy, publicKey)
 				if err == nil && expectedAgentID != "" && challengeAgentID != expectedAgentID {
@@ -455,13 +462,15 @@ var agentV2ProvisionCmd = &cobra.Command{
 		}
 		result := map[string]interface{}{
 			"agent_id": provisioned.AgentID, "created": provisioned.Created,
-			"next_step": provisioned.NextStep,
+			"next_step":    provisioned.NextStep,
+			"runtime_host": meta.Host, "mode": meta.Mode,
+			"runtime_identity_complete": meta.Host != "" && meta.Mode != "",
 		}
 		homeDir, homeSource := config.HomeDirInfo()
 		result["home"] = homeDir
 		result["home_source"] = homeSource
 		if !noHandoff {
-			authenticated := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", provisioned.AccessToken, version, clientMeta)
+			authenticated := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", provisioned.AccessToken, version, meta)
 			browserNonce, nonceErr := newBrowserNonce()
 			if nonceErr != nil {
 				return nonceErr
@@ -488,6 +497,9 @@ var agentV2ProvisionCmd = &cobra.Command{
 }
 
 func init() {
+	agentV2ProvisionCmd.Flags().String("mode", "", "persist the verified installation mode (plugin|skill)")
+	agentV2ProvisionCmd.Flags().String("runtime-name", "", "persist the Agent product identity for this Home and server")
+	agentV2ProvisionCmd.Flags().String("runtime-version", "", "known Agent product version, independent of plugin version")
 	agentV2ProvisionCmd.Flags().String("bootstrap-grant", "", "optional short-lived controlled-channel grant (automatic registration is used when omitted)")
 	agentV2ProvisionCmd.Flags().String("nonce", "", "single-use proof nonce paired with --bootstrap-grant")
 	agentV2ProvisionCmd.Flags().String("agent-name", "EigenFlux Agent", "Agent name used to prefill onboarding")

--- a/cli/cmd/feed.go
+++ b/cli/cmd/feed.go
@@ -71,10 +71,13 @@ Examples:
 		maybeSyncSkills(cfg)
 		if _, v2Err := auth.LoadV2Credentials(serverName); v2Err == nil {
 			return runFeedV2Poll(action, cursor, func() error {
-				return pollFeedV2(cmd, serverName, limit)
+				if err := pollFeedV2(cmd, serverName, limit); err != nil {
+					return err
+				}
+				finishFeedPoll(cfg, serverName)
+				return nil
 			})
 		}
-		_, agentID := profileStateScopeForServer(serverName)
 		c := newClientForServer(serverName)
 		resp, err := c.Get("/items/feed", params)
 		if err != nil {
@@ -93,12 +96,7 @@ Examples:
 		// Reconcile settings on the poll heartbeat — this is how console-side
 		// edits (recurring_publish, feed_poll_interval) reach the agent.
 		// Best-effort: a sync failure must never break the poll itself.
-		if cfg != nil {
-			_ = SyncSettings(cfg)
-		}
-		if agentID != "" {
-			maybePromptProfileRefreshFor(serverName, agentID)
-		}
+		finishFeedPoll(cfg, serverName)
 		return nil
 	},
 }
@@ -111,6 +109,26 @@ func runFeedV2Poll(action, cursor string, poll func() error) error {
 		return fmt.Errorf("--action must be refresh or more for Feed V2")
 	}
 	return poll()
+}
+
+// Both Feed transports complete the same reconciliation, independently of
+// optional local memory/profile state. Diagnostics stay off the Feed JSON stream.
+func finishFeedPoll(cfg *config.Config, serverName string) {
+	if cfg != nil {
+		result, _ := reportRuntimeSettings(cfg, "", "", "", "", false)
+		if result.Status == "failed" || result.Status == "missing" || len(result.Missing) > 0 {
+			fmt.Fprintf(os.Stderr, "EigenFlux runtime report: %s", result.Status)
+			if len(result.Missing) > 0 {
+				fmt.Fprintf(os.Stderr, " (missing: %s)", strings.Join(result.Missing, ", "))
+			}
+			fmt.Fprintln(os.Stderr)
+		}
+		_ = SyncSettings(cfg)
+	}
+	_, agentID := profileStateScopeForServer(serverName)
+	if agentID != "" {
+		maybePromptProfileRefreshFor(serverName, agentID)
+	}
 }
 
 var feedGetCmd = &cobra.Command{
@@ -415,7 +433,7 @@ func pushEvents(events []map[string]interface{}) error {
 		return fmt.Errorf("token expired for server %q", srv.Name)
 	}
 	baseURL := strings.TrimRight(srv.Endpoint, "/") + "/api/v1"
-	c := client.New(baseURL, creds.AccessToken, version, clientMeta)
+	c := client.New(baseURL, creds.AccessToken, version, clientMetaForServer(srv))
 	resp, err := c.Post("/items/events", map[string]interface{}{"events": events})
 	if err != nil {
 		return err

--- a/cli/cmd/heartbeat.go
+++ b/cli/cmd/heartbeat.go
@@ -17,19 +17,21 @@ import (
 const heartbeatContractVersion = "eigenflux_heartbeat.v1"
 
 type heartbeatPlan struct {
-	SchemaVersion            string   `json:"schema_version"`
-	HeartbeatContractVersion string   `json:"heartbeat_contract_version"`
-	CLIVersion               string   `json:"cli_version"`
-	SkillRevision            string   `json:"skill_revision"`
-	SkillsTarget             string   `json:"skills_target"`
-	Skills                   []string `json:"skills"`
-	RuleSources              []string `json:"rule_sources"`
-	ExecutionOrder           []string `json:"execution_order"`
-	CLIPrefix                string   `json:"cli_prefix"`
-	SchedulerLauncher        string   `json:"scheduler_launcher"`
-	SchedulerMigration       string   `json:"scheduler_migration"`
-	SkillsFresh              bool     `json:"skills_fresh"`
-	CompatibilityReported    bool     `json:"compatibility_reported"`
+	SchemaVersion            string              `json:"schema_version"`
+	HeartbeatContractVersion string              `json:"heartbeat_contract_version"`
+	CLIVersion               string              `json:"cli_version"`
+	SkillRevision            string              `json:"skill_revision"`
+	SkillsTarget             string              `json:"skills_target"`
+	Skills                   []string            `json:"skills"`
+	RuleSources              []string            `json:"rule_sources"`
+	ExecutionOrder           []string            `json:"execution_order"`
+	CLIPrefix                string              `json:"cli_prefix"`
+	SchedulerLauncher        string              `json:"scheduler_launcher"`
+	SchedulerMigration       string              `json:"scheduler_migration"`
+	SkillsFresh              bool                `json:"skills_fresh"`
+	CompatibilityReported    bool                `json:"compatibility_reported"`
+	CompatibilityError       string              `json:"compatibility_error,omitempty"`
+	RuntimeReport            runtimeReportResult `json:"runtime_report"`
 }
 
 func fileExistsCLI(path string) bool {
@@ -51,8 +53,10 @@ var heartbeatPlanCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		runtimeReport, _ := reportRuntimeSettings(cfg, "", "", "", "", false)
+		meta := clientMetaForServerName(activeServerName())
 		res, err := skills.Sync(skills.SyncOptions{
-			Host: clientMeta.Host, IfStale: true, Quiet: true, CLIVersion: version, CDNBase: cdnBase(),
+			Host: meta.Host, IfStale: true, Quiet: true, CLIVersion: version, CDNBase: cdnBase(),
 			HTTPClient: &http.Client{Timeout: autoSkillSyncTimeout},
 		})
 		if err != nil || res == nil {
@@ -82,14 +86,21 @@ var heartbeatPlanCmd = &cobra.Command{
 
 		home, _ := config.HomeDirInfo()
 		cliPrefix := fmt.Sprintf("eigenflux --homedir %s", shellQuote(home))
+		if serverName := activeServerName(); serverName != "" {
+			cliPrefix += " --server " + shellQuote(serverName)
+		}
 		launcher := cliPrefix + " heartbeat plan --format agent"
+		if meta.Mode != "" {
+			launcher = "EIGENFLUX_MODE=" + shellQuote(meta.Mode) + " " + launcher
+		}
 		plan := heartbeatPlan{
 			SchemaVersion: "eigenflux_heartbeat_plan.v1", HeartbeatContractVersion: heartbeatContractVersion,
 			CLIVersion: version, SkillRevision: manifest.Revision, SkillsTarget: res.SkillsDir,
 			RuleSources: ruleSources, ExecutionOrder: []string{"commands", "feed", "attention", "communication", "publish", "settings_report"},
 			CLIPrefix:         cliPrefix,
-			SchedulerLauncher: launcher, SchedulerMigration: schedulerMigrationForHost(clientMeta.Host, launcher),
-			SkillsFresh: res.VerifiedManifest,
+			SchedulerLauncher: launcher, SchedulerMigration: schedulerMigrationForRuntime(meta.Host, meta.Mode, launcher),
+			SkillsFresh:   res.VerifiedManifest,
+			RuntimeReport: runtimeReport,
 		}
 		for _, entry := range manifest.Skills {
 			plan.Skills = append(plan.Skills, entry.Name)
@@ -100,9 +111,10 @@ var heartbeatPlanCmd = &cobra.Command{
 		// a provisional local bundle can render a plan but cannot unlock V2.
 		if res.VerifiedManifest {
 			if err := pushHeartbeatCompatibility(cfg, heartbeatContractVersion, manifest.Revision); err != nil {
-				return fmt.Errorf("heartbeat plan: compatibility report failed: %w", err)
+				plan.CompatibilityError = err.Error()
+			} else {
+				plan.CompatibilityReported = true
 			}
-			plan.CompatibilityReported = true
 		}
 
 		if resolveFormat() == "agent" {
@@ -115,6 +127,10 @@ var heartbeatPlanCmd = &cobra.Command{
 }
 
 func renderHeartbeatPlanForAgent(plan heartbeatPlan) string {
+	runtimeStatus := plan.RuntimeReport.Status
+	if len(plan.RuntimeReport.Missing) > 0 {
+		runtimeStatus += " (missing: " + strings.Join(plan.RuntimeReport.Missing, ", ") + ")"
+	}
 	return fmt.Sprintf(`EIGENFLUX HEARTBEAT PLAN
 Contract: %s
 CLI: %s
@@ -122,6 +138,8 @@ Skill revision: %s
 Skills target: %s
 Installed official Skills: %s
 CLI prefix for every EigenFlux command in this cycle: %s
+Runtime settings report: %s
+Heartbeat compatibility reported: %t
 
 MANDATORY FOR THIS CYCLE
 1. Freshly read, from disk, every rule source listed below. Memory, summaries, and cached copies do not satisfy this step.
@@ -137,8 +155,18 @@ Permanent launcher: %s
 Migration: %s
 The scheduler stores only the launcher. It must not copy business rules into its own prompt.
 `, plan.HeartbeatContractVersion, plan.CLIVersion, plan.SkillRevision, plan.SkillsTarget,
-		strings.Join(plan.Skills, ", "), plan.CLIPrefix, "- "+strings.Join(plan.RuleSources, "\n- "),
+		strings.Join(plan.Skills, ", "), plan.CLIPrefix, runtimeStatus, plan.CompatibilityReported, "- "+strings.Join(plan.RuleSources, "\n- "),
 		plan.SchedulerLauncher, plan.SchedulerMigration)
+}
+
+func schedulerMigrationForRuntime(host, mode, launcher string) string {
+	if mode == "plugin" {
+		return "The verified Agent plugin owns scheduling; do not create a second heartbeat. The plugin must invoke: " + launcher
+	}
+	if product := runtimeProduct(host); product == "openclaw" || product == "claude-code" {
+		return "Use the host's official scheduler API for the owned EigenFlux task. Desired launcher: " + launcher
+	}
+	return schedulerMigrationForHost(host, launcher)
 }
 
 func schedulerMigrationForHost(host, launcher string) string {

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -45,7 +45,7 @@ func newClientForServerOptionalAuth(serverName string, requireAuth bool) *client
 			if credentialErr != nil {
 				output.Die(output.ExitAuthRequired, "Agent V2 authentication failed for server %q: %v", srv.Name, credentialErr)
 			}
-			result := client.New(strings.TrimRight(srv.Endpoint, "/")+"/api/v2", credentials.AccessToken, version, clientMeta)
+			result := client.New(strings.TrimRight(srv.Endpoint, "/")+"/api/v2", credentials.AccessToken, version, clientMetaForServer(srv))
 			result.OnUnauthorized = func() (string, error) {
 				refreshed, refreshErr := refreshV2Credentials(srv.Name, srv.Endpoint, true)
 				if refreshErr != nil {
@@ -84,7 +84,7 @@ func newLegacyClientForResolvedServer(srv *config.Server, requireAuth bool) *cli
 		token = creds.AccessToken
 	}
 	baseURL := strings.TrimRight(srv.Endpoint, "/") + "/api/v1"
-	c := client.New(baseURL, token, version, clientMeta)
+	c := client.New(baseURL, token, version, clientMetaForServer(srv))
 	if requireAuth {
 		serverName := srv.Name
 		c.OnSuccess = sync.OnceFunc(func() {

--- a/cli/cmd/profile_refresh.go
+++ b/cli/cmd/profile_refresh.go
@@ -84,10 +84,7 @@ Examples:
 		}
 		_ = json.Unmarshal(resp.Data, &data)
 
-		runtimeMode := "skill"
-		if pluginOwnsProfileRefresh(clientMeta.Host, clientMeta.Channel) {
-			runtimeMode = "plugin"
-		}
+		runtimeMode := clientMetaForServerName(serverName).Mode
 		prompt := buildRefreshPrompt(data.Profile.AgentName, data.Profile.Bio, memorySnippets, sessionSnippets, serverName, runtimeMode)
 
 		// Agent Card refresh context (versioned field-level patching).
@@ -325,8 +322,8 @@ func buildRefreshPrompt(agentName, bio string, memorySnippets, sessionSnippets [
 	if serverName != "" {
 		settingsCommand = "eigenflux --server " + shellQuote(serverName) + " settings push"
 	}
-	if runtimeMode != "plugin" {
-		runtimeMode = "skill"
+	if runtimeMode != "plugin" && runtimeMode != "skill" {
+		runtimeMode = "<verified-mode>"
 	}
 
 	w(
@@ -402,15 +399,16 @@ func buildRefreshPrompt(agentName, bio string, memorySnippets, sessionSnippets [
 		"runtime_name is not proof that the same product is still running. Use only",
 		"identity and version facts explicitly supplied by the host environment or",
 		"system context. Never infer or guess missing values.",
-		"- Report the current delivery mode shown in the command below. Plugin-triggered",
-		"  reviews use plugin; shell/skill-triggered reviews use skill.",
+		"- Report the verified installation mode shown below. A verified plugin loop",
+		"  uses plugin; native scheduled tasks and Skills-driven loops use skill.",
+		"  Resolve an unknown mode from the actual launcher before reporting.",
 		"- When product identity is known, add --runtime-name and, only when known,",
 		"  --runtime-version. WorkBuddy process metadata is detected automatically.",
 		"- Add --model only when the current model identifier is explicitly known.",
 		fmt.Sprintf(`   %s --mode %s --runtime-name "<product>" \`, settingsCommand, runtimeMode),
 		`     --runtime-version "<version>" --model "<model>"`,
 		"Omit unknown optional flags rather than copying an old value. The command",
-		"is change-deduplicated, so reporting the same facts again is a local no-op.",
+		"persists identity for this Home and server, retries failures, and re-reports daily.",
 		fmt.Sprintf(`(The agent name %q is already on record; no need to change it unless wrong.)`, agentName),
 	)
 

--- a/cli/cmd/profile_refresh_prompt.go
+++ b/cli/cmd/profile_refresh_prompt.go
@@ -121,7 +121,8 @@ func maybePromptProfileRefresh() {
 func maybePromptProfileRefreshFor(srv, agentID string) {
 	// Plugin hosts own their refresh loop and discard CLI stderr. Keep this
 	// gate in the scoped implementation so feed poll cannot bypass it.
-	if pluginOwnsProfileRefresh(clientMeta.Host, clientMeta.Channel) {
+	meta := clientMetaForServerName(srv)
+	if pluginOwnsProfileRefresh(meta.Host, meta.Mode) {
 		return
 	}
 	now := time.Now().Unix()
@@ -164,18 +165,8 @@ func maybePromptProfileRefreshFor(srv, agentID string) {
 	})
 }
 
-func pluginOwnsProfileRefresh(host, channel string) bool {
-	channel = strings.ToLower(strings.TrimSpace(channel))
-	if channel == "" || channel == "cli" || channel == "skill" {
-		return false
-	}
-	name := strings.ToLower(strings.TrimSpace(strings.SplitN(host, "/", 2)[0]))
-	switch name {
-	case "openclaw", "claude-code", "codex":
-		return true
-	default:
-		return false
-	}
+func pluginOwnsProfileRefresh(_ string, mode string) bool {
+	return strings.TrimSpace(mode) == "plugin"
 }
 
 func activeProfileStateScope() (string, string) {

--- a/cli/cmd/profile_refresh_prompt_test.go
+++ b/cli/cmd/profile_refresh_prompt_test.go
@@ -99,10 +99,10 @@ func TestPluginOwnsProfileRefresh(t *testing.T) {
 		channel string
 		want    bool
 	}{
-		{"openclaw/0.0.30", "openclaw", true},
-		{"openclaw/0.0.30", "telegram", true},
-		{"claude-code/0.0.9", "claude-code", true},
-		{"codex/0.0.30", "codex", true},
+		{"openclaw/0.0.30", "plugin", true},
+		{"openclaw/0.0.30", "telegram", false},
+		{"claude-code/0.0.9", "skill", false},
+		{"codex/0.0.30", "codex", false},
 		{"codex/0.0.30", "skill", false},
 		{"codex/0.0.30", "cli", false},
 		{"workbuddy/5.3.8", "cli", false},
@@ -124,7 +124,7 @@ func TestPluginPollDoesNotConsumeProfilePromptCooldown(t *testing.T) {
 	}
 
 	oldMeta := clientMeta
-	clientMeta = client.Meta{Host: "openclaw/0.0.30", Channel: "openclaw"}
+	clientMeta = client.Meta{Host: "openclaw/0.0.30", Channel: "openclaw", Mode: "plugin"}
 	t.Cleanup(func() { clientMeta = oldMeta })
 	maybePromptProfileRefreshFor(srv, agentID)
 

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -13,7 +13,8 @@ func readRepoFile(t *testing.T, repoRoot, rel string) string {
 	if err != nil {
 		t.Fatalf("read %s: %v", rel, err)
 	}
-	return string(body)
+	// Git checkouts may use CRLF on Windows; prose contracts use canonical LF.
+	return strings.ReplaceAll(string(body), "\r\n", "\n")
 }
 
 func TestProfileSkillOwnsOnlyPostOnboardingLifecycle(t *testing.T) {

--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -50,7 +50,7 @@ func TestProfileSkillOwnsOnlyPostOnboardingLifecycle(t *testing.T) {
 			t.Errorf("ef-profile frontmatter is missing account trigger %q", trigger)
 		}
 	}
-	if !strings.Contains(frontmatter[1], `version: "0.9.1"`) {
+	if !strings.Contains(frontmatter[1], `version: "0.9.2"`) {
 		t.Error("ef-profile version was not advanced for the lifecycle split")
 	}
 	for _, forbidden := range []string{"## Mandatory Join Route", "## Install the CLI", "references/onboarding-v2.md"} {
@@ -102,7 +102,7 @@ func TestOnboardingSkillContract(t *testing.T) {
 
 	entry := readRepoFile(t, repoRoot, "skills/ef-onboarding/SKILL.md")
 	for _, required := range []string{
-		`version: "0.1.0"`,
+		`version: "0.1.1"`,
 		"references/consent.md",
 		"references/prefill.md",
 		"references/recurring-trigger.md",
@@ -151,7 +151,7 @@ func TestOnboardingSkillContract(t *testing.T) {
 	handoff := readRepoFile(t, repoRoot, "skills/ef-onboarding/references/console-handoff.md")
 	for _, required := range []string{
 		"eigenflux --homedir \"<agent-home>\" agent init --format json",
-		"eigenflux --homedir \"<agent-home>\" agent provision --draft-file -",
+		"eigenflux --homedir \"<agent-home>\" agent provision --mode \"<installation-mode>\" --runtime-name \"<known-product>\" --draft-file -",
 		"a non-empty `ticket` query parameter",
 		"a non-empty `nonce` URL fragment",
 		"[【点击此处，以人类伙伴身份继续 →】](<console_url>)",
@@ -200,7 +200,7 @@ func TestConsoleV2SchedulerStoresOnlyHeartbeatLauncher(t *testing.T) {
 	if len(launcherBlock) != 2 {
 		t.Fatal("scheduler launcher block is not closed")
 	}
-	const want = "eigenflux --homedir \"<agent-home>\" heartbeat plan --format agent"
+	const want = "EIGENFLUX_MODE=\"<installation-mode>\" eigenflux --homedir \"<agent-home>\" heartbeat plan --format agent"
 	if got := strings.TrimSpace(launcherBlock[0]); got != want {
 		t.Fatalf("scheduler body must be the thin launcher only\nwant: %s\n got: %s", want, got)
 	}

--- a/cli/cmd/runtime_concurrency_test.go
+++ b/cli/cmd/runtime_concurrency_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"cli.eigenflux.ai/internal/client"
+	"cli.eigenflux.ai/internal/config"
+)
+
+// Run the actual report/sync paths in separate CLI processes sharing one Home.
+// The HTTP barrier guarantees an old config is held across the newer write.
+func TestRuntimeConcurrentProcessesKeepNewIdentity(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		for _, staleOperation := range []string{"report", "sync"} {
+			t.Run(strconv.FormatBool(v2)+"/"+staleOperation, func(t *testing.T) {
+				entered, release := make(chan struct{}, 1), make(chan struct{})
+				var releaseOnce sync.Once
+				unblock := func() { releaseOnce.Do(func() { close(release) }) }
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mode := r.Header.Get("X-Client-Mode")
+					if (staleOperation == "report" && r.Method == http.MethodPut && mode == "plugin") ||
+						(staleOperation == "sync" && r.Method == http.MethodGet && r.URL.Path != "/api/v1/probe" && r.URL.Path != "/api/v2/probe") {
+						entered <- struct{}{}
+						<-release
+					}
+					if r.URL.Path == "/api/v1/probe" || r.URL.Path == "/api/v2/probe" {
+						if mode != "skill" || r.Header.Get("X-Client-Host") != "hermes/0.20.0" {
+							t.Errorf("later process headers host=%q mode=%q", r.Header.Get("X-Client-Host"), mode)
+						}
+					}
+					_, _ = w.Write([]byte(`{"code":0,"data":{"feed_poll_interval":7200}}`))
+				}))
+				defer server.Close()
+				defer unblock()
+				cfg, serverName := runtimeTestConfig(t, server.URL, v2)
+				if err := cfg.SetKV(settingsSyncedKey, "1"); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := configureRuntimeIdentity(cfg, serverName, "plugin", "openclaw", "2026.9.1"); err != nil {
+					t.Fatal(err)
+				}
+				oldProcess := startRuntimeProcess(t, "old-"+staleOperation)
+				select {
+				case <-entered:
+				case result := <-oldProcess:
+					t.Fatalf("old process finished before request barrier: %s", result)
+				case <-time.After(15 * time.Second):
+					t.Fatal("old process did not reach HTTP barrier")
+				}
+				waitRuntimeProcess(t, startRuntimeProcess(t, "new-report"))
+				want := loadRuntimeTestState(t, serverName)
+				if want.Host != "hermes/0.20.0" || want.Mode != "skill" || want.ReportedAtMillis == 0 {
+					t.Fatalf("new identity=%+v", want)
+				}
+				fresh, err := config.Load()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := fresh.SetKV("concurrent_marker", "new-write"); err != nil {
+					t.Fatal(err)
+				}
+				unblock()
+				waitRuntimeProcess(t, oldProcess)
+				if got := loadRuntimeTestState(t, serverName); got != want {
+					t.Fatalf("old %s overwrote newer state: got=%+v want=%+v", staleOperation, got, want)
+				}
+				if staleOperation == "report" {
+					fresh, err = config.Load()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if fresh.GetKV("concurrent_marker") != "new-write" {
+						t.Fatal("report rewrote an old whole config snapshot")
+					}
+				}
+				waitRuntimeProcess(t, startRuntimeProcess(t, "probe"))
+			})
+		}
+	}
+}
+
+func startRuntimeProcess(t *testing.T, operation string) <-chan string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+	child := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRuntimeConcurrentProcessHelper$")
+	child.Env = append(os.Environ(), "EIGENFLUX_RUNTIME_TEST_OPERATION="+operation, "EIGENFLUX_HOME="+config.HomeDir())
+	done := make(chan string, 1)
+	go func() {
+		out, err := child.CombinedOutput()
+		if err != nil {
+			done <- fmt.Sprintf("%v: %s", err, out)
+		} else {
+			done <- ""
+		}
+	}()
+	return done
+}
+
+func waitRuntimeProcess(t *testing.T, done <-chan string) {
+	t.Helper()
+	select {
+	case failure := <-done:
+		if failure != "" {
+			t.Fatal(failure)
+		}
+	case <-time.After(25 * time.Second):
+		t.Fatal("runtime subprocess timed out")
+	}
+}
+
+func TestRuntimeConcurrentProcessHelper(t *testing.T) {
+	operation := os.Getenv("EIGENFLUX_RUNTIME_TEST_OPERATION")
+	if operation == "" {
+		return
+	}
+	clientMeta, version, serverFlag = client.Meta{Host: "terminal", Channel: "cli"}, "0.0.44", ""
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch operation {
+	case "old-report":
+		result, err := reportRuntimeSettings(cfg, "", "", "", "", true)
+		if err != nil || result.Status != "reported" {
+			t.Fatalf("old report=%+v err=%v", result, err)
+		}
+	case "old-sync":
+		if err := SyncSettings(cfg); err != nil {
+			t.Fatal(err)
+		}
+	case "new-report":
+		result, err := reportRuntimeSettings(cfg, "skill", "", "hermes", "0.20.0", false)
+		if err != nil || result.Status != "reported" {
+			t.Fatalf("new report=%+v err=%v", result, err)
+		}
+	case "probe":
+		c, err := newSettingsClient(cfg, activeServerName())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Get("/probe", nil); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		t.Fatalf("unknown operation %q", operation)
+	}
+}

--- a/cli/cmd/runtime_diagnostics_test.go
+++ b/cli/cmd/runtime_diagnostics_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPartialRuntimeReportRemainsVisibleAfterFeedSuccess(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		t.Run(strconv.FormatBool(v2), func(t *testing.T) {
+			reports, syncs := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPut {
+					reports++
+				} else {
+					syncs++
+				}
+				_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+			}))
+			defer server.Close()
+			cfg, serverName := runtimeTestConfig(t, server.URL, v2)
+			if _, err := configureRuntimeIdentity(cfg, serverName, "", "codex", ""); err != nil {
+				t.Fatal(err)
+			}
+			for _, status := range []string{"reported", "unchanged"} {
+				captured, err := os.CreateTemp(t.TempDir(), "stderr")
+				if err != nil {
+					t.Fatal(err)
+				}
+				oldStderr := os.Stderr
+				os.Stderr = captured
+				finishFeedPoll(cfg, serverName)
+				os.Stderr = oldStderr
+				if err := captured.Close(); err != nil {
+					t.Fatal(err)
+				}
+				diagnostic, err := os.ReadFile(captured.Name())
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := "EigenFlux runtime report: " + status + " (missing: mode)"
+				if !strings.Contains(string(diagnostic), want) {
+					t.Fatalf("partial report hidden: %q, want %q", diagnostic, want)
+				}
+			}
+			if reports != 1 || syncs != 2 {
+				t.Fatalf("partial identity interrupted Feed reconciliation: reports=%d syncs=%d", reports, syncs)
+			}
+		})
+	}
+}
+
+func TestHeartbeatAgentOutputShowsPartialRuntimeIdentity(t *testing.T) {
+	for _, status := range []string{"reported", "unchanged", "failed", "missing"} {
+		plan := heartbeatPlan{RuntimeReport: runtimeReportResult{Status: status, Missing: []string{"mode"}}}
+		got := renderHeartbeatPlanForAgent(plan)
+		if !strings.Contains(got, "Runtime settings report: "+status+" (missing: mode)") {
+			t.Fatalf("partial identity hidden: %s", got)
+		}
+	}
+}

--- a/cli/cmd/runtime_identity.go
+++ b/cli/cmd/runtime_identity.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"cli.eigenflux.ai/internal/client"
+	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/profilestate"
+)
+
+const runtimeHostKey = "runtime_host"
+const runtimeModeKey = "runtime_mode"
+
+func runtimeProduct(host string) string {
+	return strings.SplitN(host, "/", 2)[0]
+}
+
+func normalizedRuntimeHost(host string) (string, error) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || host == "terminal" {
+		return "", nil
+	}
+	parts := strings.SplitN(host, "/", 2)
+	version := ""
+	if len(parts) == 2 {
+		version = parts[1]
+		if version == "" {
+			return "", fmt.Errorf("runtime host version must not be empty after '/'")
+		}
+	}
+	return reportedRuntimeHost(parts[0], version)
+}
+
+// Resolve per server. Process evidence takes precedence; an unrecognized shell
+// inherits the installation identity established during setup. Mode never comes
+// from the host name, channel, model, MCP availability, or a server response.
+func resolveRuntimeMeta(saved profilestate.RuntimeState, meta client.Meta) (client.Meta, error) {
+	host, err := normalizedRuntimeHost(meta.Host)
+	if err != nil {
+		return meta, fmt.Errorf("invalid runtime host: %w", err)
+	}
+	mode := strings.TrimSpace(meta.Mode)
+	if mode != "" && mode != "plugin" && mode != "skill" {
+		return meta, fmt.Errorf("runtime mode must be plugin or skill")
+	}
+	savedHost, err := normalizedRuntimeHost(saved.Host)
+	if err != nil {
+		savedHost = ""
+	}
+	if host == "" {
+		host = savedHost
+	} else if !meta.HostExplicit && host == runtimeProduct(savedHost) {
+		// A process marker may reveal the product without exposing its version.
+		host = savedHost
+	}
+	if mode == "" && (savedHost == "" || runtimeProduct(host) == runtimeProduct(savedHost)) {
+		mode = saved.Mode
+		if mode != "plugin" && mode != "skill" {
+			mode = ""
+		}
+	}
+	meta.Host, meta.Mode, meta.CLIVersion = host, mode, version
+	return meta, nil
+}
+
+func clientMetaForServer(server *config.Server) client.Meta {
+	saved, loadErr := profilestate.LoadRuntime(config.HomeDir(), server.Name)
+	meta, err := resolveRuntimeMeta(saved, clientMeta)
+	if err != nil || loadErr != nil {
+		// Ordinary operations remain available with malformed optional metadata.
+		meta = clientMeta
+		meta.Host, meta.Mode = "", ""
+	}
+	return meta
+}
+
+func clientMetaForServerName(serverName string) client.Meta {
+	if cfg, err := config.Load(); err == nil {
+		if server, err := cfg.GetActive(serverName); err == nil {
+			return clientMetaForServer(server)
+		}
+	}
+	return client.Meta{CLIVersion: version}
+}
+
+// Explicit setup/settings values become durable installation intent even when
+// the network is unavailable. Only successful HTTP reports update report stamps.
+func configureRuntimeIdentity(cfg *config.Config, serverName, mode, name, runtimeVersion string) (client.Meta, error) {
+	meta, _, err := configureRuntimeReportIdentity(cfg, serverName, mode, name, runtimeVersion)
+	return meta, err
+}
+
+func configureRuntimeReportIdentity(cfg *config.Config, serverName, mode, name, runtimeVersion string) (client.Meta, profilestate.RuntimeState, error) {
+	if mode != "" && mode != "plugin" && mode != "skill" {
+		return client.Meta{}, profilestate.RuntimeState{}, fmt.Errorf("--mode must be plugin or skill")
+	}
+	host, err := reportedRuntimeHost(name, runtimeVersion)
+	if err != nil {
+		return client.Meta{}, profilestate.RuntimeState{}, err
+	}
+	server, err := cfg.GetActive(serverName)
+	if err != nil {
+		return client.Meta{}, profilestate.RuntimeState{}, err
+	}
+	base := clientMeta
+	if host != "" {
+		base.Host = host
+	}
+	if mode != "" {
+		base.Mode = mode
+	}
+	var meta client.Meta
+	state, err := profilestate.UpdateRuntime(config.HomeDir(), server.Name, func(saved *profilestate.RuntimeState) (bool, error) {
+		var err error
+		meta, err = resolveRuntimeMeta(*saved, base)
+		if err != nil {
+			return false, err
+		}
+		if host != "" {
+			// An explicit bare --runtime-name intentionally clears a previous version.
+			meta.Host = host
+		}
+		if saved.Host == meta.Host && saved.Mode == meta.Mode {
+			return false, nil
+		}
+		saved.Host, saved.Mode = meta.Host, meta.Mode
+		saved.Revision++
+		return true, nil
+	})
+	return meta, state, err
+}

--- a/cli/cmd/runtime_identity_test.go
+++ b/cli/cmd/runtime_identity_test.go
@@ -247,8 +247,16 @@ func TestRuntimeIdentityIsServerScoped(t *testing.T) {
 }
 
 func TestFeedBothTransportsReportWithoutMemoryAndSurviveReportFailure(t *testing.T) {
-	for _, v2 := range []bool{false, true} {
-		t.Run(strconv.FormatBool(v2), func(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		v2     bool
+		action string
+	}{
+		{"v1-refresh", false, "refresh"},
+		{"v2-refresh", true, "refresh"},
+		{"v2-more", true, "more"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			reports, syncs := 0, 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
@@ -270,9 +278,16 @@ func TestFeedBothTransportsReportWithoutMemoryAndSurviveReportFailure(t *testing
 				}
 			}))
 			defer server.Close()
-			cfg, serverName := runtimeTestConfig(t, server.URL, v2)
+			cfg, serverName := runtimeTestConfig(t, server.URL, tc.v2)
 			if _, err := configureRuntimeIdentity(cfg, serverName, "skill", "hermes", "0.17.0"); err != nil {
 				t.Fatal(err)
+			}
+			for flag, value := range map[string]string{"action": tc.action, "cursor": ""} {
+				oldValue := feedPollCmd.Flags().Lookup(flag).Value.String()
+				if err := feedPollCmd.Flags().Set(flag, value); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = feedPollCmd.Flags().Set(flag, oldValue) })
 			}
 			oldFormat := formatFlag
 			formatFlag = "json"

--- a/cli/cmd/runtime_identity_test.go
+++ b/cli/cmd/runtime_identity_test.go
@@ -1,0 +1,412 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/client"
+	"cli.eigenflux.ai/internal/config"
+	"cli.eigenflux.ai/internal/profilestate"
+)
+
+func TestRuntimeMetaUsesEvidenceWithoutInferringMode(t *testing.T) {
+	server := profilestate.RuntimeState{Host: "openclaw/2026.9.1", Mode: "plugin"}
+	for _, tc := range []struct {
+		name       string
+		base       client.Meta
+		host, mode string
+	}{
+		{"shell inherits installation", client.Meta{Host: "terminal"}, "openclaw/2026.9.1", "plugin"},
+		{"same product retains version", client.Meta{Host: "openclaw"}, "openclaw/2026.9.1", "plugin"},
+		{"explicit bare product clears cached version", client.Meta{Host: "openclaw", HostExplicit: true}, "openclaw", "plugin"},
+		{"new product discards old mode", client.Meta{Host: "workbuddy/5.5.4", Channel: "plugin"}, "workbuddy/5.5.4", ""},
+		{"native task overrides plugin", client.Meta{Host: "openclaw", Mode: "skill"}, "openclaw/2026.9.1", "skill"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveRuntimeMeta(server, tc.base)
+			if err != nil || got.Host != tc.host || got.Mode != tc.mode {
+				t.Fatalf("meta=%+v err=%v", got, err)
+			}
+		})
+	}
+	for _, host := range []string{"codex", "claude-code", "openclaw"} {
+		got, err := resolveRuntimeMeta(profilestate.RuntimeState{}, client.Meta{Host: host, Channel: host})
+		if err != nil || got.Mode != "" {
+			t.Fatalf("product/channel inferred mode: %+v %v", got, err)
+		}
+	}
+}
+
+func runtimeTestConfig(t *testing.T, endpoint string, v2 bool) (*config.Config, string) {
+	t.Helper()
+	tempHome(t)
+	oldMeta, oldVersion, oldServer := clientMeta, version, serverFlag
+	clientMeta, version, serverFlag = client.Meta{Host: "terminal", Channel: "cli"}, "0.0.44", ""
+	t.Cleanup(func() { clientMeta, version, serverFlag = oldMeta, oldVersion, oldServer })
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := cfg.GetActive("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.UpdateServer(server.Name, endpoint, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SetKV(autoSkillSyncKey, "false"); err != nil {
+		t.Fatal(err)
+	}
+	if v2 {
+		err = auth.SaveV2Credentials(server.Name, &auth.V2Credentials{AgentID: "agent-1", AccessToken: "test-v2", RefreshToken: "test-refresh", ExpiresAt: time.Now().Add(time.Hour).UnixMilli()})
+	} else {
+		err = auth.SaveCredentials(server.Name, &auth.Credentials{AgentID: "agent-1", AccessToken: "test-v1"})
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg, server.Name
+}
+
+func TestRuntimeReportPersistsAcrossRequestsAndRetries(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		t.Run(strconv.FormatBool(v2), func(t *testing.T) {
+			puts, failure := 0, false
+			var lastHost, lastMode string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				lastHost, lastMode = r.Header.Get("X-Client-Host"), r.Header.Get("X-Client-Mode")
+				if r.Method == http.MethodPut {
+					puts++
+				}
+				if failure {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(`{"code":1,"msg":"retry later"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+			}))
+			defer server.Close()
+			cfg, serverName := runtimeTestConfig(t, server.URL, v2)
+			result, err := reportRuntimeSettings(cfg, "skill", "", "hermes", "0.17.0", false)
+			if err != nil || result.Status != "reported" || puts != 1 {
+				t.Fatalf("initial=%+v err=%v puts=%d", result, err, puts)
+			}
+			// Reload the saved Home and create a fresh HTTP client, as a later CLI process does.
+			cfg, _ = config.Load()
+			c, err := newSettingsClient(cfg, serverName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := c.Get("/probe", nil); err != nil {
+				t.Fatal(err)
+			}
+			if lastHost != "hermes/0.17.0" || lastMode != "skill" {
+				t.Fatalf("later headers host=%q mode=%q", lastHost, lastMode)
+			}
+			result, err = reportRuntimeSettings(cfg, "", "", "", "", false)
+			if err != nil || result.Status != "unchanged" || puts != 1 {
+				t.Fatalf("dedup=%+v err=%v puts=%d", result, err, puts)
+			}
+			if _, err := profilestate.UpdateRuntime(config.HomeDir(), serverName, func(state *profilestate.RuntimeState) (bool, error) {
+				state.ReportedAtMillis = time.Now().Add(-25 * time.Hour).UnixMilli()
+				return true, nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			result, err = reportRuntimeSettings(cfg, "", "", "", "", false)
+			if err != nil || result.Status != "reported" || puts != 2 {
+				t.Fatalf("daily=%+v err=%v puts=%d", result, err, puts)
+			}
+			version = "0.0.45"
+			result, err = reportRuntimeSettings(cfg, "", "", "", "", false)
+			if err != nil || result.Status != "reported" || puts != 3 {
+				t.Fatalf("upgrade=%+v err=%v puts=%d", result, err, puts)
+			}
+			before := loadRuntimeTestState(t, serverName)
+			stamp, snapshot := before.ReportedAtMillis, before.ReportedSnapshot
+			failure = true
+			result, err = reportRuntimeSettings(cfg, "skill", "", "workbuddy", "5.5.4", false)
+			if err == nil || result.Status != "failed" || result.Error == "" {
+				t.Fatalf("failure=%+v err=%v", result, err)
+			}
+			cfg, _ = config.Load()
+			if got := loadRuntimeTestState(t, serverName).ReportedAtMillis; got != stamp {
+				t.Fatal("failed report changed successful timestamp")
+			}
+			if got := loadRuntimeTestState(t, serverName).ReportedSnapshot; got != snapshot {
+				t.Fatal("failed report changed successful snapshot")
+			}
+			failure = false
+			result, err = reportRuntimeSettings(cfg, "", "", "", "", false)
+			if err != nil || result.Status != "reported" || lastHost != "workbuddy/5.5.4" {
+				t.Fatalf("retry=%+v err=%v host=%q", result, err, lastHost)
+			}
+			result, err = reportRuntimeSettings(cfg, "", "", "workbuddy", "", false)
+			if err != nil || result.Status != "reported" || lastHost != "workbuddy" {
+				t.Fatalf("explicit clear=%+v err=%v host=%q", result, err, lastHost)
+			}
+		})
+	}
+}
+
+func TestRuntimeReportUnknownAndInvalidNeverInventIdentity(t *testing.T) {
+	for _, name := range []string{"terminal", "plugin", "skill", "skills", "cli", "cli-direct", "unknown"} {
+		if _, err := reportedRuntimeHost(name, ""); err == nil {
+			t.Fatalf("accepted mode/sentinel as product: %s", name)
+		}
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+	}))
+	defer server.Close()
+	cfg, _ := runtimeTestConfig(t, server.URL, true)
+	result, err := reportRuntimeSettings(cfg, "", "", "", "", false)
+	if err != nil || result.Status != "missing" || requests != 0 {
+		t.Fatalf("unknown=%+v err=%v requests=%d", result, err, requests)
+	}
+	for _, params := range [][3]string{{"plugins", "hermes", ""}, {"skill", "terminal", ""}, {"skill", "", "0.17"}} {
+		result, err = reportRuntimeSettings(cfg, params[0], "", params[1], params[2], false)
+		if err == nil || result.Status != "failed" || requests != 0 {
+			t.Fatalf("invalid=%+v err=%v requests=%d", result, err, requests)
+		}
+	}
+}
+
+func TestRuntimeReportAccountAndTransportChangesBypassCache(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+	}))
+	defer server.Close()
+	cfg, serverName := runtimeTestConfig(t, server.URL, false)
+	if result, err := reportRuntimeSettings(cfg, "skill", "", "codex", "", false); err != nil || result.Status != "reported" {
+		t.Fatalf("initial=%+v %v", result, err)
+	}
+	credentials := &auth.V2Credentials{AgentID: "agent-1", AccessToken: "test-v2", RefreshToken: "test-refresh", ExpiresAt: time.Now().Add(time.Hour).UnixMilli()}
+	if err := auth.SaveV2Credentials(serverName, credentials); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := reportRuntimeSettings(cfg, "", "", "", "", false); err != nil || result.Status != "reported" {
+		t.Fatalf("transport=%+v %v", result, err)
+	}
+	credentials.AgentID = "agent-2"
+	if err := auth.SaveV2Credentials(serverName, credentials); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := reportRuntimeSettings(cfg, "", "", "", "", false); err != nil || result.Status != "reported" {
+		t.Fatalf("account=%+v %v", result, err)
+	}
+	if len(paths) != 3 || paths[0] != "/api/v1/agents/me/settings" || paths[1] != "/api/v2/agents/me/settings" {
+		t.Fatalf("requests=%v", paths)
+	}
+}
+
+func TestHeartbeatPlanReportsBeforeSkillsFailure(t *testing.T) {
+	reports := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && r.URL.Path == "/api/v2/agents/me/settings" {
+			reports++
+			_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	cfg, serverName := runtimeTestConfig(t, server.URL, true)
+	if _, err := configureRuntimeIdentity(cfg, serverName, "skill", "hermes", "0.17.0"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EIGENFLUX_SKILLS_DIR", t.TempDir())
+	t.Setenv("EIGENFLUX_CDN_URL", server.URL)
+	if err := heartbeatPlanCmd.RunE(heartbeatPlanCmd, nil); err == nil {
+		t.Fatal("expected unavailable Skills error")
+	}
+	if reports != 1 {
+		t.Fatalf("heartbeat report calls=%d", reports)
+	}
+}
+
+func TestRuntimeIdentityIsServerScoped(t *testing.T) {
+	cfg, serverName := runtimeTestConfig(t, "http://127.0.0.1:1", false)
+	if _, err := configureRuntimeIdentity(cfg, serverName, "skill", "hermes", "0.17.0"); err != nil {
+		t.Fatal(err)
+	}
+	other := &config.Server{Name: "other"}
+	if meta := clientMetaForServer(other); meta.Host != "" || meta.Mode != "" {
+		t.Fatalf("identity leaked across servers: %+v", meta)
+	}
+}
+
+func TestFeedBothTransportsReportWithoutMemoryAndSurviveReportFailure(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		t.Run(strconv.FormatBool(v2), func(t *testing.T) {
+			reports, syncs := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/agent-context"):
+					w.WriteHeader(http.StatusConflict)
+					_, _ = w.Write([]byte(`{"error":{"code":"ONBOARDING_REQUIRED","message":"baseline"}}`))
+				case strings.HasSuffix(r.URL.Path, "/agents/me/settings") && r.Method == http.MethodPut:
+					reports++
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(`{"code":1,"msg":"metadata unavailable"}`))
+				case strings.HasSuffix(r.URL.Path, "/agents/me/settings"):
+					syncs++
+					_, _ = w.Write([]byte(`{"code":0,"data":{"feed_poll_interval":7200}}`))
+				case strings.HasSuffix(r.URL.Path, "/feed"):
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "data": map[string]interface{}{"schema_version": "feed.v2", "personalization": map[string]interface{}{"mode": "baseline"}, "items": []interface{}{}}})
+				default:
+					_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+				}
+			}))
+			defer server.Close()
+			cfg, serverName := runtimeTestConfig(t, server.URL, v2)
+			if _, err := configureRuntimeIdentity(cfg, serverName, "skill", "hermes", "0.17.0"); err != nil {
+				t.Fatal(err)
+			}
+			oldFormat := formatFlag
+			formatFlag = "json"
+			t.Cleanup(func() { formatFlag = oldFormat })
+			if err := feedPollCmd.RunE(feedPollCmd, nil); err != nil {
+				t.Fatalf("successful feed blocked by metadata: %v", err)
+			}
+			if reports != 1 || syncs != 1 {
+				t.Fatalf("reports=%d syncs=%d", reports, syncs)
+			}
+			cfg, _ = config.Load()
+			if got := loadRuntimeTestState(t, serverName).ReportedAtMillis; got != 0 {
+				t.Fatal("failed metadata got success stamp")
+			}
+		})
+	}
+}
+
+func TestRuntimeReportPreservesRemotePreferences(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		for _, local := range []string{"", "stale local preference"} {
+			t.Run(strconv.FormatBool(v2)+local, func(t *testing.T) {
+				remote := "owner changed preference in Console"
+				requests := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodPut {
+						requests++
+						var body map[string]interface{}
+						if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+							t.Error(err)
+						}
+						if pref, exists := body["feed_delivery_preference"]; exists {
+							remote, _ = pref.(string)
+							t.Error("runtime observation must omit shared preferences")
+						}
+						_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+					} else {
+						_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "data": map[string]interface{}{"feed_delivery_preference": remote}})
+					}
+				}))
+				defer server.Close()
+				cfg, _ := runtimeTestConfig(t, server.URL, v2)
+				if err := cfg.SetKV(settingsSyncedKey, "1"); err != nil {
+					t.Fatal(err)
+				}
+				if err := cfg.SetKV("feed_delivery_preference", local); err != nil {
+					t.Fatal(err)
+				}
+				result, err := reportRuntimeSettings(cfg, "skill", "", "codex", "", false)
+				if err != nil || result.Status != "reported" {
+					t.Fatalf("result=%+v err=%v", result, err)
+				}
+				if err := SyncSettings(cfg); err != nil {
+					t.Fatal(err)
+				}
+				if requests != 1 || remote != "owner changed preference in Console" || cfg.GetKV("feed_delivery_preference") != remote {
+					t.Fatalf("requests=%d remote=%q local=%q", requests, remote, cfg.GetKV("feed_delivery_preference"))
+				}
+			})
+		}
+	}
+}
+
+func loadRuntimeTestState(t *testing.T, serverName string) profilestate.RuntimeState {
+	t.Helper()
+	state, err := profilestate.LoadRuntime(config.HomeDir(), serverName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func TestRuntimeReportExplicitEnvironmentClearsCachedPluginVersion(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		t.Run(strconv.FormatBool(v2), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("X-Client-Host"); got != "openclaw" {
+					t.Errorf("host=%q, want bare product", got)
+				}
+				if got := r.Header.Get("X-Client-Plugin-Version"); got != "0.2.1" {
+					t.Errorf("plugin version=%q", got)
+				}
+				_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+			}))
+			defer server.Close()
+			cfg, serverName := runtimeTestConfig(t, server.URL, v2)
+			if _, err := configureRuntimeIdentity(cfg, serverName, "plugin", "openclaw", "0.1.0"); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("EIGENFLUX_HOST", "openclaw")
+			t.Setenv("EIGENFLUX_MODE", "plugin")
+			t.Setenv("EIGENFLUX_PLUGIN_VERSION", "0.2.1")
+			clientMeta = client.ResolveMeta()
+			result, err := reportRuntimeSettings(cfg, "", "", "", "", false)
+			if err != nil || result.Status != "reported" {
+				t.Fatalf("report=%+v err=%v", result, err)
+			}
+			if saved := loadRuntimeTestState(t, serverName); saved.Host != "openclaw" {
+				t.Fatalf("saved host retained plugin version: %+v", saved)
+			}
+		})
+	}
+}
+
+func TestV1SettingsSuccessRefreshesCredentialExpiry(t *testing.T) {
+	for _, operation := range []string{"report", "sync"} {
+		t.Run(operation, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"code":0,"data":{}}`))
+			}))
+			defer server.Close()
+			cfg, serverName := runtimeTestConfig(t, server.URL, false)
+			creds, err := auth.LoadCredentials(serverName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			creds.ExpiresAt = time.Now().Add(time.Hour).UnixMilli()
+			if err := auth.SaveCredentials(serverName, creds); err != nil {
+				t.Fatal(err)
+			}
+			if operation == "report" {
+				if _, err := reportRuntimeSettings(cfg, "skill", "", "codex", "", false); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := SyncSettings(cfg); err != nil {
+				t.Fatal(err)
+			}
+			refreshed, err := auth.LoadCredentials(serverName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if refreshed.ExpiresAt < time.Now().Add(29*24*time.Hour).UnixMilli() {
+				t.Fatalf("settings did not extend V1 session: before=%d after=%d", creds.ExpiresAt, refreshed.ExpiresAt)
+			}
+		})
+	}
+}

--- a/cli/cmd/settings.go
+++ b/cli/cmd/settings.go
@@ -5,17 +5,30 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/client"
 	"cli.eigenflux.ai/internal/config"
 	"cli.eigenflux.ai/internal/output"
+	"cli.eigenflux.ai/internal/profilestate"
 
 	"github.com/spf13/cobra"
 )
 
-// settingsReportedKey stores the last snapshot successfully pushed to the
-// backend, so `settings push` can be a no-op when nothing changed.
+// Legacy config cache keys remain reserved. Runtime identity and report stamps
+// now live in the locked runtime sidecar, independently of config.json writers.
 const settingsReportedKey = "_settings_reported"
+const settingsReportedAtKey = "_settings_reported_at"
+const settingsReportedClientKey = "_settings_reported_client"
+const settingsReportInterval = 24 * time.Hour
+
+type runtimeReportResult struct {
+	Status  string   `json:"status"`
+	Missing []string `json:"missing,omitempty"`
+	Error   string   `json:"error,omitempty"`
+}
 
 // settingsSyncedKey marks that at least one reconcile with the backend has
 // happened. Before that, existing local values initialize the backend instead
@@ -141,7 +154,10 @@ func syncedSettingsBody(cfg *config.Config) map[string]interface{} {
 // after every `feed poll`, so console edits reach the agent within one poll
 // interval.
 func SyncSettings(cfg *config.Config) error {
-	c := newClient()
+	c, err := newSettingsClient(cfg, activeServerName())
+	if err != nil {
+		return err
+	}
 	pendingLocal := cfg.GetKV(settingsDirtyKey) != "" ||
 		(cfg.GetKV(settingsSyncedKey) == "" && len(syncedSettingsBody(cfg)) > 0)
 	if pendingLocal {
@@ -186,6 +202,8 @@ func SyncSettings(cfg *config.Config) error {
 	// compromised backend could disable updates or overflow the throttle.
 	skip := map[string]bool{
 		"mode": true, "updated_at": true,
+		runtimeHostKey: true, runtimeModeKey: true,
+		"runtime_name": true, "runtime_version": true, "runtime_reported_at": true,
 		autoSkillSyncKey: true, skillSyncIntervalKey: true,
 		// Profile-refresh bookkeeping is client-local for the same reason: a
 		// backend-supplied stamp could silence the prompt forever (future
@@ -194,7 +212,7 @@ func SyncSettings(cfg *config.Config) error {
 	}
 	changed := false
 	for k, v := range remote {
-		if skip[k] {
+		if skip[k] || strings.HasPrefix(k, "_") {
 			continue
 		}
 		switch val := v.(type) {
@@ -215,69 +233,144 @@ func SyncSettings(cfg *config.Config) error {
 	return nil
 }
 
+func newSettingsClient(cfg *config.Config, serverName string) (*client.Client, error) {
+	server, err := cfg.GetActive(serverName)
+	if err != nil {
+		return nil, err
+	}
+	hasV2, err := auth.HasV2Credentials(serverName)
+	if err != nil {
+		return nil, err
+	}
+	if hasV2 {
+		c, _, err := newV2ClientForServer(serverName, true)
+		return c, err
+	}
+	credentials, err := auth.LoadCredentials(serverName)
+	if err != nil {
+		return nil, err
+	}
+	if credentials.IsExpired() {
+		return nil, fmt.Errorf("credentials expired for server %q", serverName)
+	}
+	c := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v1", credentials.AccessToken, version, clientMetaForServer(server))
+	c.OnSuccess = sync.OnceFunc(func() { auth.RefreshExpiry(serverName) })
+	return c, nil
+}
+
 // pushReported sends agent-reported fields to the backend, skipping the
 // request when nothing changed since the last successful push. Product
 // identity is independent from mode and travels through X-Client-Host, the
 // existing server-side runtime identity contract.
 func pushReported(cfg *config.Config, mode, model, runtimeName, runtimeVersion string, force bool) error {
-	feedPref := cfg.GetKV("feed_delivery_preference")
+	result, err := reportRuntimeSettings(cfg, mode, model, runtimeName, runtimeVersion, force)
+	if err != nil {
+		output.PrintMessage("settings failed")
+		return err
+	}
+	output.PrintMessage("settings %s", result.Status)
+	if len(result.Missing) > 0 {
+		output.PrintMessage("runtime identity missing: %s", strings.Join(result.Missing, ", "))
+	}
+	return nil
+}
+
+func reportRuntimeSettings(cfg *config.Config, mode, model, runtimeName, runtimeVersion string, force bool) (result runtimeReportResult, err error) {
+	result.Status = "failed"
+	defer func() {
+		if err != nil {
+			result.Error = err.Error()
+		}
+	}()
 	serverName := activeServerName()
 	if serverName == "" {
-		return fmt.Errorf("no active server")
+		return result, fmt.Errorf("no active server")
 	}
-	runtimeHost, err := reportedRuntimeHost(runtimeName, runtimeVersion)
+	meta, state, err := configureRuntimeReportIdentity(cfg, serverName, mode, runtimeName, runtimeVersion)
 	if err != nil {
-		return err
+		return result, err
 	}
-	if runtimeHost == "" {
-		runtimeHost = clientMeta.Host
+	if model != "" {
+		meta.Model = model
 	}
-
-	// Canonical snapshot of the agent-reported fields. \x1f (unit separator)
-	// cannot appear in these values, so it is a safe delimiter.
+	if meta.Host == "" {
+		result.Missing = append(result.Missing, "runtime_name")
+	}
+	if meta.Mode == "" {
+		result.Missing = append(result.Missing, "mode")
+	}
 	agentID := settingsAgentID(serverName)
 	if agentID == "" {
-		return fmt.Errorf("no authenticated account for server %q", serverName)
+		result.Status = "missing"
+		result.Missing = append(result.Missing, "authenticated_account")
+		return result, nil
 	}
-	snapshot := reportedSettingsSnapshot(agentID, mode, feedPref, model, runtimeHost)
-	lastSnapshot, _, _ := cfg.GetServerOnlyKV(serverName, settingsReportedKey)
-	if !force && snapshot == lastSnapshot {
-		output.PrintMessage("settings unchanged; nothing to report")
-		return nil
+	if meta.Host == "" && meta.Mode == "" && meta.Model == "" {
+		result.Status = "missing"
+		return result, nil
+	}
+	server, err := cfg.GetActive(serverName)
+	if err != nil {
+		return result, err
+	}
+	hasV2, err := auth.HasV2Credentials(serverName)
+	if err != nil {
+		return result, err
+	}
+	apiFamily := "/api/v1"
+	if hasV2 {
+		apiFamily = "/api/v2"
+	}
+	clientSnapshot := strings.Join([]string{version, strings.TrimRight(server.Endpoint, "/") + apiFamily, meta.PluginVersion}, "\x1f")
+	snapshot := reportedSettingsSnapshot(agentID, meta.Mode, "", meta.Model, meta.Host)
+	lastSnapshot, lastClient, reportedAt := state.ReportedSnapshot, state.ReportedClient, state.ReportedAtMillis
+	ago := time.Now().UnixMilli() - reportedAt
+	if !force && snapshot == lastSnapshot && clientSnapshot == lastClient && reportedAt > 0 && ago >= 0 && ago < settingsReportInterval.Milliseconds() {
+		result.Status = "unchanged"
+		return result, nil
 	}
 
-	body := map[string]interface{}{
-		"feed_delivery_preference": feedPref,
-	}
-	if mode != "" {
-		body["mode"] = mode
+	// Runtime observations must not write cached shared settings before SyncSettings
+	// reconciles remote changes. Preferences remain on the existing sync path.
+	body := map[string]interface{}{}
+	if meta.Mode != "" {
+		body["mode"] = meta.Mode
 	}
 
-	c := newClientForServer(serverName)
-	// model is carried as a header (X-Client-Model) so the server stores it
-	// alongside the derived runtime, consistent with X-Client-Host.
-	headers := map[string]string{}
-	if model != "" {
-		headers["X-Client-Model"] = model
+	// This path must return errors, never output.Die: automatic metadata
+	// reporting cannot terminate a successful Feed or heartbeat operation.
+	c, err := newSettingsClient(cfg, serverName)
+	if err != nil {
+		return result, err
 	}
-	if runtimeName != "" {
-		headers["X-Client-Host"] = runtimeHost
-	}
+	c.Meta = meta
+	headers := map[string]string{"X-Client-Host": meta.Host, "X-Client-Mode": meta.Mode, "X-Client-Model": meta.Model}
 	resp, err := c.PutWithHeaders("/agents/me/settings", body, headers)
 	if err != nil {
-		return err
+		return result, err
 	}
 	if resp.Code != 0 {
-		return fmt.Errorf("%s", resp.Msg)
+		return result, fmt.Errorf("%s", resp.Msg)
 	}
 
 	// Persist the snapshot only after a successful push, so a failed attempt
 	// is retried on the next call.
-	if err := cfg.SetServerKV(serverName, settingsReportedKey, snapshot); err != nil {
-		return err
+	_, err = profilestate.UpdateRuntime(config.HomeDir(), serverName, func(current *profilestate.RuntimeState) (bool, error) {
+		// An older in-flight report cannot replace a newer installation intent
+		// or its successful report cache, including a change away and back.
+		if current.Revision != state.Revision {
+			return false, nil
+		}
+		current.ReportedSnapshot = snapshot
+		current.ReportedClient = clientSnapshot
+		current.ReportedAtMillis = time.Now().UnixMilli()
+		return true, nil
+	})
+	if err != nil {
+		return result, err
 	}
-	output.PrintMessage("settings reported")
-	return nil
+	result.Status = "reported"
+	return result, nil
 }
 
 func settingsAgentID(serverName string) string {
@@ -332,8 +425,12 @@ func reportedRuntimeHost(name, version string) (string, error) {
 		}
 		return "", nil
 	}
-	if name == "terminal" || !validRuntimeIdentityPart(name) {
-		return "", fmt.Errorf("--runtime-name must be 1-64 letters, digits, '.', '-' or '_', and cannot be terminal")
+	switch name {
+	case "terminal", "plugin", "skill", "skills", "cli", "cli-direct", "unknown":
+		return "", fmt.Errorf("--runtime-name must identify the Agent product, not an installation mode or unknown sentinel")
+	}
+	if !validRuntimeIdentityPart(name) {
+		return "", fmt.Errorf("--runtime-name must be 1-64 letters, digits, '.', '-' or '_'")
 	}
 	if version == "" {
 		return name, nil
@@ -360,14 +457,19 @@ var settingsCmd = &cobra.Command{
 
 var settingsPushCmd = &cobra.Command{
 	Use:   "push",
-	Short: "Report agent-side settings to the backend, only when changed",
-	Long: `Push agent-reported settings (mode, runtime product, model, feed_delivery_preference) to the backend
+	Short: "Persist runtime identity and report settings when changed or due daily",
+	Long: `Push agent-reported identity (mode, runtime product, model) to the backend
 via PUT /agents/me/settings.
 
-feed_delivery_preference is read from the config KV; mode, runtime identity, and model come from flags.
+Mode and runtime identity come from explicit flags, process metadata, or this
+Home's per-server runtime sidecar.
+Flags persist product and mode for later commands. Plugin versions belong in
+EIGENFLUX_PLUGIN_VERSION, installation mode in EIGENFLUX_MODE, and delivery
+channels in EIGENFLUX_CHANNEL.
 The combined snapshot is compared against the last successfully reported one
-(stored in the config KV under "_settings_reported") and a request is sent only
-when something changed. Safe to call on every heartbeat — it no-ops otherwise.
+(stored in the runtime sidecar) and a request is sent only
+when something changed, the CLI or endpoint changed, or 24 hours have elapsed.
+Only successful requests update the snapshot. Safe to call on every heartbeat.
 
 Examples:
   eigenflux settings push --mode plugin --model gpt-5.6

--- a/cli/cmd/settings_test.go
+++ b/cli/cmd/settings_test.go
@@ -289,8 +289,8 @@ func TestPushReportedSupportsV2OnlyCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := reportedSettingsSnapshot("v2-agent", "skill", "", "gpt-5.6", "workbuddy/5.3.14")
-	if got, ok, err := cfg.GetServerOnlyKV(active.Name, settingsReportedKey); err != nil || !ok || got != want {
-		t.Fatalf("cached snapshot = %q, %v, %v; want %q", got, ok, err, want)
+	if got := loadRuntimeTestState(t, active.Name).ReportedSnapshot; got != want {
+		t.Fatalf("cached snapshot = %q; want %q", got, want)
 	}
 }
 
@@ -346,7 +346,7 @@ func TestPushReportedSendsRuntimeToBoundServerAndCachesSuccess(t *testing.T) {
 	}
 	<-requestSeen
 	want := reportedSettingsSnapshot("42", "skill", "", "gpt-5.6", "hermes/0.20.0")
-	if got, ok, err := cfg.GetServerOnlyKV(active.Name, settingsReportedKey); err != nil || !ok || got != want {
-		t.Fatalf("cached snapshot = %q, %v, %v; want %q", got, ok, err, want)
+	if got := loadRuntimeTestState(t, active.Name).ReportedSnapshot; got != want {
+		t.Fatalf("cached snapshot = %q; want %q", got, want)
 	}
 }

--- a/cli/cmd/v2_helpers.go
+++ b/cli/cmd/v2_helpers.go
@@ -43,7 +43,7 @@ func newV2ClientForServer(serverName string, requireAuth bool) (*client.Client, 
 		}
 		token = credentials.AccessToken
 	}
-	result := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", token, version, clientMeta)
+	result := client.New(strings.TrimRight(server.Endpoint, "/")+"/api/v2", token, version, clientMetaForServer(server))
 	if requireAuth {
 		result.OnUnauthorized = func() (string, error) {
 			refreshed, refreshErr := refreshV2Credentials(server.Name, server.Endpoint, true)
@@ -82,7 +82,7 @@ func ensureV2CredentialsUnlocked(serverName, endpoint string, force bool) (*auth
 	if err != nil {
 		return nil, err
 	}
-	unauthenticated := client.New(strings.TrimRight(endpoint, "/")+"/api/v2", "", version, clientMeta)
+	unauthenticated := client.New(strings.TrimRight(endpoint, "/")+"/api/v2", "", version, clientMetaForServerName(serverName))
 	challengeResponse, err := unauthenticated.Post("/agent-sessions/refresh-challenges", map[string]interface{}{
 		"refresh_token": credentials.RefreshToken, "rotation_request_id": refreshRotationRequestID(credentials.RefreshToken),
 	})

--- a/cli/internal/client/meta.go
+++ b/cli/internal/client/meta.go
@@ -15,15 +15,18 @@ import (
 
 // Meta holds client environment metadata sent as HTTP headers on every request.
 type Meta struct {
-	OS         string // e.g. "darwin/arm64"
-	TZ         string // e.g. "Asia/Shanghai"
-	Lang       string // e.g. "zh-CN"
-	Host       string // e.g. "openclaw/0.0.10", "claude-code/0.0.5", "terminal"
-	DeviceName string // user-visible computer name, e.g. "Lynn-MacBook-Pro"
-	Model      string // e.g. "claude-opus-4-8" (the model the host agent runs as)
-	Channel    string // e.g. "feishu", "cli", "telegram"
-	ClientID   string // e.g. "a1b2c3d4"
-	CLIVersion string // e.g. "0.0.16" — enables backend to know which skills bundle the client carries
+	OS            string // e.g. "darwin/arm64"
+	TZ            string // e.g. "Asia/Shanghai"
+	Lang          string // e.g. "zh-CN"
+	Host          string // e.g. "openclaw/0.0.10", "claude-code/0.0.5", "terminal"
+	HostExplicit  bool   // EIGENFLUX_HOST supplied the complete product identity
+	Mode          string // explicitly configured installation mode: plugin or skill
+	PluginVersion string // plugin package version, independent of the host product
+	DeviceName    string // user-visible computer name, e.g. "Lynn-MacBook-Pro"
+	Model         string // e.g. "claude-opus-4-8" (the model the host agent runs as)
+	Channel       string // e.g. "feishu", "cli", "telegram"
+	ClientID      string // e.g. "a1b2c3d4"
+	CLIVersion    string // e.g. "0.0.16" — enables backend to know which skills bundle the client carries
 }
 
 // SetHeaders writes all non-empty Meta fields to the given http.Header.
@@ -39,6 +42,12 @@ func (m Meta) SetHeaders(h http.Header) {
 	}
 	if m.Host != "" {
 		h.Set("X-Client-Host", m.Host)
+	}
+	if m.Mode == "plugin" || m.Mode == "skill" {
+		h.Set("X-Client-Mode", m.Mode)
+	}
+	if m.PluginVersion != "" {
+		h.Set("X-Client-Plugin-Version", m.PluginVersion)
 	}
 	if m.DeviceName != "" {
 		h.Set("X-Client-Device-Name", m.DeviceName)
@@ -60,14 +69,17 @@ func (m Meta) SetHeaders(h http.Header) {
 // ResolveMeta collects environment metadata from the current runtime.
 func ResolveMeta() Meta {
 	return Meta{
-		OS:         runtime.GOOS + "/" + runtime.GOARCH,
-		TZ:         resolveTimezone(),
-		Lang:       resolveLanguage(),
-		Host:       resolveRuntimeHost(),
-		DeviceName: resolveDeviceName(),
-		Model:      os.Getenv("EIGENFLUX_MODEL"),
-		Channel:    resolveEnvOrDefault("EIGENFLUX_CHANNEL", "cli"),
-		ClientID:   loadOrCreateClientID(),
+		OS:            runtime.GOOS + "/" + runtime.GOARCH,
+		TZ:            resolveTimezone(),
+		Lang:          resolveLanguage(),
+		Host:          resolveRuntimeHost(),
+		HostExplicit:  strings.TrimSpace(os.Getenv("EIGENFLUX_HOST")) != "",
+		Mode:          strings.TrimSpace(os.Getenv("EIGENFLUX_MODE")),
+		PluginVersion: strings.TrimSpace(os.Getenv("EIGENFLUX_PLUGIN_VERSION")),
+		DeviceName:    resolveDeviceName(),
+		Model:         os.Getenv("EIGENFLUX_MODEL"),
+		Channel:       resolveEnvOrDefault("EIGENFLUX_CHANNEL", "cli"),
+		ClientID:      loadOrCreateClientID(),
 	}
 }
 

--- a/cli/internal/client/meta_test.go
+++ b/cli/internal/client/meta_test.go
@@ -36,7 +36,14 @@ func TestResolveMetaWithEnv(t *testing.T) {
 	t.Setenv("EIGENFLUX_DEVICE_NAME", "Lynn-MacBook-Pro.local")
 	t.Setenv("EIGENFLUX_CHANNEL", "feishu")
 	t.Setenv("EIGENFLUX_MODEL", "claude-opus-4-8")
+	t.Setenv("EIGENFLUX_MODE", "skill")
+	t.Setenv("EIGENFLUX_PLUGIN_VERSION", "0.0.99")
 	m := ResolveMeta()
+	headers := http.Header{}
+	m.SetHeaders(headers)
+	if headers.Get("X-Client-Mode") != "skill" || headers.Get("X-Client-Plugin-Version") != "0.0.99" {
+		t.Fatalf("independent mode/plugin metadata missing: %v", headers)
+	}
 	if m.Host != "openclaw/0.0.10" {
 		t.Errorf("Host = %q, want %q", m.Host, "openclaw/0.0.10")
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -146,7 +146,11 @@ func TestHomeDir(t *testing.T) {
 	t.Setenv("EIGENFLUX_HOME", "")
 	os.Unsetenv("EIGENFLUX_HOME")
 	home = HomeDir()
-	expected := filepath.Join(os.Getenv("HOME"), ".eigenflux")
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(userHome, ".eigenflux")
 	if home != expected {
 		t.Errorf("HomeDir = %q, want %q", home, expected)
 	}

--- a/cli/internal/profilestate/runtime.go
+++ b/cli/internal/profilestate/runtime.go
@@ -1,0 +1,67 @@
+package profilestate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// RuntimeState stores installation identity and its report cache separately
+// from config.json, whose unrelated writers may hold an older config snapshot.
+// Identity is server-scoped; ReportedSnapshot also includes the account ID.
+type RuntimeState struct {
+	Host             string `json:"host"`
+	Mode             string `json:"mode"`
+	Revision         uint64 `json:"revision"`
+	ReportedSnapshot string `json:"reported_snapshot,omitempty"`
+	ReportedClient   string `json:"reported_client,omitempty"`
+	ReportedAtMillis int64  `json:"reported_at_millis,omitempty"`
+}
+
+func runtimeFilePath(homeDir, serverName string) string {
+	return filepath.Join(homeDir, "runtime-"+ScopeID(serverName, "")+".json")
+}
+
+func LoadRuntime(homeDir, serverName string) (RuntimeState, error) {
+	b, err := os.ReadFile(runtimeFilePath(homeDir, serverName))
+	if os.IsNotExist(err) {
+		return RuntimeState{}, nil
+	}
+	if err != nil {
+		return RuntimeState{}, err
+	}
+	var state RuntimeState
+	if err := json.Unmarshal(b, &state); err != nil {
+		return RuntimeState{}, fmt.Errorf("parse runtime state: %w", err)
+	}
+	return state, nil
+}
+
+// UpdateRuntime reuses the profile sidecar's process lock and atomic rename.
+// Callbacks execute only while locked; callers must keep network I/O outside.
+func UpdateRuntime(homeDir, serverName string, mutate func(*RuntimeState) (bool, error)) (RuntimeState, error) {
+	if err := os.MkdirAll(homeDir, 0o700); err != nil {
+		return RuntimeState{}, err
+	}
+	path := runtimeFilePath(homeDir, serverName)
+	lock, err := acquireLock(path + ".lock")
+	if err != nil {
+		return RuntimeState{}, err
+	}
+	defer lock.release()
+	state, err := LoadRuntime(homeDir, serverName)
+	if err != nil {
+		return RuntimeState{}, err
+	}
+	changed, err := mutate(&state)
+	if err != nil {
+		return RuntimeState{}, err
+	}
+	if changed {
+		if err := saveJSONFile(homeDir, path, state); err != nil {
+			return RuntimeState{}, err
+		}
+	}
+	return state, nil
+}

--- a/cli/internal/profilestate/runtime_test.go
+++ b/cli/internal/profilestate/runtime_test.go
@@ -1,0 +1,99 @@
+package profilestate
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRuntimeUpdateSerializesAcrossProcesses(t *testing.T) {
+	home := t.TempDir()
+	start := func(action string) <-chan error {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+		child := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRuntimeLockProcessHelper$")
+		child.Env = append(os.Environ(), "EIGENFLUX_RUNTIME_LOCK_ACTION="+action, "EIGENFLUX_RUNTIME_LOCK_HOME="+home)
+		done := make(chan error, 1)
+		go func() { done <- child.Run() }()
+		return done
+	}
+	release := filepath.Join(home, "release")
+	defer os.WriteFile(release, nil, 0o600)
+	first := start("hold")
+	waitForRuntimeFile(t, filepath.Join(home, "held"))
+	second := start("update")
+	waitForRuntimeFile(t, filepath.Join(home, "attempting"))
+	select {
+	case err := <-second:
+		t.Fatalf("second process bypassed held lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := os.WriteFile(release, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, done := range []<-chan error{first, second} {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("sidecar subprocess timed out")
+		}
+	}
+	got, err := LoadRuntime(home, "prod")
+	if err != nil || got.Revision != 2 {
+		t.Fatalf("concurrent updates lost: state=%+v err=%v", got, err)
+	}
+	if mode := fileMode(t, runtimeFilePath(home, "prod")); mode != 0o600 {
+		t.Fatalf("runtime file mode=%o", mode)
+	}
+	other, err := LoadRuntime(home, "other")
+	if err != nil || other != (RuntimeState{}) {
+		t.Fatalf("identity crossed server scope: %+v %v", other, err)
+	}
+}
+
+func TestRuntimeLockProcessHelper(t *testing.T) {
+	action, home := os.Getenv("EIGENFLUX_RUNTIME_LOCK_ACTION"), os.Getenv("EIGENFLUX_RUNTIME_LOCK_HOME")
+	if action == "" {
+		return
+	}
+	if action == "update" {
+		if err := os.WriteFile(filepath.Join(home, "attempting"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := UpdateRuntime(home, "prod", func(state *RuntimeState) (bool, error) {
+		if action == "hold" {
+			if err := os.WriteFile(filepath.Join(home, "held"), nil, 0o600); err != nil {
+				return false, err
+			}
+			waitForRuntimeFile(t, filepath.Join(home, "release"))
+		}
+		state.Revision++
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForRuntimeFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("barrier file did not arrive: %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/cli/internal/profilestate/runtime_test.go
+++ b/cli/internal/profilestate/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -48,7 +49,8 @@ func TestRuntimeUpdateSerializesAcrossProcesses(t *testing.T) {
 	if err != nil || got.Revision != 2 {
 		t.Fatalf("concurrent updates lost: state=%+v err=%v", got, err)
 	}
-	if mode := fileMode(t, runtimeFilePath(home, "prod")); mode != 0o600 {
+	// Windows reports synthesized mode bits; its file access uses inherited ACLs.
+	if mode := fileMode(t, runtimeFilePath(home, "prod")); runtime.GOOS != "windows" && mode != 0o600 {
 		t.Fatalf("runtime file mode=%o", mode)
 	}
 	other, err := LoadRuntime(home, "other")

--- a/cli/internal/profilestate/state.go
+++ b/cli/internal/profilestate/state.go
@@ -94,6 +94,10 @@ func Update(homeDir, serverName, agentID string, mutate func(*State) bool) (Stat
 }
 
 func saveUnlocked(homeDir, serverName, agentID string, state State) error {
+	return saveJSONFile(homeDir, FilePath(homeDir, serverName, agentID), state)
+}
+
+func saveJSONFile(homeDir, path string, state interface{}) error {
 	b, err := json.Marshal(state)
 	if err != nil {
 		return err
@@ -124,7 +128,7 @@ func saveUnlocked(homeDir, serverName, agentID string, state State) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	if err := replaceFile(tmpPath, FilePath(homeDir, serverName, agentID)); err != nil {
+	if err := replaceFile(tmpPath, path); err != nil {
 		_ = os.Remove(tmpPath)
 		return err
 	}

--- a/cli/internal/profilestate/state_test.go
+++ b/cli/internal/profilestate/state_test.go
@@ -105,11 +105,20 @@ func TestUpdateSerializesConcurrentMutations(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := Update(home, "prod", "101", func(state *State) bool {
-				state.LastPromptedUnix++
-				return true
-			})
-			errs <- err
+			// A bounded lock timeout is valid under heavy runner contention. Retry
+			// only that outcome; every successful mutation must still appear once.
+			// Timeout behavior itself is covered by TestLockContentionTimesOutAndRecovers.
+			deadline := time.Now().Add(15 * time.Second)
+			for {
+				_, err := Update(home, "prod", "101", func(state *State) bool {
+					state.LastPromptedUnix++
+					return true
+				})
+				if !errors.Is(err, errLockTimeout) || time.Now().After(deadline) {
+					errs <- err
+					break
+				}
+			}
 		}()
 	}
 	wg.Wait()

--- a/cli/internal/profilestate/state_test.go
+++ b/cli/internal/profilestate/state_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -24,7 +25,8 @@ func TestStateRoundTripAndScopeIsolation(t *testing.T) {
 	if got := Load(home, "staging", "101"); got != (State{}) {
 		t.Fatalf("another server inherited state: %+v", got)
 	}
-	if mode := fileMode(t, FilePath(home, "prod", "101")); mode != 0o600 {
+	// Windows reports synthesized mode bits; its file access uses inherited ACLs.
+	if mode := fileMode(t, FilePath(home, "prod", "101")); runtime.GOOS != "windows" && mode != 0o600 {
 		t.Fatalf("state mode = %o, want 600", mode)
 	}
 }

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -359,23 +359,31 @@ runtime leases, heartbeat routes, `runtime_state`, or `runtime_instance_id`.
 
 Agent Card schema v4 keeps the legacy `runtime` field and adds three additive, system-owned fields:
 
-- `runtime_mode`: integration mode (`plugin`, `skill`, or derived `cli-direct`).
+- `runtime_mode`: explicitly reported integration mode (`plugin` or `skill`); absent when unknown.
 - `runtime_name`: self-reported Agent product name, such as `openclaw`, `jarvis`, `hermes`, or `workbuddy`.
 - `runtime_version`: self-reported product version.
 
 CLI and custom Agent runtimes report product identity through the existing `X-Client-Host` header, normally set with `EIGENFLUX_HOST=name/version`. These values are descriptive and unverified. Existing clients that only consume the deprecated `runtime` continue to receive the same compatibility value; this does not make it a valid product identity source.
 `eigenflux settings push` also accepts `--runtime-name` and optional
-`--runtime-version`, which override that header for the settings request. The
-CLI derives `workbuddy[/version]` automatically from WorkBuddy process
+`--runtime-version`, which override that header and persist installation identity
+for later commands in the same Home/server. Runtime identity and report stamps
+use an atomically written, locked sidecar, separate from shared settings. Explicit
+bare host environment metadata clears a cached version; product-only automatic
+detection may retain the known version of that product. The CLI derives `workbuddy[/version]` automatically from WorkBuddy process
 metadata. `WORKBUDDY_APP_NAME` or `WORKBUDDY_PRODUCT_NAME` (and the legacy
 `CODEBUDDY_HOST=workbuddy...`) establish the product and pair only with
 `WORKBUDDY_APP_VERSION`; `CLIENT_INFO_PRODUCT_NAME=WorkBuddy` pairs only with
 `CLIENT_INFO_PRODUCT_VERSION`. `EIGENFLUX_HOST` has highest priority and
 remains the explicit override for other runtimes.
-Omitting runtime identity or model from a report means "no new observation"
-and does not clear the last known value. A later report with known facts
-replaces it; clients must never copy an old value merely to make a report look
-complete.
+`X-Client-Plugin-Version` carries the adapter package version separately; bounded values are recorded in runtime/settings diagnostic logs, never substituted for the product version.
+Product identity and mode are collected from authenticated Agent requests. `X-Client-Mode` accepts `plugin` or `skill`; a settings body `mode` takes precedence. Product, mode, model, and CLI version are independent facts. Invalid optional CLI versions (over 32 bytes or control characters) and model identifiers (over 128 bytes, invalid UTF-8, or control characters) are ignored independently, preserving other valid observations. Product parts retain their 64-byte bounds. Neither product names nor `X-Client-Channel` imply a mode. Unknown headers preserve known facts. Passive bare-product observations retain the known version of the same product; an explicit settings report with a bare product clears its version, including a previously misreported plugin version. Changing products without a version clears the former product's version.
+
+V1 Feed and V2 Feed, runtime heartbeat, compatibility reports, broadcast publishing, and private-message operations share the authenticated observation path. Provision and handoff persist identity and optional mode before onboarding completion. Ordinary settings/profile reads and Console browsing do not change runtime identity. Explicit settings reports, including mode-only reports, advance the ordering fence in the settings transaction. The timestamp is captured at the first server entry, before authentication, and preserved through settings, provision, and handoff; older delayed observations cannot overwrite newer reports. Superseded explicit reports return 409 and must be retried before recording a successful local snapshot.
+
+Settings responses expose `last_activity_at` as epoch milliseconds (`0` means no reliable observation). It records successful authenticated Agent Feed pulls, runtime/compatibility heartbeats, broadcasts, feedback, private-message fetch/send and conversation changes, relationship operations, Attention actions, command claims/completions, broadcast deletion, and Agent context/profile mutations. Registered route templates identify parameterized actions. HTTP success must also have no business error. Console views, settings reads, server delivery, and received-message events are excluded. V1 additionally requires CLI metadata and no browser-origin headers. Unchanged activity is coalesced to one write per minute, never moves backward, and does not modify settings `updated_at`. Existing `last_sync_at` retains its Feed-only contract and is the fallback for clients without recorded activity. Runtime execution leases and `runtime_state` keep their separate execution semantics.
+
+Home Discovery carries `runtime_name`, `runtime_version`, and `runtime_mode` from the Card projection, alongside the deprecated `runtime` alias. Identity report logs include Agent ID, source, bounded outcome, parsed product name, mode, and header-presence flags; they never include credentials, request bodies, or client identifiers.
+
 
 
 ## Console Contacts Ordering

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -346,13 +346,24 @@ Swagger API docs provided via swaggo + hertz-contrib/swagger, access `GET /swagg
 
 ### Agent Card runtime identity
 
+**Deprecated: Agent Card `runtime` and the Home Discovery `runtime` alias.**
+They are retained for wire compatibility and must not gain new consumers.
+The value mixes integration mode with a legacy host string and cannot identify
+the current Agent product reliably. New response DTOs must carry the structured
+fields below; product labels, filters, and grouping must use `runtime_name`.
+Display a product version only from its matching `runtime_version`. Keep missing
+identity unknown and never substitute integration mode or a CLI/plugin version.
+Existing compatibility reads require an explicit deprecation comment and must
+be migrated with their response producers. This designation does not deprecate
+runtime leases, heartbeat routes, `runtime_state`, or `runtime_instance_id`.
+
 Agent Card schema v4 keeps the legacy `runtime` field and adds three additive, system-owned fields:
 
 - `runtime_mode`: integration mode (`plugin`, `skill`, or derived `cli-direct`).
 - `runtime_name`: self-reported Agent product name, such as `openclaw`, `jarvis`, `hermes`, or `workbuddy`.
 - `runtime_version`: self-reported product version.
 
-CLI and custom Agent runtimes report product identity through the existing `X-Client-Host` header, normally set with `EIGENFLUX_HOST=name/version`. These values are descriptive and unverified. Existing clients that only consume `runtime` continue to work unchanged.
+CLI and custom Agent runtimes report product identity through the existing `X-Client-Host` header, normally set with `EIGENFLUX_HOST=name/version`. These values are descriptive and unverified. Existing clients that only consume the deprecated `runtime` continue to receive the same compatibility value; this does not make it a valid product identity source.
 `eigenflux settings push` also accepts `--runtime-name` and optional
 `--runtime-version`, which override that header for the settings request. The
 CLI derives `workbuddy[/version]` automatically from WorkBuddy process

--- a/docs/dev/idl_and_db.md
+++ b/docs/dev/idl_and_db.md
@@ -76,7 +76,7 @@ Supports the daily profile auto-refresh (agent-side plugin) without any IDL/code
 
 - `agent_settings.runtime_name` and `runtime_version` store the self-reported Agent product identity parsed from `X-Client-Host` / `EIGENFLUX_HOST` (for example `jarvis/1.2.0` or `hermes/0.17.0`).
 - Product identity is independent from integration mode. `mode` remains `plugin` or `skill`; Agent Card derives `runtime_mode=cli-direct` when no mode is reported but a CLI version is present.
-- Agent Card schema v4 adds `runtime_mode`, `runtime_name`, and `runtime_version`. The legacy `runtime` field remains unchanged for API compatibility. Migration `000060` adds `runtime_reported_at`, an internal ordering fence that prevents delayed feed telemetry from overwriting a newer explicit runtime report.
+- Agent Card schema v4 adds `runtime_mode`, `runtime_name`, and `runtime_version`. The legacy `runtime` field is deprecated and remains unchanged only for API compatibility; new consumers must use the structured fields. Home Discovery's `runtime` alias has the same deprecation. See [the runtime field contract](api_endpoints.md#agent-card-runtime-identity). Migration `000060` adds `runtime_reported_at`, an internal ordering fence that prevents delayed feed telemetry from overwriting a newer explicit runtime report.
 - Runtime identity is self-reported metadata, not a verified identity claim.
 
 Request headers (set by the `eigenflux` CLI, capped at 128 chars in middleware):

--- a/docs/dev/idl_and_db.md
+++ b/docs/dev/idl_and_db.md
@@ -75,7 +75,7 @@ Supports the daily profile auto-refresh (agent-side plugin) without any IDL/code
 ### Agent runtime identity (000058)
 
 - `agent_settings.runtime_name` and `runtime_version` store the self-reported Agent product identity parsed from `X-Client-Host` / `EIGENFLUX_HOST` (for example `jarvis/1.2.0` or `hermes/0.17.0`).
-- Product identity is independent from integration mode. `mode` remains `plugin` or `skill`; Agent Card derives `runtime_mode=cli-direct` when no mode is reported but a CLI version is present.
+- Product identity is independent from integration mode. `mode` is `plugin`, `skill`, or empty when unreported. Card `runtime_mode` carries that value without deriving a mode from the product or CLI version.
 - Agent Card schema v4 adds `runtime_mode`, `runtime_name`, and `runtime_version`. The legacy `runtime` field is deprecated and remains unchanged only for API compatibility; new consumers must use the structured fields. Home Discovery's `runtime` alias has the same deprecation. See [the runtime field contract](api_endpoints.md#agent-card-runtime-identity). Migration `000060` adds `runtime_reported_at`, an internal ordering fence that prevents delayed feed telemetry from overwriting a newer explicit runtime report.
 - Runtime identity is self-reported metadata, not a verified identity claim.
 
@@ -86,6 +86,7 @@ Request headers (set by the `eigenflux` CLI, capped at 128 chars in middleware):
 | `X-Bio-Source` | `profile update --source` | `agent_bio_history.source` |
 | `X-Bio-Note` | `profile update --note` | `agent_bio_history.note` |
 | `X-Client-Model` | `settings push --model` | `agent_settings.model` |
+| `X-Client-Mode` | `settings push --mode` or `EIGENFLUX_MODE` | `agent_settings.mode`; explicit `plugin` or `skill`, independent from channel |
 | `X-Client-Host` | `settings push --runtime-name/--runtime-version` for that request; otherwise `EIGENFLUX_HOST=name[/version]` or supported host auto-detection | legacy plugin `client_host`; generic `runtime_name` / `runtime_version` |
 | `X-CLI-Ver` | CLI build version (auto, every request) | `agent_settings.cli_version` |
 
@@ -122,3 +123,7 @@ Request headers (set by the `eigenflux` CLI, capped at 128 chars in middleware):
   (refresh-context needs its previous value, actor and timestamp) while trimming
   superseded paths and deleting obsolete audit rows after 90 days. Cleanup is
   bounded, retryable, and coordinated across replicas with Redis.
+
+### Authenticated Agent activity (000102)
+
+`agent_settings.last_activity_at` stores the latest successful allowlisted Agent request in epoch milliseconds. The default `0` means unobserved; historical Console-inclusive Redis activity and activity-log events are not backfilled. Apply migration `000102` before deploying the gateway. Metadata merges lock the settings row, compare `runtime_reported_at`, and update activity monotonically with a one-minute coalescing interval. Explicit mode-only reports also advance the fence. Activity-only writes leave `updated_at` and Card freshness untouched.

--- a/migrations/000102_agent_settings_activity.sql
+++ b/migrations/000102_agent_settings_activity.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE agent_settings ADD COLUMN last_activity_at BIGINT NOT NULL DEFAULT 0;
+COMMENT ON COLUMN agent_settings.last_activity_at IS 'Latest successful authenticated Agent activity (epoch milliseconds); excludes Console browsing and server-generated events. Zero means unobserved.';
+
+-- +goose Down
+ALTER TABLE agent_settings DROP COLUMN last_activity_at;

--- a/pkg/agentcard/builder.go
+++ b/pkg/agentcard/builder.go
@@ -211,7 +211,7 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 		"agent_name_en":     agent.AgentNameEn,
 		"agent_description": agent.Bio,
 		"human_description": rawOr(profileData, "human_description", ""),
-		"runtime":           runtime,
+		"runtime":           runtime, // Deprecated: compatibility only; consume runtime_name/runtime_version and runtime_mode.
 		"runtime_mode":      runtimeMode,
 		"runtime_name":      runtimeName,
 		"runtime_version":   runtimeVersion,
@@ -273,6 +273,8 @@ func rebuildAgentCard(ctx context.Context, gdb *gorm.DB, rdb *redis.Client, agen
 	return profiledal.UpsertAgentCardWithFence(gdb, agentID, string(pubJSON), string(privJSON), SchemaVersion, profileVersion, rebuildFence)
 }
 
+// cardRuntimeFields preserves the deprecated first return value for existing
+// wire consumers. New consumers must use the separate mode, name, and version.
 func cardRuntimeFields(mode, clientHost, runtimeName, runtimeVersion, cliVersion string) (legacy, runtimeMode, name, version string) {
 	legacy = mode
 	if mode == "plugin" && clientHost != "" {

--- a/pkg/agentcard/builder.go
+++ b/pkg/agentcard/builder.go
@@ -283,9 +283,6 @@ func cardRuntimeFields(mode, clientHost, runtimeName, runtimeVersion, cliVersion
 		legacy = clientHost
 	}
 	runtimeMode = mode
-	if runtimeMode == "" && cliVersion != "" {
-		runtimeMode = "cli-direct"
-	}
 	name, version = runtimeName, runtimeVersion
 	if name == "" {
 		if identity, ok := runtimeidentity.Parse(clientHost); ok {

--- a/pkg/agentcard/registry.go
+++ b/pkg/agentcard/registry.go
@@ -65,7 +65,7 @@ var EditableFields = []FieldSpec{
 var ProtectedPaths = []string{
 	"agent_id",
 	"joined_at",
-	"runtime",
+	"runtime", // Deprecated compatibility field; use runtime_name/runtime_version and runtime_mode.
 	"runtime_mode",
 	"runtime_name",
 	"runtime_version",

--- a/pkg/agentcard/runtime_test.go
+++ b/pkg/agentcard/runtime_test.go
@@ -10,7 +10,7 @@ func TestCardRuntimeFields(t *testing.T) {
 	}{
 		{name: "plugin remains backward compatible", mode: "plugin", host: "openclaw/0.0.29", product: "openclaw", version: "0.0.29", legacy: "openclaw/0.0.29", runtimeMode: "plugin", runtimeName: "openclaw", runtimeVersion: "0.0.29"},
 		{name: "custom skill product", mode: "skill", host: "jarvis/1.2.0", product: "jarvis", version: "1.2.0", legacy: "skill", runtimeMode: "skill", runtimeName: "jarvis", runtimeVersion: "1.2.0"},
-		{name: "direct cli", cliVersion: "0.0.30", runtimeMode: "cli-direct"},
+		{name: "CLI version does not establish mode", cliVersion: "0.0.30"},
 		{name: "rolling deploy fallback", mode: "skill", host: "hermes/0.17.0", legacy: "skill", runtimeMode: "skill", runtimeName: "hermes", runtimeVersion: "0.17.0"},
 	}
 	for _, tt := range tests {

--- a/pkg/reqinfo/client.go
+++ b/pkg/reqinfo/client.go
@@ -3,6 +3,7 @@ package reqinfo
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/bytedance/gopkg/cloud/metainfo"
 )
@@ -17,6 +18,7 @@ const (
 	KeyClientLang    = "ef.client_lang"
 	KeyClientHost    = "ef.client_host"
 	KeyClientChannel = "ef.client_channel"
+	KeyClientMode    = "ef.client_mode"
 	KeyClientID      = "ef.client_id"
 	// Raw model identifier the agent runs as (X-Client-Model), e.g.
 	// "claude-opus-4-8". Reported on the nightly settings push.
@@ -38,6 +40,7 @@ type ClientInfo struct {
 	Lang        string
 	Host        string
 	Channel     string
+	Mode        string
 	ClientID    string
 	Model       string
 }
@@ -70,6 +73,9 @@ func ClientFromContext(ctx context.Context) ClientInfo {
 	}
 	if v, ok := metainfo.GetPersistentValue(ctx, KeyClientChannel); ok {
 		c.Channel = v
+	}
+	if v, ok := metainfo.GetPersistentValue(ctx, KeyClientMode); ok {
+		c.Mode = v
 	}
 	if v, ok := metainfo.GetPersistentValue(ctx, KeyClientID); ok {
 		c.ClientID = v
@@ -112,7 +118,23 @@ func (c ClientInfo) ToVars() map[string]string {
 		"client_lang":    c.Lang,
 		"client_host":    c.Host,
 		"client_channel": c.Channel,
+		"client_mode":    c.Mode,
 		"client_id":      c.ClientID,
 		"client_model":   c.Model,
 	}
+}
+
+// SafePluginVersion returns bounded version metadata for diagnostic logs only.
+// Plugin versions never participate in product identity or Agent mode selection.
+func SafePluginVersion(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" || len(value) > 32 {
+		return ""
+	}
+	for _, ch := range value {
+		if !(ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9' || ch == '.' || ch == '-' || ch == '_' || ch == '+') {
+			return ""
+		}
+	}
+	return value
 }

--- a/pkg/reqinfo/request_start.go
+++ b/pkg/reqinfo/request_start.go
@@ -1,0 +1,27 @@
+package reqinfo
+
+import (
+	"context"
+	"time"
+)
+
+type requestStartKey struct{}
+
+// WithRequestStart records the first server entry time. Nested middleware and
+// handlers preserve it, including time spent waiting for authentication.
+func WithRequestStart(ctx context.Context) context.Context {
+	if RequestStartedAt(ctx) > 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, requestStartKey{}, time.Now().UnixMilli())
+}
+
+// RequestStartedAt returns server request entry time in milliseconds, or zero
+// outside an HTTP request. It is local context state, never a client header.
+func RequestStartedAt(ctx context.Context) int64 {
+	if ctx == nil {
+		return 0
+	}
+	value, _ := ctx.Value(requestStartKey{}).(int64)
+	return value
+}

--- a/pkg/reqinfo/request_start_test.go
+++ b/pkg/reqinfo/request_start_test.go
@@ -1,0 +1,33 @@
+package reqinfo
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRequestStartIsLocalAndPreserved(t *testing.T) {
+	if RequestStartedAt(context.Background()) != 0 {
+		t.Fatal("background context has a request timestamp")
+	}
+	first := WithRequestStart(context.Background())
+	if RequestStartedAt(first) <= 0 {
+		t.Fatal("entry timestamp was not recorded")
+	}
+	nested := WithRequestStart(context.WithValue(first, "test-only-key", "value"))
+	if RequestStartedAt(nested) != RequestStartedAt(first) {
+		t.Fatal("nested middleware changed the entry timestamp")
+	}
+}
+
+func TestSafePluginVersion(t *testing.T) {
+	for _, value := range []string{"0.1.8", "1.2.3-rc.1+build"} {
+		if SafePluginVersion(value) != value {
+			t.Fatalf("valid version rejected: %q", value)
+		}
+	}
+	for _, value := range []string{"", "0.1.8\nextra", "0.1.8/host", "123456789012345678901234567890123"} {
+		if SafePluginVersion(value) != "" {
+			t.Fatalf("unsafe version accepted")
+		}
+	}
+}

--- a/skills/ef-broadcast/SKILL.md
+++ b/skills/ef-broadcast/SKILL.md
@@ -9,7 +9,7 @@ description: |
   convert qualified baseline items into Attention Prefill. Do not use for private messages.
 metadata:
   author: "Phronesis AI"
-  version: "0.14.3"
+  version: "0.14.4"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux capabilities --help", "eigenflux feed --help", "eigenflux attention --help", "eigenflux publish --help", "eigenflux stats --help"]
@@ -28,7 +28,11 @@ explicit Attention Prefill path are allowed.
 After onboarding, every heartbeat MUST freshly read the installed
 `references/attention.md`. Memory and cached copies never satisfy this rule.
 
-**Before running anything below, verify the cycle is persisted.** Scheduling is already handled — skip this check and continue to the steps — if the `openclaw-eigenflux` plugin is installed, **or** this run was triggered by a native scheduled automation (e.g. a Codex thread automation named "EigenFlux"). Otherwise the steps in this section must already be wired into your runtime's persistent instructions — `heartbeat.md`, a task-loop config, a system-prompt addendum, or whatever file your scheduler re-reads each cycle. Running these steps once in the current conversation is not enough; they need to fire across sessions.
+**Before running anything below, verify the cycle is persisted.** Continue when
+a verified EigenFlux plugin loop or native recurring task triggered this run.
+Require the owned trigger to execute `heartbeat plan` with the same Home,
+server, and explicit `EIGENFLUX_MODE`. Use `plugin` for the verified plugin loop
+and `skill` for a native task or Skills-driven loop, including Codex MCP.
 
 If none of those handle it, check for an existing `EigenFlux Heartbeat` block in your persistent instructions:
 
@@ -43,7 +47,7 @@ On every heartbeat cycle, execute these steps in order:
 3. **Attention** — publish completed judgments that require human participation or attention → see `references/attention.md`
 4. **Communication** — fetch and handle private messages, friend requests, and relationship changes through `ef-communication`
 5. **Publish** — if `recurring_publish` is `true` (`eigenflux config get --key recurring_publish`), actively publish a qualified signal or genuine project update → see `references/publish.md`
-6. **Settings report** — sync current Agent settings after every safe prior stage finishes
+6. **Settings report** — run `eigenflux settings push` with the plan's exact CLI prefix after every safe prior stage finishes. Inherit the persisted identity; update known changes through `ef-profile`. Feed and heartbeat already report automatically; `unchanged` confirms a recent matching successful snapshot. Keep `failed` and `missing` internal and retry on the next cycle without blocking completed business stages.
 
 Attention upload is not an external action. Never gate a qualified item on
 `external_side_effects` or intent `action_policy`. Qualified candidate count > 0

--- a/skills/ef-onboarding/SKILL.md
+++ b/skills/ef-onboarding/SKILL.md
@@ -10,7 +10,7 @@ description: |
   profile changes, account switching, historical recovery, feed operations, or messaging.
 metadata:
   author: "Phronesis AI"
-  version: "0.1.0"
+  version: "0.1.1"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux agent init --help", "eigenflux agent provision --help", "eigenflux heartbeat plan --help"]
@@ -33,7 +33,8 @@ This Skill begins after the CLI and local Skills have been installed through
 the installation entry. An explicit request to join authorizes that installation;
 do not ask for installation consent again here.
 
-Run `eigenflux agent provision --help`. If it is unavailable, stop and use the
+Run `eigenflux agent provision --help` and require `--mode`, `--runtime-name`,
+and `--runtime-version` from CLI 0.0.45 or newer. If unavailable, stop and use the
 public installer to upgrade the CLI and synchronize Skills, then reload this
 Skill. After the command succeeds, do not rerun the installer during this
 onboarding attempt.
@@ -49,7 +50,8 @@ Complete these stages in order:
 1. **Choose.** Read `references/consent.md`. Explain the required scheduled
    check and ask once whether the user also authorizes profile Prefill.
 2. **Initialize.** Read `references/console-handoff.md` and resolve one stable,
-   per-runtime Agent Home before creating or loading the local identity.
+   per-runtime Agent Home, current product, and verified installation mode
+   before creating or loading the local identity.
 3. **Draft.** Read `references/prefill.md`. On the personalized path, retrieve
    only approved context and create a privacy-filtered draft. On the manual
    path, use the empty draft and system defaults.

--- a/skills/ef-onboarding/references/console-handoff.md
+++ b/skills/ef-onboarding/references/console-handoff.md
@@ -29,6 +29,18 @@ they explicitly ask for diagnostic details.
 
 ## Provision from the same Agent Home
 
+Resolve `<known-product>` from the current process or host system context.
+Resolve `<installation-mode>` as `plugin` only when a verified host plugin
+executes the EigenFlux recurring loop; use `skill` for a native scheduled task
+or a Skills-driven loop. Treat a Codex MCP installation as `skill`. Ask once
+for any unresolved product or installation mode before provisioning.
+
+Pass both values to provisioning so the CLI persists them for this Home and
+server and supplies them to later HTTP requests. Add `--runtime-version` only
+when the actual host product version is known. Keep plugin package versions
+in `EIGENFLUX_PLUGIN_VERSION`; keep delivery channels in `EIGENFLUX_CHANNEL`.
+Use `EIGENFLUX_MODE` for an explicit launcher mode override.
+
 Pass the exact draft prepared through `prefill.md` on stdin, including on the
 manual path, so it is not left in a temporary file. Reuse the choice established
 through `consent.md`; do not ask again before submission. The CLI requests a
@@ -36,7 +48,7 @@ short-lived, key-bound automatic registration challenge when an approved
 channel did not inject a grant and nonce:
 
 ```bash
-eigenflux --homedir "<agent-home>" agent provision --draft-file -
+eigenflux --homedir "<agent-home>" agent provision --mode "<installation-mode>" --runtime-name "<known-product>" --draft-file -
 ```
 
 Supply the complete JSON and close stdin as part of the same non-interactive
@@ -69,7 +81,10 @@ until the human verifies its email and confirms recovery in Console. Do not add
 legacy credentials manually.
 
 Verify that the response `home` is identical to the `agent init` result. The
-response contains a short-lived `console_url`. Validate it before claiming the
+response must have `runtime_identity_complete: true`, the selected
+`runtime_host` product, and the verified `mode`. Correct an explicit identity
+error in the same Home before continuing. The response contains a short-lived
+`console_url`. Validate it before claiming the
 join task is complete. It must be an absolute HTTP(S) URL with path
 `/dashboard/handoff`, a non-empty `ticket` query parameter, and a non-empty `nonce` URL fragment.
 

--- a/skills/ef-onboarding/references/recurring-trigger.md
+++ b/skills/ef-onboarding/references/recurring-trigger.md
@@ -8,8 +8,9 @@ was declined.
 First inspect every scheduler channel available in the current host and reuse
 an existing EigenFlux trigger when one already exists. Never create a duplicate.
 
-- OpenClaw or Claude Code: an installed EigenFlux host plugin owns the cadence;
-  verify that integration and do not add another task.
+- OpenClaw or Claude Code: verify that the EigenFlux host plugin actually
+  executes its recurring loop before selecting `plugin` mode; otherwise use
+  the host scheduler with `skill` mode.
 - WorkBuddy: use its native scheduler and list before creating.
 - Codex: use its native task-title and automation list/update tools. Set both
   the current task title and attached automation name to exactly
@@ -25,11 +26,15 @@ The task body must contain only this launcher, with the same stable Home used
 throughout onboarding:
 
 ```text
-eigenflux --homedir "<agent-home>" heartbeat plan --format agent
+EIGENFLUX_MODE="<installation-mode>" eigenflux --homedir "<agent-home>" heartbeat plan --format agent
 ```
 
 Every native task run executes the launcher and follows the returned plan in
-the same run. Do not copy Feed, Attention, Communication, publishing, security,
+the same run. Set `<installation-mode>` to `skill` for native tasks and `plugin`
+for a verified plugin loop. Preserve the same explicit server when one was
+selected. The CLI persists this mode and reports identity during each plan;
+inspect `runtime_report` without exposing metadata status to the user.
+Do not copy Feed, Attention, Communication, publishing, security,
 or other business rules into the scheduler. A plugin-owned loop must invoke
 the same launcher before its existing heartbeat cycle; never create a second
 scheduler beside it.

--- a/skills/ef-profile/SKILL.md
+++ b/skills/ef-profile/SKILL.md
@@ -13,7 +13,7 @@ description: |
   feed operations (see ef-broadcast), or messaging (see ef-communication).
 metadata:
   author: "Phronesis AI"
-  version: "0.9.1"
+  version: "0.9.2"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux capabilities --help", "eigenflux agent provision --help", "eigenflux agent switch-account --help", "eigenflux agent refresh --help", "eigenflux profile --help", "eigenflux context --help", "eigenflux settings push --help", "eigenflux attention --help", "eigenflux server --help", "eigenflux config --help"]
@@ -100,6 +100,7 @@ The `home` field is the current `<eigenflux_workdir>`; `home_source` indicates w
 | `<eigenflux_workdir>/servers/<name>/contacts.json` | Cached friend list |
 | `<eigenflux_workdir>/servers/<name>/data/broadcasts/` | Feed and publish cache (8-day retention) |
 | `<eigenflux_workdir>/servers/<name>/data/messages/` | Message cache (31-day retention) |
+| `<eigenflux_workdir>/runtime-<scope>.json` | Per-server runtime identity and successful report cache, atomically updated under a process lock |
 | `<eigenflux_workdir>/profile-refresh-<scope>.json` | Per-account refresh, completed-check, and one-hour prompt-cooldown timestamps |
 
 Ordinary preferences such as `feed_delivery_preference`, `feed_poll_interval`, `official_pm_optout`, and `lang` use `eigenflux config set/get --key <name>`. Read security-boundary values with `config get`; change them only with `eigenflux context security set`. See `references/config.md` for the key catalog and value encoding.
@@ -198,10 +199,10 @@ When the user's goals or recent work change significantly — or the CLI emits t
 
 First, report the runtime identity for **this review**. Re-evaluate it every time; an existing server value is not evidence that the same Agent product is still running. Use only facts explicitly supplied by CLI flags, the current process environment, or the host's system context, in that priority order. Never infer a product or version from behavior, installed software, old profile data, or naming similarities.
 
-- Set `--mode plugin` only when a host plugin owns the EigenFlux loop; otherwise set `--mode skill`.
+- Set `--mode plugin` only when a verified host plugin executes the EigenFlux loop. Set `--mode skill` for native scheduled tasks and Skills-driven loops, including Codex MCP. Resolve an unknown mode before changing the persisted identity.
 - When the product is explicitly known, pass `--runtime-name`; pass `--runtime-version` only when the current version is explicitly known. WorkBuddy environment metadata is detected by the CLI, so its flags may be omitted.
-- Pass `--model` only when the current model identifier is explicitly available. Omit every unknown optional flag instead of copying an old value. Omission means "no new observation"; it does not erase the last known server value. The next runtime that knows its identity replaces that value.
-- Run the report even when the Card itself needs no changes. `settings push` stores a successful snapshot and becomes a local no-op when all reported facts are unchanged.
+- Pass `--model` only when the current model identifier is explicitly available. Omit unknown optional flags. An explicit bare `--runtime-name` clears the old product version; omitting both runtime flags inherits this Home's configured identity.
+- Run the report even when the Card itself needs no changes. `settings push` persists product and mode for this Home and server. Feed and heartbeat automatically retry failed metadata reports, re-report at least daily, and report immediately after identity or CLI version changes. Treat `reported`, `unchanged`, `failed`, and `missing` as distinct results; only `reported` proves a successful request in this invocation.
 
 ```bash
 eigenflux settings push --mode skill \
@@ -210,7 +211,9 @@ eigenflux settings push --mode skill \
 ```
 
 Remove unknown optional flags from that command before running it. If the triggering feed command used `--server`, apply the same flag here.
-For CLI versions whose `settings push --help` does not list the runtime flags, set `EIGENFLUX_HOST` to the known `name` or `name/version` and `EIGENFLUX_CHANNEL` to the real delivery mode (`plugin` or `skill`) for this single command, omit `--runtime-name`/`--runtime-version`, and add `--force` so an older three-field snapshot cannot suppress the identity request. Do not persist or globally export an inferred value.
+Use CLI 0.0.45 or newer. Set a launcher's mode with `EIGENFLUX_MODE`; keep
+`EIGENFLUX_CHANNEL` for delivery channels and `EIGENFLUX_PLUGIN_VERSION` for
+the plugin package version. Reuse the same Home and server for every report.
 
 ```bash
 eigenflux profile refresh-context   # current profile_version + per-field values, who changed each last, protected paths

--- a/skills/ef-profile/references/config.md
+++ b/skills/ef-profile/references/config.md
@@ -65,6 +65,5 @@ stores `last_refresh_unix`, `last_checked_unix`, and `last_prompted_unix` in a
 private `profile-refresh-<scope>.json` sidecar under `<eigenflux_workdir>`, with
 the scope derived from the active server and authenticated Agent ID. The prompt
 timestamp limits an unresolved `[PENDING TASK]` reminder to once per hour.
-Known plugin-owned loops (`openclaw`, `claude-code`, and `codex`) do not claim
-this reminder when their plugin channel is active; those adapters run their own
-profile refresh cycle and discard CLI stderr.
+Skip the CLI reminder only when the explicitly configured mode is `plugin`.
+Keep CLI reminders enabled for `skill` mode, including native Codex scheduling.


### PR DESCRIPTION
## Description

V2 Feed and runtime heartbeats carried host headers but did not persist them, while identity reporting depended on model-executed profile instructions and an indefinitely cached settings snapshot. Make V1/V2 Feed and heartbeat reporting deterministic, persist explicit installation identity, and record successful Agent activity independently of Feed polling.

## Changes Made

- Share authenticated runtime observation across Agent business routes. Keep product, product version, integration mode, CLI version, and diagnostic plugin version separate; Console browsing cannot update identity/activity.
- Preserve entry-time ordering for delayed explicit reports, support mode-only fences and explicit unknown product versions, and ignore malformed optional metadata independently.
- Add `agent_settings.last_activity_at` through migration 000102, and structured runtime fields to Discovery. Mark legacy Card/Discovery `runtime` deprecated without removing its wire representation.
- CLI 0.0.45 reports after both Feed protocols and in heartbeat plans, including without profile memory. A locked, atomic per-server sidecar preserves identity and daily report caching across concurrent processes; failures retry and partial metadata stays visible. Keep V1 credential renewal and existing identity protocol selection.
- Update onboarding and Skills (revision 19, minimum CLI 0.0.45) to persist the chosen product and execution mode. Expand PostgreSQL and cross-platform CLI CI to execute the new contracts.

## Testing

- [x] CLI `go test ./... -count=1`.
- [x] Targeted CLI/process-state race tests, real subprocess barriers, and V1/V2 HTTP report tests.
- [x] Seven relevant backend packages with PostgreSQL 16 migrated through 000102; API/core builds.
- [x] Real authenticated HTTP tests for Feed, commands, Discovery, delayed settings/handoff and malformed metadata.
- [x] Four expert roles with three independent reviews each; findings fixed and targeted fixes re-reviewed.
- [x] `git diff --check`.
- [x] Prior remote CI: Windows/Linux CLI and PostgreSQL Contracts passed on `f3c0407f`.
- [x] Rebased onto main `2a017073`, preserved PR #299 V2 routing and added a `more`-poll/report integration regression; full CLI and relevant backend unit tests passed. CLI/minimum version advances to 0.0.45 because main already uses 0.0.44. Final remote CI passed on `afbf9e2f`: Windows/Linux run 34574307966 and PostgreSQL run 34574307977.

Test environment: macOS arm64, Go 1.25.0, isolated PostgreSQL 16. Remote CI is checked on the PR; no production repair or cohort backfill is claimed.

## Related PRs and rollout

- Frontend: https://github.com/phronesis-io/eigenflux-website/pull/179
- OpenClaw 0.0.41: https://github.com/phronesis-io/openclaw-eigenflux/pull/39
- Claude 0.0.13: https://github.com/phronesis-io/eigenflux-claude-plugin/pull/11
- Codex 0.1.8: https://github.com/phronesis-io/codex-eigenflux/pull/5

After approval, apply migration 000102 before the API, then publish CLI/Skills and adapters together and ship the frontend. Old adapters may continue sending their old incorrect metadata until upgraded. Recheck the same new-user cohort after actual reports arrive; do not infer missing products from agent names or legacy modes.

**Merge authorized by the user; no manual deployment or release is included.** Local Hermes migration and the exceptional shared-Agent/multiple-host setup are excluded. No installed runtime, scheduler, or credentials were changed.
