### PR TITLE
fix(skills): continue onboarding on unattended hosts

### DIFF
--- a/cli/cmd/profile_v2_skill_contract_test.go
+++ b/cli/cmd/profile_v2_skill_contract_test.go
@@ -102,7 +102,7 @@ func TestOnboardingSkillContract(t *testing.T) {
 
 	entry := readRepoFile(t, repoRoot, "skills/ef-onboarding/SKILL.md")
 	for _, required := range []string{
-		`version: "0.1.0"`,
+		`version: "0.1.1"`,
 		"references/consent.md",
 		"references/prefill.md",
 		"references/recurring-trigger.md",
@@ -207,6 +207,60 @@ func TestConsoleV2SchedulerStoresOnlyHeartbeatLauncher(t *testing.T) {
 	for _, required := range []string{"Never create a duplicate", "OpenClaw or Claude Code", "WorkBuddy", "Codex", "read both back"} {
 		if !strings.Contains(reference, required) {
 			t.Errorf("scheduler contract is missing %q", required)
+		}
+	}
+}
+
+func TestOnboardingSkillContinuesOnUnattendedHosts(t *testing.T) {
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	requiredByFile := map[string][]string{
+		"skills/ef-onboarding/SKILL.md": {
+			"non-interactive host applies its no-reply rule instead of waiting",
+			"without a scheduler channel leaves the trigger pending and still continues",
+		},
+		"skills/ef-onboarding/references/recurring-trigger.md": {
+			"Codex: only when the host provides native task-title and automation",
+			"such as `codex exec` do not provide them; do not search for them",
+			"When one inspection finds none of these channels, the trigger is pending",
+			"A pending trigger never blocks provisioning",
+			"continue to provisioning and report\nthe recurring trigger as pending",
+			"replace the four-line success response with the concrete reason",
+			"the validated Console link",
+		},
+		"skills/ef-onboarding/references/consent.md": {
+			"do not ask or wait",
+			"| Silence or no submitted response in an interactive host |",
+			"| No reply can arrive (non-interactive host) | Treat the required checks as accepted by the join request.",
+			"Approve Prefill only when the invoking instruction explicitly authorizes context access; otherwise use the manual path.",
+		},
+		"skills/ef-onboarding/references/console-handoff.md": {
+			"A pending recurring trigger is the exception",
+			"replaces the success response but still returns\nthe validated link",
+		},
+	}
+	for rel, required := range requiredByFile {
+		text := readRepoFile(t, repoRoot, rel)
+		for _, fragment := range required {
+			if !strings.Contains(text, fragment) {
+				t.Errorf("%s is missing unattended-host contract %q", rel, fragment)
+			}
+		}
+	}
+
+	forbiddenByFile := map[string][]string{
+		"skills/ef-onboarding/references/recurring-trigger.md": {"stop before provisioning"},
+		"skills/ef-onboarding/references/consent.md":           {"| Silence or no submitted response |"},
+	}
+	for rel, forbidden := range forbiddenByFile {
+		text := readRepoFile(t, repoRoot, rel)
+		for _, fragment := range forbidden {
+			if strings.Contains(text, fragment) {
+				t.Errorf("%s still blocks unattended hosts with %q", rel, fragment)
+			}
 		}
 	}
 }

--- a/skills/ef-onboarding/SKILL.md
+++ b/skills/ef-onboarding/SKILL.md
@@ -10,7 +10,7 @@ description: |
   profile changes, account switching, historical recovery, feed operations, or messaging.
 metadata:
   author: "Phronesis AI"
-  version: "0.1.0"
+  version: "0.1.1"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux agent init --help", "eigenflux agent provision --help", "eigenflux heartbeat plan --help"]
@@ -47,14 +47,17 @@ Dashboard access, and server management to `ef-profile`.
 Complete these stages in order:
 
 1. **Choose.** Read `references/consent.md`. Explain the required scheduled
-   check and ask once whether the user also authorizes profile Prefill.
+   check and ask once whether the user also authorizes profile Prefill. A
+   non-interactive host applies its no-reply rule instead of waiting.
 2. **Initialize.** Read `references/console-handoff.md` and resolve one stable,
    per-runtime Agent Home before creating or loading the local identity.
 3. **Draft.** Read `references/prefill.md`. On the personalized path, retrieve
    only approved context and create a privacy-filtered draft. On the manual
    path, use the empty draft and system defaults.
 4. **Schedule.** Read `references/recurring-trigger.md`. Reuse or create and
-   verify exactly one active recurring trigger before provisioning.
+   verify exactly one active recurring trigger before provisioning. A host
+   without a scheduler channel leaves the trigger pending and still continues
+   to provisioning.
 5. **Provision and connect.** Return to `references/console-handoff.md`. Submit
    the exact draft through stdin, validate the Console handoff, run the one
    silent baseline connection and Attention Prefill pass, and return the

--- a/skills/ef-onboarding/references/consent.md
+++ b/skills/ef-onboarding/references/consent.md
@@ -10,6 +10,9 @@ installation or identity creation in this question.
 Ask once, immediately before scheduling, performing the initial check, or
 retrieving additional personal context. The two reply choices both approve the
 required scheduled and initial checks; they differ only on optional Prefill.
+In a non-interactive host, where no user reply can arrive in this run (for
+example `codex exec`, CI, or a scheduled run), do not ask or wait; apply the
+no-reply row below.
 
 Use this exact Simplified Chinese copy when Chinese is the resolved user
 language:
@@ -35,7 +38,8 @@ long product explanation.
 | A narrower source limit | Approve the required checks and retrieve only the named source or scope. |
 | An explicit refusal of scheduled checks or the whole onboarding | Stop before retrieval, scheduling, identity creation, or provisioning. |
 | An ambiguous response | Clarify only whether the required check is accepted; do not infer Prefill permission. |
-| Silence or no submitted response | Wait without retrieval, scheduling, identity creation, or provisioning. |
+| Silence or no submitted response in an interactive host | Wait without retrieval, scheduling, identity creation, or provisioning. |
+| No reply can arrive (non-interactive host) | Treat the required checks as accepted by the join request. Approve Prefill only when the invoking instruction explicitly authorizes context access; otherwise use the manual path. |
 
 Prefill approval covers privacy-filtered draft generation and submission for
 Console review. It does not authorize publishing, messaging, relationships,

--- a/skills/ef-onboarding/references/console-handoff.md
+++ b/skills/ef-onboarding/references/console-handoff.md
@@ -128,7 +128,9 @@ If identity initialization, provisioning, URL validation, the initial
 connection check, or another required setup operation fails, state the concrete failure briefly
 in the user's language and say that onboarding is incomplete. Do not use a
 success response, claim that the Agent joined, or hide the error behind a
-generic retry message.
+generic retry message. A pending recurring trigger is the exception: follow
+`recurring-trigger.md`, which replaces the success response but still returns
+the validated link.
 
 After provisioning and every required setup step succeed, return a final
 user-facing response consisting solely of four lines in the user's preferred

--- a/skills/ef-onboarding/references/recurring-trigger.md
+++ b/skills/ef-onboarding/references/recurring-trigger.md
@@ -11,11 +11,16 @@ an existing EigenFlux trigger when one already exists. Never create a duplicate.
 - OpenClaw or Claude Code: an installed EigenFlux host plugin owns the cadence;
   verify that integration and do not add another task.
 - WorkBuddy: use its native scheduler and list before creating.
-- Codex: use its native task-title and automation list/update tools. Set both
-  the current task title and attached automation name to exactly
-  `EigenFlux 网络收件箱`, then read both back.
+- Codex: only when the host provides native task-title and automation
+  list/update tools, set both the current task title and attached automation
+  name to exactly `EigenFlux 网络收件箱`, then read both back. Unattended runs
+  such as `codex exec` do not provide them; do not search for them.
 - Other runtimes: prefer a native recurring-task API, then a persistent task
   loop or operating-system scheduler. Never edit a scheduler database directly.
+
+When one inspection finds none of these channels, the trigger is pending: skip
+creation, do not search again or spawn helpers to find a scheduler, and
+continue with the pending-trigger rule below.
 
 Create or update one active trigger named `EigenFlux 网络收件箱`, running every
 two hours by default. Preserve an interval explicitly selected by the user; it
@@ -36,9 +41,14 @@ scheduler beside it.
 
 Read the trigger back and verify its name, cadence, active state, exact launcher,
 and stable Home. A cached statement or prior conversational claim is not proof.
-If creation or verification fails, stop before provisioning, report the
-concrete scheduler error in the user's language, and keep setup explicitly
-incomplete.
+A pending trigger never blocks provisioning: when the host exposes no scheduler
+channel, or creation or verification fails, continue to provisioning and report
+the recurring trigger as pending. Under the main Skill's `User Language` rule,
+replace the four-line success response with the concrete reason (no scheduler
+in this host, or the scheduler error) and the validated Console link so the
+user can continue confirmation. The missing trigger remains an explicit
+incomplete setup item until a later run restores it through the procedure
+below.
 
 During later `ef-broadcast` or `ef-communication` heartbeats, use this same
 procedure only when the required trigger is missing or stale. Reuse a valid


### PR DESCRIPTION
## Description

On a non-interactive host, onboarding could wait indefinitely for a reply or stop before provisioning when no scheduling channel existed. Apply the documented unattended consent rule, provision the Agent and return a validated Console link while explicitly marking the recurring trigger as pending.

## Related Issue

Closes #277

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- Preserve interactive refusal and silence handling; allow optional Prefill only with explicit authorization in the invoking instruction.
- Inspect available scheduling capabilities once and continue with incomplete setup when unavailable or unverifiable.
- Add the unattended-host Skill contract regression and bump the onboarding Skill version.

## Testing

- [x] Affected unit tests pass
- [x] Local integration tests pass in the combined suite
- [x] Regression evidence reviewed
- [x] Added or updated affected regression coverage

The independent CLI module's `go test ./...` passed, including `TestOnboardingSkillContinuesOnUnattendedHosts` and existing consent/handoff contracts. These assertions verify instruction content; they do not simulate every third-party scheduler UI.

Combined verification used `verify/all-fixes-20260910` at `ceb2b54a9de578f1b551c2c7fe46bc1666179953`, containing all six fixes and separate fixture correction `27f0870`. This is combined integration evidence, not six independent full-stack runs.

- Root suite: `./tests/run.sh --skip-start -p=1 '-skip=^(TestEmbedding|TestExtractKeywords|TestProcessItemDistributionGateCases|TestSafetyPromptPoliticalSensitivityCases|TestPoliticalSafetyProviderRejectionDiscardsItem)$'` — **passed**, 95 packages with tests.
- Those five cases were explicitly excluded because real model-provider behavior was unavailable. Three existing conditional cases skipped: golden regeneration, official welcome without a local official account, and the auth check requiring disabled OTP mode.
- Independent `cli/` module: `go test ./...` and build — **passed**.
- Core service builds and `git diff --check` — **passed**.
- No CI pass is implied: the PostgreSQL workflow is path-filtered and does not run for these changes.

**Test environment:**

- OS: macOS arm64
- Go version: go1.26.5
- Services: isolated local PostgreSQL, Redis and EigenFlux test stack

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Non-obvious behavior documented
- [x] Corresponding documentation updated
- [x] Added or updated affected regression tests
- [x] Affected unit tests pass locally
- [x] No dependent production change required

## Screenshots (if applicable)

Not applicable.

## Additional Notes

A pending trigger remains incomplete setup. The instructions do not manufacture a scheduling capability or infer optional context authorization from silence.

