### PR TITLE
feat(api): unify broadcast detail roles and agent identities

### DIFF
--- a/.github/workflows/postgres-contracts.yml
+++ b/.github/workflows/postgres-contracts.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'api/consolev2/**'
+      - 'api/handler_gen/eigenflux/api/**'
       - 'api/install/**'
       - 'contracts/**'
       - 'migrations/**'
@@ -18,6 +19,7 @@ on:
     branches: [main]
     paths:
       - 'api/consolev2/**'
+      - 'api/handler_gen/eigenflux/api/**'
       - 'api/install/**'
       - 'contracts/**'
       - 'migrations/**'
@@ -68,6 +70,8 @@ jobs:
         run: go test -count=1 ./api/install -run '^TestPostgresShortIDInviteAttribution$'
       - name: Verify Console V2 PostgreSQL flow and races
         run: go test -count=1 ./api/consolev2 -run 'Test(ConsoleV2ProvisionHandoffAndOnboardingFlow|HistoricalRecovery.*|Postgres.*)'
+      - name: Verify broadcast detail ownership and reader permissions
+        run: go test -count=1 ./api/handler_gen/eigenflux/api -run 'Test(PostgresBroadcastDetail.*|GetItemAggregateStats|BroadcastCountryCode)'
       - name: Verify Attention schema and golden corpus
         run: go test -count=1 ./api/consolev2 -run '^(TestAttentionGoldenCorpusMatchesServerValidators|TestAttentionSchemaEnumsMatchServer)$'
       - name: Verify Console homepage HTTP and data contracts

--- a/api/handler_gen/eigenflux/api/api_service.go
+++ b/api/handler_gen/eigenflux/api/api_service.go
@@ -961,19 +961,62 @@ func GetItem(ctx context.Context, c *app.RequestContext) {
 		}
 	}
 
+	var metadata struct {
+		CreatedAt         int64  `gorm:"column:created_at"`
+		CountryCode       string `gorm:"column:country_code"`
+		ViewerCountryCode string `gorm:"column:viewer_country_code"`
+	}
+	if err := db.DB.Table("raw_items AS raw").
+		Select("raw.created_at, COALESCE(card.private_card->>'geo', '') AS country_code, COALESCE(viewer_card.private_card->>'geo', '') AS viewer_country_code").
+		Joins("LEFT JOIN agent_cards card ON card.agent_id = raw.author_agent_id").
+		Joins("LEFT JOIN agent_cards viewer_card ON viewer_card.agent_id = ?", agentID).
+		Where("raw.item_id = ?", req.ItemID).Scan(&metadata).Error; err != nil {
+		writeJSON(c, http.StatusInternalServerError, 500, "failed to load broadcast metadata", nil)
+		return
+	}
+	isMine := item.AuthorAgentID == agentID
+	authorCountryCode := broadcastCountryCode(metadata.CountryCode)
 	detail := map[string]interface{}{
-		"item_id":        strconv.FormatInt(item.ItemID, 10),
-		"status":         item.Status,
-		"broadcast_type": item.BroadcastType,
-		"domains":        []string{},
-		"keywords":       []string{},
-		"content":        item.RawContent,
-		"url":            item.RawURL,
-		"updated_at":     item.UpdatedAt,
+		"item_id":             strconv.FormatInt(item.ItemID, 10),
+		"author_agent_id":     strconv.FormatInt(item.AuthorAgentID, 10),
+		"is_mine":             isMine,
+		"can_retract":         isMine && item.Status >= itemdal.StatusPending && item.Status <= itemdal.StatusCompleted,
+		"retracted":           item.Status == itemdal.StatusDeleted,
+		"author_country_code": authorCountryCode,
+		"country_code":        authorCountryCode,
+		"viewer_country_code": broadcastCountryCode(metadata.ViewerCountryCode),
+		"created_at":          metadata.CreatedAt,
+		"my_score":            nil,
+		"feedback_at":         nil,
+		"status":              item.Status,
+		"broadcast_type":      item.BroadcastType,
+		"domains":             []string{},
+		"keywords":            []string{},
+		"content":             item.RawContent,
+		"url":                 item.RawURL,
+		"updated_at":          item.UpdatedAt,
 	}
 	if identity, identityErr := agentidentity.Get(ctx, db.DB, item.AuthorAgentID); identityErr == nil {
 		detail["author_short_id"] = identity.ShortID
 		detail["author_display_name"] = identity.DisplayName
+		detail["author_display_name_en"] = identity.DisplayNameEn
+		detail["author_name"] = identity.AgentName
+		detail["author_name_en"] = identity.AgentNameEn
+	}
+	var feedback struct {
+		Score      int16 `gorm:"column:score"`
+		FeedbackAt int64 `gorm:"column:feedback_at"`
+	}
+	feedbackResult := db.DB.Table("feedback_logs").Select("score, feedback_at").
+		Where("item_id = ? AND agent_id = ?", req.ItemID, agentID).
+		Order("feedback_at DESC, id DESC").Limit(1).Scan(&feedback)
+	if feedbackResult.Error != nil {
+		writeJSON(c, http.StatusInternalServerError, 500, "failed to load your broadcast feedback", nil)
+		return
+	}
+	if feedbackResult.RowsAffected > 0 {
+		detail["my_score"] = feedback.Score
+		detail["feedback_at"] = feedback.FeedbackAt
 	}
 	if item.Summary != "" {
 		detail["summary"] = item.Summary
@@ -1027,13 +1070,14 @@ func GetItem(ctx context.Context, c *app.RequestContext) {
 	if statsErr == nil {
 		detail["consumed_count"] = stats.ConsumedCount
 		detail["praise_count"] = stats.Score1Count + stats.Score2Count
+		detail["total_score"] = stats.TotalScore
 	} else if !errors.Is(statsErr, gorm.ErrRecordNotFound) {
 		logger.Ctx(ctx).Warn("GetItem failed to load aggregate stats", "itemID", req.ItemID, "err", statsErr)
 	}
 
-	// Interaction details (who scored this broadcast, with what score and when)
-	// are private to the author. Gate on ownership so only the author sees them.
-	if statsErr == nil && stats.AuthorAgentID == agentID {
+	// Readers of this broadcast share its positive-feedback roster. Non-public
+	// broadcasts remain author-only through the item lookup above.
+	if statsErr == nil {
 		// Count only "found helpful" (1/2), matching GetRecentItemInteractions'
 		// interface-layer filter so the total lines up with the returned list.
 		detail["interaction_total"] = stats.Score1Count + stats.Score2Count
@@ -1056,6 +1100,22 @@ func GetItem(ctx context.Context, c *app.RequestContext) {
 		for _, interaction := range interactions {
 			interactionIDs = append(interactionIDs, interaction.AgentID)
 		}
+		interactionCountries := make(map[int64]string, len(interactionIDs))
+		if len(interactionIDs) > 0 {
+			var countryRows []struct {
+				AgentID     int64  `gorm:"column:agent_id"`
+				CountryCode string `gorm:"column:country_code"`
+			}
+			if err := db.DB.Table("agent_cards").
+				Select("agent_id, COALESCE(private_card->>'geo', '') AS country_code").
+				Where("agent_id IN ?", interactionIDs).Scan(&countryRows).Error; err != nil {
+				writeJSON(c, http.StatusInternalServerError, 500, "failed to load feedback Agent locations", nil)
+				return
+			}
+			for _, row := range countryRows {
+				interactionCountries[row.AgentID] = broadcastCountryCode(row.CountryCode)
+			}
+		}
 		interactionIdentities, identityErr := agentidentity.GetBatch(ctx, db.DB, interactionIDs)
 		if identityErr != nil {
 			logger.Ctx(ctx).Warn("GetItem failed to load optional public Agent identities", "itemID", req.ItemID, "err", identityErr)
@@ -1067,6 +1127,7 @@ func GetItem(ctx context.Context, c *app.RequestContext) {
 				"agent_id":        strconv.FormatInt(it.AgentID, 10),
 				"agent_name":      it.AgentName,
 				"agent_name_en":   it.AgentNameEn,
+				"country_code":    interactionCountries[it.AgentID],
 				"score":           it.Score,
 				"feedback_at":     it.FeedbackAt,
 				"is_friend":       it.IsFriend,

--- a/api/handler_gen/eigenflux/api/item_detail.go
+++ b/api/handler_gen/eigenflux/api/item_detail.go
@@ -1,0 +1,23 @@
+package api
+
+import "strings"
+
+// Broadcast author location comes exclusively from Agent Card geo. Missing or
+// unrecognized values stay unknown rather than inheriting the broadcast's geo.
+func broadcastCountryCode(raw string) string {
+	value := strings.ToUpper(strings.TrimSpace(raw))
+	aliases := map[string]string{
+		"CHINA": "CN", "中国": "CN", "中国大陆": "CN",
+		"HONG KONG": "HK", "香港": "HK", "中国香港": "HK",
+		"SINGAPORE": "SG", "新加坡": "SG", "JAPAN": "JP", "日本": "JP",
+		"USA": "US", "UNITED STATES": "US", "美国": "US",
+		"UK": "GB", "UNITED KINGDOM": "GB", "英国": "GB",
+	}
+	if code, exists := aliases[value]; exists {
+		return code
+	}
+	if len(value) == 2 && value != "ZZ" && value[0] >= 'A' && value[0] <= 'Z' && value[1] >= 'A' && value[1] <= 'Z' {
+		return value
+	}
+	return ""
+}

--- a/api/handler_gen/eigenflux/api/item_detail_postgres_test.go
+++ b/api/handler_gen/eigenflux/api/item_detail_postgres_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/route/param"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"eigenflux_server/pkg/agentidentity"
+	"eigenflux_server/pkg/db"
+)
+
+func TestPostgresBroadcastDetailOwnerAndGuest(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for broadcast detail contracts")
+	}
+	database, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, _ := database.DB()
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	tx := database.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	t.Cleanup(func() { tx.Rollback() })
+	previous := db.DB
+	db.DB = tx
+	t.Cleanup(func() { db.DB = previous })
+
+	base, created := time.Now().UnixNano(), time.Now().UnixMilli()-10000
+	owner, guest, helpful := base, base+1, base+2
+	itemID := base + 100
+	exec := func(query string, args ...interface{}) {
+		t.Helper()
+		if err := tx.Exec(query, args...).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, id := range []int64{owner, guest, helpful} {
+		shortID, err := agentidentity.GenerateShortID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		exec(`INSERT INTO agents (agent_id, short_id, email, agent_name, agent_name_en, bio, created_at, updated_at)
+			VALUES (?, ?, ?, '原始名字', 'Original Name', '', ?, ?)`, id, shortID,
+			fmt.Sprintf("broadcast-detail-%d@example.test", id), created, created)
+	}
+	exec(`INSERT INTO raw_items (item_id, author_agent_id, raw_content, raw_url, created_at)
+		VALUES (?, ?, 'complete broadcast body', 'https://example.test/broadcast', ?)`, itemID, owner, created)
+	exec(`INSERT INTO processed_items (item_id, status, geo, updated_at)
+		VALUES (?, 3, 'US', ?)`, itemID, created+1000)
+	exec(`INSERT INTO item_stats (item_id, author_agent_id, consumed_count, score_1_count, score_2_count, total_score, created_at, updated_at)
+		VALUES (?, ?, 32, 0, 1, 2, ?, ?)`, itemID, owner, created, created+2000)
+	exec(`INSERT INTO agent_cards (agent_id, private_card, generated_at)
+		VALUES (?, '{"geo":"Singapore","current_focus":"PRIVATE_CARD_MUST_NOT_LEAK"}'::jsonb, ?),
+		       (?, '{"geo":"CN","human_status":"PRIVATE_CARD_MUST_NOT_LEAK"}'::jsonb, ?),
+		       (?, '{"geo":"US","current_focus":"PRIVATE_CARD_MUST_NOT_LEAK"}'::jsonb, ?)`,
+		owner, created, guest, created, helpful, created)
+	exec(`INSERT INTO user_relations (from_uid, to_uid, rel_type, created_at)
+		VALUES (?, ?, 1, ?)`, guest, helpful, created)
+	for index, feedback := range []struct {
+		agent int64
+		score int
+	}{
+		{guest, -1}, {guest, 0}, {helpful, 2},
+	} {
+		exec(`INSERT INTO feedback_logs (stream_message_id, agent_id, item_id, score, feedback_at, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`, fmt.Sprintf("detail-%d-%d", base, index), feedback.agent,
+			itemID, feedback.score, created+3000, created+3000)
+	}
+
+	request := func(viewer int64, expectedStatus int) map[string]interface{} {
+		t.Helper()
+		c := app.NewContext(1)
+		id := strconv.FormatInt(itemID, 10)
+		c.Request.SetRequestURI("/api/v1/items/" + id)
+		c.Request.Header.SetMethod(http.MethodGet)
+		c.Params = param.Params{{Key: "item_id", Value: id}}
+		c.Set("agent_id", viewer)
+		GetItem(context.Background(), c)
+		if c.Response.StatusCode() != expectedStatus {
+			t.Fatalf("status=%d body=%s", c.Response.StatusCode(), c.Response.Body())
+		}
+		if strings.Contains(string(c.Response.Body()), "PRIVATE_CARD_MUST_NOT_LEAK") {
+			t.Fatal("private Card fields leaked")
+		}
+		var result struct {
+			Data struct{ Item map[string]interface{} }
+		}
+		if err := json.Unmarshal(c.Response.Body(), &result); err != nil {
+			t.Fatal(err)
+		}
+		return result.Data.Item
+	}
+	for _, viewer := range []int64{owner, guest} {
+		item := request(viewer, http.StatusOK)
+		if item["author_agent_id"] != strconv.FormatInt(owner, 10) || item["is_mine"] != (viewer == owner) || item["can_retract"] != (viewer == owner) {
+			t.Fatalf("ownership mismatch: %#v", item)
+		}
+		if item["author_country_code"] != "SG" || item["country_code"] != "SG" || item["created_at"] != float64(created) || item["author_display_name_en"] != "Original Name" {
+			t.Fatalf("author metadata mismatch: %#v", item)
+		}
+		viewerCountry := "SG"
+		if viewer == guest {
+			viewerCountry = "CN"
+		}
+		if item["viewer_country_code"] != viewerCountry {
+			t.Fatalf("viewer location mismatch: %#v", item)
+		}
+		if item["consumed_count"] != float64(32) || item["praise_count"] != float64(1) || item["total_score"] != float64(2) {
+			t.Fatalf("aggregate stats mismatch: %#v", item)
+		}
+		interactions := item["recent_interactions"].([]interface{})
+		if len(interactions) != 1 || item["interaction_total"] != float64(1) {
+			t.Fatalf("positive roster mismatch: %#v", item)
+		}
+		interaction := interactions[0].(map[string]interface{})
+		if interaction["agent_id"] != strconv.FormatInt(helpful, 10) || interaction["country_code"] != "US" || interaction["score"] != float64(2) || interaction["is_friend"] != (viewer == guest) {
+			t.Fatalf("roster scope or viewer relationship mismatch: %#v", interaction)
+		}
+		if viewer == guest {
+			if item["my_score"] != float64(0) || item["feedback_at"] != float64(created+3000) {
+				t.Fatalf("latest neutral feedback was lost: %#v", item)
+			}
+		} else if item["my_score"] != nil || item["feedback_at"] != nil {
+			t.Fatalf("another viewer's feedback leaked: %#v", item)
+		}
+	}
+	exec(`UPDATE agent_cards SET private_card = '{"geo":""}'::jsonb WHERE agent_id = ?`, owner)
+	if item := request(guest, http.StatusOK); item["author_country_code"] != "" || item["country_code"] != "" {
+		t.Fatalf("cleared country inherited broadcast geo: %#v", item)
+	}
+	for _, status := range []int{0, 1, 2, 4, 5} {
+		exec(`UPDATE processed_items SET status = ? WHERE item_id = ?`, status, itemID)
+		if item := request(guest, http.StatusNotFound); item != nil {
+			t.Fatalf("non-public broadcast data leaked: %#v", item)
+		}
+		item := request(owner, http.StatusOK)
+		if item["is_mine"] != true || item["can_retract"] != (status >= 0 && status <= 3) || item["status"] != float64(status) || item["retracted"] != (status == 5) {
+			t.Fatalf("owner's non-public detail mismatch: %#v", item)
+		}
+	}
+}

--- a/api/handler_gen/eigenflux/api/item_detail_test.go
+++ b/api/handler_gen/eigenflux/api/item_detail_test.go
@@ -1,0 +1,14 @@
+package api
+
+import "testing"
+
+func TestBroadcastCountryCode(t *testing.T) {
+	for input, want := range map[string]string{
+		"SG": "SG", " cn ": "CN", "Singapore": "SG", "中国": "CN", "UK": "GB",
+		"DE": "DE", "": "", "ZZ": "", "Other": "", "unknown": "", "123": "",
+	} {
+		if got := broadcastCountryCode(input); got != want {
+			t.Errorf("broadcastCountryCode(%q)=%q, want %q", input, got, want)
+		}
+	}
+}

--- a/api/handler_gen/eigenflux/api/item_stats_test.go
+++ b/api/handler_gen/eigenflux/api/item_stats_test.go
@@ -24,16 +24,17 @@ func TestGetItemAggregateStats(t *testing.T) {
 	db.DB = database
 	defer func() { db.DB = previous }()
 	for _, query := range []string{
-		`CREATE TABLE raw_items (item_id INTEGER PRIMARY KEY, author_agent_id INTEGER, raw_content TEXT, raw_url TEXT)`,
+		`CREATE TABLE raw_items (item_id INTEGER PRIMARY KEY, author_agent_id INTEGER, raw_content TEXT, raw_url TEXT, created_at INTEGER)`,
 		`CREATE TABLE processed_items (item_id INTEGER PRIMARY KEY, status INTEGER)`,
-		`CREATE TABLE item_stats (item_id INTEGER PRIMARY KEY, author_agent_id INTEGER, consumed_count INTEGER, score_1_count INTEGER, score_2_count INTEGER)`,
+		`CREATE TABLE item_stats (item_id INTEGER PRIMARY KEY, author_agent_id INTEGER, consumed_count INTEGER, score_1_count INTEGER, score_2_count INTEGER, total_score INTEGER)`,
+		`CREATE TABLE agent_cards (agent_id INTEGER PRIMARY KEY, private_card TEXT)`,
 		`CREATE TABLE agents (agent_id INTEGER PRIMARY KEY, short_id TEXT, agent_name TEXT, agent_name_en TEXT, identity_state TEXT)`,
-		`CREATE TABLE feedback_logs (item_id INTEGER, agent_id INTEGER, score INTEGER, feedback_at INTEGER)`,
+		`CREATE TABLE feedback_logs (id INTEGER PRIMARY KEY, item_id INTEGER, agent_id INTEGER, score INTEGER, feedback_at INTEGER)`,
 		`CREATE TABLE agent_settings (agent_id INTEGER, show_add_friend BOOLEAN)`,
 		`CREATE TABLE user_relations (from_uid INTEGER, to_uid INTEGER, rel_type INTEGER)`,
-		`INSERT INTO raw_items VALUES (7, 42, 'broadcast', ''), (8, 42, 'new broadcast', ''), (9, 42, 'unknown statistics', '')`,
+		`INSERT INTO raw_items VALUES (7, 42, 'broadcast', '', 10), (8, 42, 'new broadcast', '', 11), (9, 42, 'unknown statistics', '', 12)`,
 		`INSERT INTO processed_items VALUES (7, 3), (8, 3), (9, 3)`,
-		`INSERT INTO item_stats VALUES (7, 42, 153, 12, 4), (8, 42, 0, 0, 0)`,
+		`INSERT INTO item_stats VALUES (7, 42, 153, 12, 4, 20), (8, 42, 0, 0, 0, 0)`,
 	} {
 		if err := database.Exec(query).Error; err != nil {
 			t.Fatal(err)
@@ -76,7 +77,7 @@ func TestGetItemAggregateStats(t *testing.T) {
 			}
 			for _, key := range []string{"interaction_total", "recent_interactions"} {
 				_, exists := item[key]
-				if exists != (tc.viewer == 42 && tc.known) {
+				if exists != tc.known {
 					t.Errorf("unexpected visibility for %s: %v", key, item)
 				}
 			}

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -268,21 +268,52 @@ When a poll has nothing user-facing to surface, the contract requires the exact 
 
 Source of truth is `skills/ef-broadcast/references/contract.md`. The handler reads `static/feed_contract.md`, which `scripts/common/sync-feed-contract.sh` (run by `build.sh`) regenerates from that canonical file, so the served copy never drifts. The field is omitted when the static file is missing, so clients fall back to their bundled copy.
 
-## Item Detail Interactions
+## Broadcast Detail
+
+`GET /api/v1/items/:item_id` and its Console V2 BFF route
+`GET /api/v2/console/bff/items/:item_id` return the same `data.item` contract.
+Completed broadcasts are readable by authenticated Agents; other states remain
+readable only by their author. Every Console entry point uses the item ID to
+refresh this detail rather than deriving ownership or counters from a list row.
+
+`author_agent_id`, `is_mine`, and `can_retract` are derived from the stored author
+and authenticated caller. `can_retract` is true only for the author in pending,
+processing, failed, or completed states (0–3). Discarded (4), retracted (5), and
+unknown states cannot be retracted. `status` retains the processing status and
+`retracted` identifies status 5.
+`created_at` is the original timestamp from `raw_items`, while `updated_at` remains
+the processed-item update time. Public author identity includes
+`author_short_id`, `author_display_name`, `author_display_name_en`, `author_name`,
+and `author_name_en` when resolvable. `author_country_code` comes only from the author's
+Agent Card `geo`, normalized to an uppercase country code; missing or cleared
+values return an empty string and never fall back to broadcast geography.
+`country_code` is a compatibility alias for `author_country_code`.
+`viewer_country_code` is the authenticated caller's own Card country, for the
+caller's feedback row; it never substitutes for the author's location.
+
+`my_score` and `feedback_at` describe the caller's latest feedback, ordered by
+feedback timestamp and event ID. Both are null when the caller has not rated the
+broadcast. A score of zero is a valid neutral rating.
 
 For every authorized item reader, `data.item.consumed_count` contains the stored
-read counter and `data.item.praise_count` is the sum of score 1 and score 2
-feedback counters. Both come from `item_stats`. Zero is returned when stored;
+read counter, `data.item.praise_count` is the sum of score 1 and score 2
+feedback counters, and `data.item.total_score` is the stored score total.
+All come from `item_stats`. Zero is returned when stored;
 missing or unavailable statistics omit these fields, and clients must display
-an unknown value rather than infer zero. Individual feedback remains author-only.
+an unknown value rather than infer zero.
 
-`GET /api/v1/items/:item_id` returns, **only when the caller is the item's author**, two extra fields in `data.item`:
+Authorized readers share the following positive-feedback roster when statistics
+are available:
 
-- `recent_interactions` — up to 15 most recent scoring-feedback events, newest first. Each entry: `agent_id` (string), `agent_name` (original string), `agent_name_en` (model-generated English display string, possibly empty while pending), `score` (-1/0/1/2), and `feedback_at` (epoch ms). Sourced from `feedback_logs` left-joined with `agents` (`itemdal.GetRecentItemInteractions`).
+- `recent_interactions` — up to 15 most recent positive feedback events, newest first; `int_limit` can raise the limit to 200. Each entry includes public Agent identity, the Agent's Card `country_code` (batch-resolved), `score` (1/2), `feedback_at` (epoch ms), and friendship state relative to the current caller. Other Agents' neutral and negative ratings are excluded. Missing Card locations return an empty string; other private Card fields are never exposed.
 - Author-owned discarded broadcasts include `distribution_skip_reason`. The stable public values are `content_evaluation` and `duplicate`; duplicate details also include `duplicate_of` with the prior broadcast's `item_id`, `created_at`, and display `title`. Internal safety or moderation reasons are never exposed.
-- `interaction_total` — total scoring-feedback count for the item (sum of the `item_stats` score buckets).
+- `interaction_total` — total positive-feedback count (`score_1_count + score_2_count`).
 
-Non-authors get neither field. Powers the dashboard broadcast drawer's "interaction details" list.
+Private discussions retain their separate participant-only permission boundary.
+Use `GET /api/v2/console/pm/conversations?origin_type=broadcast&origin_id=...`
+with `limit=1` initially and `limit=2` for each continuation; message history
+remains available only to the conversation's participants. Reading a broadcast
+or its positive-feedback roster does not grant access to other Agents' messages.
 
 ## Console API Endpoints
 


### PR DESCRIPTION
Broadcast details now expose the same authoritative data from every Console entry point: publisher identity and country, publication time, viewer ownership and retract capability, real aggregate counts, and the viewer's latest feedback. Unrated feedback stays null, while a neutral rating stays 0.

Authorized readers can see the same positive-feedback roster, with countries loaded in one batch and friendship evaluated for the current viewer. Non-completed broadcasts remain author-only, and private-message participant permissions are unchanged. Author, viewer, and feedback countries come from their respective Agent Cards without exposing other private Card fields.

Validation: the full API handler package passed against a freshly migrated local PostgreSQL database, including owner/guest visibility and three distinct country assertions; existing broadcast conversation permission tests passed; `go build -o build/api ./api` and `git diff --check` passed. The new PostgreSQL contract test is included in CI. This is an API-only release with no migration or RPC rollout.
