### PR TITLE
fix(pm): return client errors for relation state mismatches

### DIFF
--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -67,6 +67,7 @@ remains backward compatible.
 ## Key Behaviors
 
 - Bidirectional block checking — sends to blocked users return silent success (no error exposed)
+- Relation state mismatches are client errors with fixed messages, mapped from `rpc/pm/dal` sentinels: `Unfriend` without a friendship returns code 400 `not friends` (`ErrNotFriends`), `UnblockUser` without a block returns code 400 `not blocked` (`ErrNotBlocked`), and `BlockUser` on an already blocked agent returns code 409 `already blocked` (`ErrAlreadyBlocked`, the existing row and remark are kept). Blocking removes any existing friendship and cancels pending requests in both directions; unblocking does not restore the friendship. Any other DAL error is logged and returned as a generic code 500 message
 - Items with `no_reply` flag disable incoming conversations from non-owners
 - Friend request notifications stored in Redis `pm:notify:{agent_id}` (HASH, 7-day TTL), read/deleted by notification service. New friend requests also publish to `pm:push:{receiverID}` for real-time WebSocket delivery
 - Auto-accept (mutual pending requests) writes a `friend_accepted` notification to `pm:notify:{originalRequesterID}` and publishes `friend_accepted:{friendUID}` to `pm:push:{originalRequesterID}` for real-time WebSocket delivery

--- a/docs/pm_relations_design.md
+++ b/docs/pm_relations_design.md
@@ -243,7 +243,13 @@ POST /api/v1/relations/block
 
 - Creates block relation (one-way)
 - Invalidates block cache
-- If already friends, friendship remains (block is separate)
+- Removes any existing friendship (both relation rows) and cancels pending requests in both directions
+- Returns code 409 `already blocked` when the block already exists; the existing row is kept
+
+**Unblocking** (`POST /api/v1/relations/unblock`):
+- Deletes the caller's block row
+- Returns code 400 `not blocked` when no block exists
+- Does not restore a previous friendship
 
 **Silent Rejection**:
 When blocked user sends friend request:
@@ -288,6 +294,7 @@ POST /api/v1/relations/unfriend
 - Deletes both symmetric relation rows
 - Updates original friend request status to `unfriended`
 - Invalidates friend cache for both users
+- Returns code 400 `not friends` when no friendship exists (including after a block)
 
 ### 4.4 Email-Based Friend Requests
 

--- a/rpc/pm/dal/relations.go
+++ b/rpc/pm/dal/relations.go
@@ -21,6 +21,15 @@ const (
 	RequestStatusUnfriended = 4
 )
 
+var (
+	// ErrNotFriends reports that no friend relation exists between the two agents.
+	ErrNotFriends = errors.New("not friends")
+	// ErrNotBlocked reports that the caller has not blocked the target agent.
+	ErrNotBlocked = errors.New("not blocked")
+	// ErrAlreadyBlocked reports that the caller has already blocked the target agent.
+	ErrAlreadyBlocked = errors.New("already blocked")
+)
+
 type UserRelation struct {
 	ID        int64  `gorm:"column:id;primaryKey"`
 	FromUID   int64  `gorm:"column:from_uid;not null"`
@@ -172,19 +181,25 @@ func CreateFriendRelation(tx *gorm.DB, uidA, uidB int64, remarkByA, remarkByB st
 }
 
 // DeleteFriendRelation deletes 2 symmetric friend relation rows in a transaction.
+// It returns ErrNotFriends when no friend relation exists between the two agents.
 func DeleteFriendRelation(tx *gorm.DB, uidA, uidB int64) error {
 	result := tx.Where("((from_uid = ? AND to_uid = ?) OR (from_uid = ? AND to_uid = ?)) AND rel_type = ?",
 		uidA, uidB, uidB, uidA, RelTypeFriend).Delete(&UserRelation{})
 	if result.Error != nil {
 		return result.Error
 	}
+	if result.RowsAffected == 0 {
+		return ErrNotFriends
+	}
 	if result.RowsAffected != 2 {
-		return errors.New("expected to delete 2 friend relation rows")
+		return fmt.Errorf("expected to delete 2 friend relation rows, deleted %d", result.RowsAffected)
 	}
 	return nil
 }
 
 // CreateBlockRelation creates a block relation row with optional remark.
+// It returns ErrAlreadyBlocked, leaving the existing row untouched, when
+// fromUID has already blocked toUID.
 func CreateBlockRelation(tx *gorm.DB, fromUID, toUID int64, remark string) error {
 	now := time.Now().UnixMilli()
 	rel := &UserRelation{
@@ -194,10 +209,18 @@ func CreateBlockRelation(tx *gorm.DB, fromUID, toUID int64, remark string) error
 		CreatedAt: now,
 		Remark:    remark,
 	}
-	return tx.Create(rel).Error
+	result := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(rel)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrAlreadyBlocked
+	}
+	return nil
 }
 
 // DeleteBlockRelation deletes a block relation row.
+// It returns ErrNotBlocked when fromUID has not blocked toUID.
 func DeleteBlockRelation(tx *gorm.DB, fromUID, toUID int64) error {
 	result := tx.Where("from_uid = ? AND to_uid = ? AND rel_type = ?", fromUID, toUID, RelTypeBlock).
 		Delete(&UserRelation{})
@@ -205,7 +228,7 @@ func DeleteBlockRelation(tx *gorm.DB, fromUID, toUID int64) error {
 		return result.Error
 	}
 	if result.RowsAffected == 0 {
-		return errors.New("block relation not found")
+		return ErrNotBlocked
 	}
 	return nil
 }

--- a/rpc/pm/dal/relations_test.go
+++ b/rpc/pm/dal/relations_test.go
@@ -1,0 +1,113 @@
+package dal
+
+import (
+	"errors"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newRelationsTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mirrors migrations/000009_add_user_relations.sql, including uq_relation.
+	if err := db.Exec(`CREATE TABLE user_relations (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		from_uid INTEGER NOT NULL,
+		to_uid INTEGER NOT NULL,
+		rel_type INTEGER NOT NULL,
+		remark TEXT NOT NULL DEFAULT '',
+		created_at INTEGER NOT NULL,
+		CONSTRAINT uq_relation UNIQUE (from_uid, to_uid, rel_type))`).Error; err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func countRelations(t *testing.T, db *gorm.DB, fromUID, toUID int64, relType int16) int64 {
+	t.Helper()
+	var n int64
+	if err := db.Model(&UserRelation{}).
+		Where("from_uid = ? AND to_uid = ? AND rel_type = ?", fromUID, toUID, relType).
+		Count(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func TestDeleteFriendRelation_NotFriends(t *testing.T) {
+	db := newRelationsTestDB(t)
+
+	if err := DeleteFriendRelation(db, 10, 20); !errors.Is(err, ErrNotFriends) {
+		t.Fatalf("expected ErrNotFriends, got %v", err)
+	}
+	if err := DeleteFriendRelation(db, 10, 10); !errors.Is(err, ErrNotFriends) {
+		t.Fatalf("expected ErrNotFriends for self target, got %v", err)
+	}
+}
+
+func TestDeleteFriendRelation_RemovesBothRows(t *testing.T) {
+	db := newRelationsTestDB(t)
+	if err := CreateFriendRelation(db, 10, 20, "b", "a"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteFriendRelation(db, 20, 10); err != nil {
+		t.Fatalf("expected friend relation delete to succeed, got %v", err)
+	}
+	if n := countRelations(t, db, 10, 20, RelTypeFriend) + countRelations(t, db, 20, 10, RelTypeFriend); n != 0 {
+		t.Fatalf("expected both friend rows deleted, %d remain", n)
+	}
+	if err := DeleteFriendRelation(db, 10, 20); !errors.Is(err, ErrNotFriends) {
+		t.Fatalf("expected ErrNotFriends after deletion, got %v", err)
+	}
+}
+
+func TestCreateBlockRelation_AlreadyBlocked(t *testing.T) {
+	db := newRelationsTestDB(t)
+	if err := CreateBlockRelation(db, 10, 20, "spam"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CreateBlockRelation(db, 10, 20, "again"); !errors.Is(err, ErrAlreadyBlocked) {
+		t.Fatalf("expected ErrAlreadyBlocked, got %v", err)
+	}
+	if n := countRelations(t, db, 10, 20, RelTypeBlock); n != 1 {
+		t.Fatalf("expected a single block row, got %d", n)
+	}
+	var rel UserRelation
+	if err := db.Where("from_uid = ? AND to_uid = ? AND rel_type = ?", 10, 20, RelTypeBlock).First(&rel).Error; err != nil {
+		t.Fatal(err)
+	}
+	if rel.Remark != "spam" {
+		t.Fatalf("expected the original remark to be kept, got %q", rel.Remark)
+	}
+	// The reverse direction is a distinct relation and is not a conflict.
+	if err := CreateBlockRelation(db, 20, 10, ""); err != nil {
+		t.Fatalf("expected reverse block to succeed, got %v", err)
+	}
+}
+
+func TestDeleteBlockRelation_NotBlocked(t *testing.T) {
+	db := newRelationsTestDB(t)
+
+	if err := DeleteBlockRelation(db, 10, 20); !errors.Is(err, ErrNotBlocked) {
+		t.Fatalf("expected ErrNotBlocked, got %v", err)
+	}
+	if err := CreateBlockRelation(db, 10, 20, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteBlockRelation(db, 20, 10); !errors.Is(err, ErrNotBlocked) {
+		t.Fatalf("expected ErrNotBlocked for the reverse direction, got %v", err)
+	}
+	if err := DeleteBlockRelation(db, 10, 20); err != nil {
+		t.Fatalf("expected unblock to succeed, got %v", err)
+	}
+	if err := DeleteBlockRelation(db, 10, 20); !errors.Is(err, ErrNotBlocked) {
+		t.Fatalf("expected ErrNotBlocked after deletion, got %v", err)
+	}
+}

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -1170,7 +1170,11 @@ func (s *PMServiceImpl) Unfriend(ctx context.Context, req *pm.UnfriendReq) (*pm.
 			Update("status", dal.RequestStatusUnfriended).Error
 	})
 	if err != nil {
-		return &pm.UnfriendResp{BaseResp: &base.BaseResp{Code: 500, Msg: err.Error()}}, nil
+		if errors.Is(err, dal.ErrNotFriends) {
+			return &pm.UnfriendResp{BaseResp: &base.BaseResp{Code: 400, Msg: err.Error()}}, nil
+		}
+		logger.Ctx(ctx).Error("Unfriend failed", "fromUID", req.FromUid, "toUID", req.ToUid, "err", err)
+		return &pm.UnfriendResp{BaseResp: &base.BaseResp{Code: 500, Msg: "failed to unfriend"}}, nil
 	}
 	_ = relations.InvalidateFriendCache(ctx, db.RDB, req.FromUid)
 	_ = relations.InvalidateFriendCache(ctx, db.RDB, req.ToUid)
@@ -1228,7 +1232,11 @@ func (s *PMServiceImpl) BlockUser(ctx context.Context, req *pm.BlockUserReq) (*p
 		return nil
 	})
 	if err != nil {
-		return &pm.BlockUserResp{BaseResp: &base.BaseResp{Code: 500, Msg: err.Error()}}, nil
+		if errors.Is(err, dal.ErrAlreadyBlocked) {
+			return &pm.BlockUserResp{BaseResp: &base.BaseResp{Code: 409, Msg: err.Error()}}, nil
+		}
+		logger.Ctx(ctx).Error("BlockUser failed", "fromUID", req.FromUid, "toUID", req.ToUid, "err", err)
+		return &pm.BlockUserResp{BaseResp: &base.BaseResp{Code: 500, Msg: "failed to block"}}, nil
 	}
 	_ = db.RDB.SAdd(ctx, fmt.Sprintf("block:%d", req.FromUid), req.ToUid)
 	_ = relations.InvalidateFriendCache(ctx, db.RDB, req.FromUid)
@@ -1254,7 +1262,11 @@ func (s *PMServiceImpl) UnblockUser(ctx context.Context, req *pm.UnblockUserReq)
 			Update("status", dal.RequestStatusCancelled).Error
 	})
 	if err != nil {
-		return &pm.UnblockUserResp{BaseResp: &base.BaseResp{Code: 500, Msg: err.Error()}}, nil
+		if errors.Is(err, dal.ErrNotBlocked) {
+			return &pm.UnblockUserResp{BaseResp: &base.BaseResp{Code: 400, Msg: err.Error()}}, nil
+		}
+		logger.Ctx(ctx).Error("UnblockUser failed", "fromUID", req.FromUid, "toUID", req.ToUid, "err", err)
+		return &pm.UnblockUserResp{BaseResp: &base.BaseResp{Code: 500, Msg: "failed to unblock"}}, nil
 	}
 	_ = db.RDB.SRem(ctx, fmt.Sprintf("block:%d", req.FromUid), req.ToUid)
 	logger.Ctx(ctx).Info("UnblockUser done", "fromUID", req.FromUid, "toUID", req.ToUid)

--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -21,7 +21,7 @@ description: |
   Do NOT use before completing authentication and onboarding (see ef-onboarding skill).
 metadata:
   author: "Phronesis AI"
-  version: "0.3.4"
+  version: "0.3.5"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux msg --help", "eigenflux relation --help", "eigenflux stream --help"]

--- a/skills/ef-communication/references/relations.md
+++ b/skills/ef-communication/references/relations.md
@@ -179,6 +179,8 @@ eigenflux relation unfriend --uid AGENT_ID
 
 Removes the friendship in both directions. After unfriending, direct friend-based messaging is no longer available.
 
+Returns code 400 `not friends` when there is no friendship to remove — including after either side blocked the other, because blocking already removed the friendship. Treat it as final; do not retry.
+
 ## Block an Agent
 
 ```bash
@@ -193,13 +195,17 @@ Blocking an agent:
 - Prevents you from sending them friend requests or messages
 - The blocked agent is **not notified** — their messages silently fail
 
+Blocking an agent you already blocked returns code 409 `already blocked` and changes nothing; the original remark is kept.
+
 ## Unblock an Agent
 
 ```bash
 eigenflux relation unblock --uid AGENT_ID
 ```
 
-Unblocking does not restore a previous friendship. A new friend request is needed to reconnect.
+Returns code 400 `not blocked` when you have not blocked this agent.
+
+Unblocking does not restore a previous friendship, so a later `unfriend` returns `not friends`. A new friend request is needed to reconnect.
 
 ## Notifications
 

--- a/tests/pm/block_concurrent_test.go
+++ b/tests/pm/block_concurrent_test.go
@@ -1,0 +1,112 @@
+package pm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"eigenflux_server/tests/testutil"
+)
+
+func TestBlockUser_ConcurrentDuplicateReturnsClientError(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"concurrent_block_a@test.com", "concurrent_block_b@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+
+	agentA := testutil.RegisterAgent(t, emails[0], "Concurrent Block A", "bio")
+	agentB := testutil.RegisterAgent(t, emails[1], "Concurrent Block B", "bio")
+	uidA := testutil.MustID(t, agentA["agent_id"], "agent_id")
+	uidB := testutil.MustID(t, agentB["agent_id"], "agent_id")
+	defer cleanRelationsData(t, uidA, uidB)
+
+	type blockResult struct {
+		remark string
+		status int
+		code   int
+		msg    string
+		err    error
+	}
+	start := make(chan struct{})
+	results := make(chan blockResult, 2)
+	client := &http.Client{Timeout: 15 * time.Second}
+	for _, remark := range []string{"first contender", "second contender"} {
+		body, err := json.Marshal(map[string]string{
+			"to_uid": agentB["agent_id"].(string),
+			"remark": remark,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := http.NewRequest(http.MethodPost, testutil.BaseURL+"/api/v1/relations/block", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+agentA["token"].(string))
+		go func(remark string, req *http.Request) {
+			<-start
+			result := blockResult{remark: remark}
+			defer func() { results <- result }()
+			resp, err := client.Do(req)
+			if err != nil {
+				result.err = err
+				return
+			}
+			defer resp.Body.Close()
+			result.status = resp.StatusCode
+			var payload struct {
+				Code int    `json:"code"`
+				Msg  string `json:"msg"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+				result.err = fmt.Errorf("decode block response: %w", err)
+				return
+			}
+			result.code, result.msg = payload.Code, payload.Msg
+		}(remark, req)
+	}
+	close(start)
+
+	responses := []blockResult{<-results, <-results}
+	successes, conflicts := 0, 0
+	winningRemark := ""
+	for _, result := range responses {
+		if result.err != nil {
+			t.Fatalf("%s failed: %v", result.remark, result.err)
+		}
+		if result.status != http.StatusOK {
+			t.Fatalf("%s HTTP status=%d, want 200; code=%d msg=%q", result.remark, result.status, result.code, result.msg)
+		}
+		switch result.code {
+		case 0:
+			successes++
+			winningRemark = result.remark
+		case 409:
+			conflicts++
+			if result.msg != "already blocked" {
+				t.Fatalf("duplicate block message=%q, want fixed client message", result.msg)
+			}
+		default:
+			t.Fatalf("%s code=%d msg=%q, want success or duplicate-block client error", result.remark, result.code, result.msg)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent blocks: successes=%d conflicts=%d, want one of each", successes, conflicts)
+	}
+
+	var count int
+	var storedRemark string
+	err := testutil.TestDB.QueryRow(
+		"SELECT COUNT(*), MIN(remark) FROM user_relations WHERE from_uid = $1 AND to_uid = $2 AND rel_type = 2",
+		uidA, uidB,
+	).Scan(&count, &storedRemark)
+	if err != nil {
+		t.Fatalf("read persisted block: %v", err)
+	}
+	if count != 1 || storedRemark != winningRemark {
+		t.Fatalf("persisted blocks=%d remark=%q, want one block with winning remark %q", count, storedRemark, winningRemark)
+	}
+}

--- a/tests/pm/relations_test.go
+++ b/tests/pm/relations_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2305,4 +2306,216 @@ func TestBroadcastConv_UnfriendReactivatesIceBreak(t *testing.T) {
 		t.Fatalf("Expected 429 after unfriend (ice-break reactivated), got code=%d msg=%v", code, resp["msg"])
 	}
 	t.Logf("Ice-break correctly reactivated after unfriend")
+}
+
+// befriend sends a friend request from agentA to agentB and accepts it as agentB.
+func befriend(t *testing.T, agentA, agentB map[string]interface{}) {
+	t.Helper()
+	applyResp := testutil.DoPost(t, "/api/v1/relations/apply", map[string]string{
+		"to_uid": agentB["agent_id"].(string),
+	}, agentA["token"].(string))
+	if code := int(applyResp["code"].(float64)); code != 0 {
+		t.Fatalf("friend request failed: code=%d msg=%v", code, applyResp["msg"])
+	}
+	requestID := applyResp["data"].(map[string]interface{})["request_id"].(string)
+	acceptResp := testutil.DoPost(t, "/api/v1/relations/handle", map[string]interface{}{
+		"request_id": requestID,
+		"action":     1,
+	}, agentB["token"].(string))
+	if code := int(acceptResp["code"].(float64)); code != 0 {
+		t.Fatalf("accept failed: code=%d msg=%v", code, acceptResp["msg"])
+	}
+}
+
+func countFriendRows(t *testing.T, uidA, uidB int64) int64 {
+	t.Helper()
+	var count int64
+	err := testutil.TestDB.QueryRow(
+		"SELECT COUNT(*) FROM user_relations WHERE ((from_uid = $1 AND to_uid = $2) OR (from_uid = $2 AND to_uid = $1)) AND rel_type = 1",
+		uidA, uidB,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count friend rows: %v", err)
+	}
+	return count
+}
+
+// Issue #278: unfriending an agent who is not a friend is a client error with
+// a fixed message, not a 500 carrying the DAL's internal row-count text.
+func TestUnfriend_NotFriends(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"unfriend_nf_a@test.com", "unfriend_nf_b@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+
+	agentA := testutil.RegisterAgent(t, emails[0], "UnfriendNF A", "bio")
+	agentB := testutil.RegisterAgent(t, emails[1], "UnfriendNF B", "bio")
+
+	uidA, _ := strconv.ParseInt(agentA["agent_id"].(string), 10, 64)
+	uidB, _ := strconv.ParseInt(agentB["agent_id"].(string), 10, 64)
+	defer cleanRelationsData(t, uidA, uidB)
+
+	resp := testutil.DoPost(t, "/api/v1/relations/unfriend", map[string]string{
+		"to_uid": agentB["agent_id"].(string),
+	}, agentA["token"].(string))
+	if code := int(resp["code"].(float64)); code != 400 {
+		t.Fatalf("expected code=400 for unfriend of non-friend, got code=%d msg=%v", code, resp["msg"])
+	}
+	if msg := resp["msg"]; msg != "not friends" {
+		t.Fatalf("expected msg=%q, got %v", "not friends", msg)
+	}
+}
+
+// Unfriending yourself has no relation to delete and is rejected the same way.
+// The general self-target guard for relation endpoints is tracked in #283.
+func TestUnfriend_Self(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"unfriend_self_a@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+
+	agentA := testutil.RegisterAgent(t, emails[0], "UnfriendSelf A", "bio")
+	uidA, _ := strconv.ParseInt(agentA["agent_id"].(string), 10, 64)
+	defer cleanRelationsData(t, uidA)
+
+	resp := testutil.DoPost(t, "/api/v1/relations/unfriend", map[string]string{
+		"to_uid": agentA["agent_id"].(string),
+	}, agentA["token"].(string))
+	if code := int(resp["code"].(float64)); code != 400 {
+		t.Fatalf("expected code=400 for self unfriend, got code=%d msg=%v", code, resp["msg"])
+	}
+	if msg := resp["msg"]; msg != "not friends" {
+		t.Fatalf("expected msg=%q, got %v", "not friends", msg)
+	}
+}
+
+func TestUnblockUser_NotBlocked(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"unblock_nb_a@test.com", "unblock_nb_b@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+
+	agentA := testutil.RegisterAgent(t, emails[0], "UnblockNB A", "bio")
+	agentB := testutil.RegisterAgent(t, emails[1], "UnblockNB B", "bio")
+
+	uidA, _ := strconv.ParseInt(agentA["agent_id"].(string), 10, 64)
+	uidB, _ := strconv.ParseInt(agentB["agent_id"].(string), 10, 64)
+	defer cleanRelationsData(t, uidA, uidB)
+
+	resp := testutil.DoPost(t, "/api/v1/relations/unblock", map[string]string{
+		"to_uid": agentB["agent_id"].(string),
+	}, agentA["token"].(string))
+	if code := int(resp["code"].(float64)); code != 400 {
+		t.Fatalf("expected code=400 for unblock without block, got code=%d msg=%v", code, resp["msg"])
+	}
+	if msg := resp["msg"]; msg != "not blocked" {
+		t.Fatalf("expected msg=%q, got %v", "not blocked", msg)
+	}
+}
+
+// Blocking twice must not surface the uq_relation constraint violation; the
+// second call is a fixed 409 and the original block row (and remark) is kept.
+func TestBlockUser_TwiceReturnsAlreadyBlocked(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"block_twice_a@test.com", "block_twice_b@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+
+	agentA := testutil.RegisterAgent(t, emails[0], "BlockTwice A", "bio")
+	agentB := testutil.RegisterAgent(t, emails[1], "BlockTwice B", "bio")
+
+	uidA, _ := strconv.ParseInt(agentA["agent_id"].(string), 10, 64)
+	uidB, _ := strconv.ParseInt(agentB["agent_id"].(string), 10, 64)
+	defer cleanRelationsData(t, uidA, uidB)
+
+	first := testutil.DoPost(t, "/api/v1/relations/block", map[string]interface{}{
+		"to_uid": agentB["agent_id"].(string),
+		"remark": "first",
+	}, agentA["token"].(string))
+	if code := int(first["code"].(float64)); code != 0 {
+		t.Fatalf("first block failed: code=%d msg=%v", code, first["msg"])
+	}
+
+	second := testutil.DoPost(t, "/api/v1/relations/block", map[string]interface{}{
+		"to_uid": agentB["agent_id"].(string),
+		"remark": "second",
+	}, agentA["token"].(string))
+	if code := int(second["code"].(float64)); code != 409 {
+		t.Fatalf("expected code=409 for repeated block, got code=%d msg=%v", code, second["msg"])
+	}
+	msg, _ := second["msg"].(string)
+	if msg != "already blocked" {
+		t.Fatalf("expected msg=%q, got %q", "already blocked", msg)
+	}
+	if strings.Contains(msg, "SQLSTATE") || strings.Contains(msg, "uq_relation") {
+		t.Fatalf("database error text leaked to client: %q", msg)
+	}
+
+	var count int64
+	var remark string
+	err := testutil.TestDB.QueryRow(
+		"SELECT COUNT(*), MIN(remark) FROM user_relations WHERE from_uid = $1 AND to_uid = $2 AND rel_type = 2",
+		uidA, uidB,
+	).Scan(&count, &remark)
+	if err != nil {
+		t.Fatalf("failed to query block rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 block row, got %d", count)
+	}
+	if remark != "first" {
+		t.Fatalf("expected original remark to be kept, got %q", remark)
+	}
+}
+
+// Blocking removes the friendship on purpose (TestBlockUser_RemovesFriendship)
+// and unblocking does not restore it, so a later unfriend finds nothing to
+// delete and is a client error rather than a 500.
+func TestUnfriend_AfterBlockUnblockCycle(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"unfriend_cycle_a@test.com", "unfriend_cycle_b@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+
+	agentA := testutil.RegisterAgent(t, emails[0], "UnfriendCycle A", "bio")
+	agentB := testutil.RegisterAgent(t, emails[1], "UnfriendCycle B", "bio")
+
+	uidA, _ := strconv.ParseInt(agentA["agent_id"].(string), 10, 64)
+	uidB, _ := strconv.ParseInt(agentB["agent_id"].(string), 10, 64)
+	defer cleanRelationsData(t, uidA, uidB)
+
+	befriend(t, agentA, agentB)
+	if n := countFriendRows(t, uidA, uidB); n != 2 {
+		t.Fatalf("expected 2 friend rows after accept, got %d", n)
+	}
+
+	blockResp := testutil.DoPost(t, "/api/v1/relations/block", map[string]string{
+		"to_uid": agentB["agent_id"].(string),
+	}, agentA["token"].(string))
+	if code := int(blockResp["code"].(float64)); code != 0 {
+		t.Fatalf("block failed: code=%d msg=%v", code, blockResp["msg"])
+	}
+	unblockResp := testutil.DoPost(t, "/api/v1/relations/unblock", map[string]string{
+		"to_uid": agentB["agent_id"].(string),
+	}, agentA["token"].(string))
+	if code := int(unblockResp["code"].(float64)); code != 0 {
+		t.Fatalf("unblock failed: code=%d msg=%v", code, unblockResp["msg"])
+	}
+	if n := countFriendRows(t, uidA, uidB); n != 0 {
+		t.Fatalf("expected friendship to stay removed after unblock, got %d rows", n)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		caller map[string]interface{}
+		target map[string]interface{}
+	}{
+		{"blocker unfriends", agentA, agentB},
+		{"blocked side unfriends", agentB, agentA},
+	} {
+		resp := testutil.DoPost(t, "/api/v1/relations/unfriend", map[string]string{
+			"to_uid": tc.target["agent_id"].(string),
+		}, tc.caller["token"].(string))
+		if code := int(resp["code"].(float64)); code != 400 {
+			t.Fatalf("%s: expected code=400 after block/unblock cycle, got code=%d msg=%v", tc.name, code, resp["msg"])
+		}
+		if msg := resp["msg"]; msg != "not friends" {
+			t.Fatalf("%s: expected msg=%q, got %v", tc.name, "not friends", msg)
+		}
+	}
 }


### PR DESCRIPTION
## Description

Removing a missing friendship or block, or repeating an existing block, surfaced internal errors. Return stable client-facing 400/409 errors for those states while unexpected database failures retain fixed public messages and server-side diagnostics.

## Related Issue

Closes #278

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- Introduce DAL sentinel errors and map expected state mismatches to client responses.
- Keep the pair lock and unique block constraint; duplicate attempts preserve the first block remark.
- Add sequential HTTP coverage and a real PostgreSQL concurrent duplicate-block test, with matching relation documentation and Skill updates.

## Testing

- [x] Affected unit tests pass
- [x] Local integration tests pass in the combined suite
- [x] Regression evidence reviewed
- [x] Added or updated affected regression coverage

`TestBlockUser_ConcurrentDuplicateReturnsClientError` passed through HTTP and PostgreSQL: two requests released together yield one success, one fixed 409 and one stored row preserving the winning remark. Affected DAL and HTTP relation tests also passed.

Combined verification used `verify/all-fixes-20260910` at `ceb2b54a9de578f1b551c2c7fe46bc1666179953`, containing all six fixes and separate fixture correction `27f0870`. This is combined integration evidence, not six independent full-stack runs.

- Root suite: `./tests/run.sh --skip-start -p=1 '-skip=^(TestEmbedding|TestExtractKeywords|TestProcessItemDistributionGateCases|TestSafetyPromptPoliticalSensitivityCases|TestPoliticalSafetyProviderRejectionDiscardsItem)$'` — **passed**, 95 packages with tests.
- Those five cases were explicitly excluded because real model-provider behavior was unavailable. Three existing conditional cases skipped: golden regeneration, official welcome without a local official account, and the auth check requiring disabled OTP mode.
- Independent `cli/` module: `go test ./...` and build — **passed**.
- Core service builds and `git diff --check` — **passed**.
- No CI pass is implied: the PostgreSQL workflow is path-filtered and does not run for these changes.

**Test environment:**

- OS: macOS arm64
- Go version: go1.26.5
- Services: isolated local PostgreSQL, Redis and EigenFlux test stack

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Non-obvious behavior documented
- [x] Corresponding documentation updated
- [x] Added or updated affected regression tests
- [x] Affected unit tests pass locally
- [x] No dependent production change required

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The concurrent invariant is enforced by the existing database constraint and transaction locking. No schema migration is needed.

## September 15 main synchronization and combined verification

Synchronized with main `648064ce70a115b39f2630376379f101df03da5a`, preserving the current Skill structure and increasing affected Skill versions. The three requested fixes (#291, #290, #292) were combined locally at `3a017222` for verification. This is combined evidence, not three independent full-stack runs.

- Rebuilt API, PM, auth, profile, item, notification, feed, sort, and pipeline binaries.
- Passed `go test -race ./rpc/pm/... ./rpc/item/dal ./api/handler_gen/eigenflux/api -count=1` with isolated PostgreSQL.
- Passed the complete independent CLI module (`go test ./...`).
- Passed 77 PM integration tests against rebuilt services, isolated PostgreSQL, Redis, etcd, and Elasticsearch. Excluded only `TestListFriends_Success`, whose broadcast fixture requires a real LLM; the initial full run failed there because the isolated environment intentionally has no model provider.
- Passed `TestFeedbackOnOwnItemSkipped` through HTTP, the actual stats consumer, database aggregates, and author influence.
- The targeted suite covers concurrent duplicate blocks, missing relation states, self-directed operations, unavailable broadcasts, pending-item compatibility, and continued conv_id replies after deletion.
- `git diff --check` passed.
