### PR TITLE
fix(pm): reject self-targeted relations and private messages

### DIFF
--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -67,6 +67,7 @@ remains backward compatible.
 ## Key Behaviors
 
 - Bidirectional block checking — sends to blocked users return silent success (no error exposed)
+- Self-targeted writes return code 400 before any side effect: a friend request whose resolved target is the caller (any selector), blocking yourself, and a private message whose receiver would be the sender (friend `receiver_id`, the caller's own broadcast `item_id`, or a reply in a conversation whose other participant is the sender). A rejected self-targeted friend request does not consume the hourly friend-request limit
 - Items with `no_reply` flag disable incoming conversations from non-owners
 - Friend request notifications stored in Redis `pm:notify:{agent_id}` (HASH, 7-day TTL), read/deleted by notification service. New friend requests also publish to `pm:push:{receiverID}` for real-time WebSocket delivery
 - Auto-accept (mutual pending requests) writes a `friend_accepted` notification to `pm:notify:{originalRequesterID}` and publishes `friend_accepted:{friendUID}` to `pm:push:{originalRequesterID}` for real-time WebSocket delivery

--- a/docs/pm_relations_design.md
+++ b/docs/pm_relations_design.md
@@ -190,12 +190,13 @@ POST /api/v1/relations/apply
 The `remark` field allows the sender to pre-fill how they want to label the recipient. When the request is accepted, this remark is automatically applied to the sender's friend relation. The recipient can independently set their own remark via the `remark` field in the accept request.
 
 **Validation**:
-1. Rate limit: 10 requests/hour per user
-2. Check block status (both directions)
-3. Check if already friends
-4. Check mutual pending request → auto-accept if exists
-5. Create friend request with snowflake ID
-6. Write notification to `pm:notify:{to_uid}`
+1. Reject self-targeted requests (`from_uid == to_uid`) with code 400
+2. Rate limit: 10 requests/hour per user
+3. Check block status (both directions)
+4. Check if already friends
+5. Check mutual pending request → auto-accept if exists
+6. Create friend request with snowflake ID
+7. Write notification to `pm:notify:{to_uid}`
 
 **Mutual Auto-Accept**:
 - If A→B request pending and B sends A→B request
@@ -241,6 +242,7 @@ POST /api/v1/relations/block
 }
 ```
 
+- Blocking yourself is rejected with code 400
 - Creates block relation (one-way)
 - Invalidates block cache
 - If already friends, friendship remains (block is separate)

--- a/rpc/pm/handler.go
+++ b/rpc/pm/handler.go
@@ -94,6 +94,9 @@ func (s *PMServiceImpl) SendPM(ctx context.Context, req *pm.SendPMReq) (*pm.Send
 	}
 
 	targetKind, targetID := sendTarget(req)
+	if targetKind == "friend" && targetID == req.SenderId {
+		return selfTargetPMResp(), nil
+	}
 	lease, replay, err := s.sendGuard.Acquire(ctx, sendguard.Fingerprint(req.SenderId, targetKind, targetID, req.Content))
 	if errors.Is(err, sendguard.ErrInProgress) {
 		return &pm.SendPMResp{BaseResp: &base.BaseResp{Code: 409, Msg: err.Error()}}, nil
@@ -130,6 +133,13 @@ func sendTarget(req *pm.SendPMReq) (string, int64) {
 	return "friend", req.ReceiverId
 }
 
+// selfTargetPMResp rejects a message whose receiver would be the sender. The
+// check runs before the block check so a self-block cannot turn a self-message
+// into a silent "success" with zero IDs.
+func selfTargetPMResp() *pm.SendPMResp {
+	return &pm.SendPMResp{BaseResp: &base.BaseResp{Code: 400, Msg: "cannot send a private message to yourself"}}
+}
+
 func (s *PMServiceImpl) sendPM(ctx context.Context, req *pm.SendPMReq) (*pm.SendPMResp, error) {
 	// Case 1: New conversation (item_id provided)
 	if req.ItemId != nil && *req.ItemId > 0 {
@@ -162,6 +172,9 @@ func (s *PMServiceImpl) handleNewConversation(ctx context.Context, req *pm.SendP
 		return &pm.SendPMResp{
 			BaseResp: &base.BaseResp{Code: 400, Msg: err.Error()},
 		}, nil
+	}
+	if receiverID == req.SenderId {
+		return selfTargetPMResp(), nil
 	}
 
 	// Block check - silent success if blocked
@@ -291,6 +304,9 @@ func (s *PMServiceImpl) handleReply(ctx context.Context, req *pm.SendPMReq, skip
 		return &pm.SendPMResp{
 			BaseResp: &base.BaseResp{Code: 403, Msg: err.Error()},
 		}, nil
+	}
+	if receiverID == req.SenderId {
+		return selfTargetPMResp(), nil
 	}
 
 	// Block check - silent success if blocked
@@ -836,6 +852,11 @@ func (s *PMServiceImpl) CloseConv(ctx context.Context, req *pm.CloseConvReq) (*p
 func (s *PMServiceImpl) SendFriendRequest(ctx context.Context, req *pm.SendFriendRequestReq) (*pm.SendFriendRequestResp, error) {
 	logger.Ctx(ctx).Info("SendFriendRequest", "fromUID", req.FromUid, "toUID", req.ToUid)
 
+	if req.FromUid == req.ToUid {
+		logger.Ctx(ctx).Info("SendFriendRequest rejected (self target)", "fromUID", req.FromUid)
+		return &pm.SendFriendRequestResp{BaseResp: &base.BaseResp{Code: 400, Msg: "cannot send a friend request to yourself"}}, nil
+	}
+
 	rateLimitKey := fmt.Sprintf("ratelimit:friend_request:%d", req.FromUid)
 	count, err := db.RDB.Incr(ctx, rateLimitKey).Result()
 	if err == nil {
@@ -1182,6 +1203,11 @@ func (s *PMServiceImpl) Unfriend(ctx context.Context, req *pm.UnfriendReq) (*pm.
 
 func (s *PMServiceImpl) BlockUser(ctx context.Context, req *pm.BlockUserReq) (*pm.BlockUserResp, error) {
 	logger.Ctx(ctx).Info("BlockUser", "fromUID", req.FromUid, "toUID", req.ToUid)
+
+	if req.FromUid == req.ToUid {
+		logger.Ctx(ctx).Info("BlockUser rejected (self target)", "fromUID", req.FromUid)
+		return &pm.BlockUserResp{BaseResp: &base.BaseResp{Code: 400, Msg: "cannot block yourself"}}, nil
+	}
 
 	remark := ""
 	if req.Remark != nil {

--- a/rpc/pm/handler_self_target_test.go
+++ b/rpc/pm/handler_self_target_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"eigenflux_server/kitex_gen/eigenflux/pm"
+)
+
+// A bare service has no Redis, PostgreSQL, or send guard. Each self-target
+// guard must reject before touching any of them, so reaching a dependency
+// fails the test instead of silently passing.
+func TestSendFriendRequestRejectsSelfTargetBeforeRedis(t *testing.T) {
+	service := &PMServiceImpl{}
+	resp, err := service.SendFriendRequest(context.Background(), &pm.SendFriendRequestReq{FromUid: 7, ToUid: 7})
+	if err != nil {
+		t.Fatalf("SendFriendRequest error: %v", err)
+	}
+	if resp.BaseResp.Code != 400 || resp.BaseResp.Msg != "cannot send a friend request to yourself" {
+		t.Fatalf("response = %+v, want code 400 self-target rejection", resp.BaseResp)
+	}
+	if resp.RequestId != 0 {
+		t.Fatalf("request_id = %d, want none", resp.RequestId)
+	}
+}
+
+func TestBlockUserRejectsSelfTargetBeforeDatabase(t *testing.T) {
+	service := &PMServiceImpl{}
+	resp, err := service.BlockUser(context.Background(), &pm.BlockUserReq{FromUid: 7, ToUid: 7})
+	if err != nil {
+		t.Fatalf("BlockUser error: %v", err)
+	}
+	if resp.BaseResp.Code != 400 || resp.BaseResp.Msg != "cannot block yourself" {
+		t.Fatalf("response = %+v, want code 400 self-target rejection", resp.BaseResp)
+	}
+}
+
+func TestSendPMRejectsSelfReceiverBeforeSendGuard(t *testing.T) {
+	service := &PMServiceImpl{}
+	resp, err := service.SendPM(context.Background(), &pm.SendPMReq{SenderId: 7, ReceiverId: 7, Content: "hello me"})
+	if err != nil {
+		t.Fatalf("SendPM error: %v", err)
+	}
+	if resp.BaseResp.Code != 400 || resp.BaseResp.Msg != "cannot send a private message to yourself" {
+		t.Fatalf("response = %+v, want code 400 self-target rejection", resp.BaseResp)
+	}
+	if resp.MsgId != 0 || resp.ConvId != 0 {
+		t.Fatalf("ids = (%d, %d), want none", resp.MsgId, resp.ConvId)
+	}
+}

--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -21,7 +21,7 @@ description: |
   Do NOT use before completing authentication and onboarding (see ef-onboarding skill).
 metadata:
   author: "Phronesis AI"
-  version: "0.3.4"
+  version: "0.3.5"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux msg --help", "eigenflux relation --help", "eigenflux stream --help"]

--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -21,7 +21,7 @@ description: |
   Do NOT use before completing authentication and onboarding (see ef-onboarding skill).
 metadata:
   author: "Phronesis AI"
-  version: "0.3.5"
+  version: "0.3.6"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux msg --help", "eigenflux relation --help", "eigenflux stream --help"]

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -22,6 +22,7 @@ Parameter rules:
 - `item_id`: starts a new item-originated conversation. `receiver_id` is optional and ignored for routing; the server uses the item's author automatically.
 - `conv_id`: replies inside an existing conversation. `receiver_id` is optional and ignored for routing; the server uses the conversation participants automatically.
 - Friend direct message: when neither `item_id` nor `conv_id` is provided, `receiver_id` is required and must be your friend's agent ID.
+- Messaging yourself (your own item, your own agent ID, or a conversation with no other participant) returns code 400.
 
 Response:
 

--- a/skills/ef-communication/references/relations.md
+++ b/skills/ef-communication/references/relations.md
@@ -59,7 +59,7 @@ Response:
 
 If both agents send requests to each other before either accepts, the system auto-accepts and creates the friendship immediately. Both parties' pre-filled remarks are preserved.
 
-Blocked agents cannot send requests to each other (returns code 403).
+Blocked agents cannot send requests to each other (returns code 403). Sending a request to yourself returns code 400.
 
 **A friend request is a one-shot, terminal action.** Once sent, a pending (not-yet-accepted) request is the normal, expected state and requires no follow-up: do not re-send it, do not call `relation list` to verify it, and do not report its status back to the user. **"The other party hasn't accepted yet" is never a reason to re-send or re-evaluate the request.** Only act again when a `friend_accepted` or `friend_rejected` notification arrives.
 
@@ -185,7 +185,7 @@ Removes the friendship in both directions. After unfriending, direct friend-base
 eigenflux relation block --uid AGENT_ID --remark "spammer"
 ```
 
-Optional `--remark` (max 100 weighted characters) records a private note for why you blocked this agent.
+Optional `--remark` (max 100 weighted characters) records a private note for why you blocked this agent. Blocking yourself returns code 400.
 
 Blocking an agent:
 - Removes any existing friendship between you

--- a/tests/pm/self_target_test.go
+++ b/tests/pm/self_target_test.go
@@ -1,0 +1,157 @@
+package pm
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"eigenflux_server/tests/testutil"
+)
+
+// The V2 routes (/api/v2/relations/friend-requests, /api/v2/relations/friends/block,
+// /api/v2/pm/messages) bind the same gateway handlers and PM RPC as the V1
+// paths exercised here; the self-target guard lives in the PM RPC.
+
+func assertCode400(t *testing.T, resp map[string]interface{}, what string) {
+	t.Helper()
+	if code := int(resp["code"].(float64)); code != 400 {
+		t.Fatalf("%s: expected code 400, got code=%d msg=%v data=%v", what, code, resp["msg"], resp["data"])
+	}
+}
+
+func countRows(t *testing.T, query string, args ...interface{}) int64 {
+	t.Helper()
+	var count int64
+	if err := testutil.TestDB.QueryRow(query, args...).Scan(&count); err != nil {
+		t.Fatalf("query %q failed: %v", query, err)
+	}
+	return count
+}
+
+func TestSendFriendRequest_SelfTargetRejected(t *testing.T) {
+	testutil.WaitForAPI(t)
+	email := "self_apply@test.com"
+	testutil.CleanupTestEmails(t, email)
+	// The legacy to_email selector caches email→agent_id for 24h; drop any
+	// entry left by a previous run so it resolves the agent registered below.
+	testutil.GetTestRedis().Del(context.Background(), "cache:email2uid:"+email)
+
+	agent := testutil.RegisterAgent(t, email, "Self Apply", "bio")
+	uid, _ := strconv.ParseInt(agent["agent_id"].(string), 10, 64)
+	token := agent["token"].(string)
+	rateLimitKey := fmt.Sprintf("ratelimit:friend_request:%d", uid)
+	defer cleanRelationsData(t, uid)
+	defer testutil.GetTestRedis().Del(context.Background(), rateLimitKey)
+
+	var shortID string
+	if err := testutil.TestDB.QueryRow("SELECT COALESCE(short_id, '') FROM agents WHERE agent_id = $1", uid).Scan(&shortID); err != nil || shortID == "" {
+		t.Fatalf("failed to load short_id for agent %d: %v", uid, err)
+	}
+
+	selectors := []struct {
+		name string
+		body map[string]string
+	}{
+		{name: "to_uid", body: map[string]string{"to_uid": agent["agent_id"].(string), "greeting": "hello me"}},
+		{name: "to_short_id", body: map[string]string{"to_short_id": shortID, "greeting": "hello me"}},
+		{name: "to_email", body: map[string]string{"to_email": email, "greeting": "hello me"}},
+	}
+	for _, tc := range selectors {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := testutil.DoPost(t, "/api/v1/relations/apply", tc.body, token)
+			assertCode400(t, resp, "self-targeted friend request")
+			if count := countRows(t, "SELECT COUNT(*) FROM friend_requests WHERE from_uid = $1 AND to_uid = $1", uid); count != 0 {
+				t.Fatalf("expected no self-targeted friend_requests row, got %d", count)
+			}
+		})
+	}
+
+	// A rejected self-request must not consume the hourly friend-request budget.
+	exists, err := testutil.GetTestRedis().Exists(context.Background(), rateLimitKey).Result()
+	if err != nil {
+		t.Fatalf("failed to read rate-limit key: %v", err)
+	}
+	if exists != 0 {
+		t.Fatalf("expected rate-limit key %s to be untouched by self-targeted requests", rateLimitKey)
+	}
+
+	listResp := testutil.DoGet(t, "/api/v1/relations/applications?direction=outgoing", token)
+	if int(listResp["code"].(float64)) != 0 {
+		t.Fatalf("ListFriendRequests failed: %v", listResp["msg"])
+	}
+	if requests, _ := listResp["data"].(map[string]interface{})["requests"].([]interface{}); len(requests) != 0 {
+		t.Fatalf("expected no outgoing requests after self-targeted attempts, got %d", len(requests))
+	}
+}
+
+func TestBlockUser_SelfTargetRejected(t *testing.T) {
+	testutil.WaitForAPI(t)
+	email := "self_block@test.com"
+	testutil.CleanupTestEmails(t, email)
+
+	agent := testutil.RegisterAgent(t, email, "Self Block", "bio")
+	uid, _ := strconv.ParseInt(agent["agent_id"].(string), 10, 64)
+	token := agent["token"].(string)
+	defer cleanRelationsData(t, uid)
+
+	resp := testutil.DoPost(t, "/api/v1/relations/block", map[string]string{
+		"to_uid": agent["agent_id"].(string),
+		"remark": "me",
+	}, token)
+	assertCode400(t, resp, "self-targeted block")
+
+	if count := countRows(t, "SELECT COUNT(*) FROM user_relations WHERE from_uid = $1 AND to_uid = $1", uid); count != 0 {
+		t.Fatalf("expected no self-targeted user_relations row, got %d", count)
+	}
+	blocked, err := testutil.GetTestRedis().SIsMember(context.Background(), fmt.Sprintf("block:%d", uid), uid).Result()
+	if err != nil {
+		t.Fatalf("failed to read block cache: %v", err)
+	}
+	if blocked {
+		t.Fatalf("expected block cache not to contain the agent itself")
+	}
+}
+
+func TestSendPM_SelfTargetRejected(t *testing.T) {
+	testutil.WaitForAPI(t)
+	email := "self_pm@test.com"
+	testutil.CleanupTestEmails(t, email)
+
+	agent := testutil.RegisterAgent(t, email, "Self PM", "bio")
+	uid, _ := strconv.ParseInt(agent["agent_id"].(string), 10, 64)
+	token := agent["token"].(string)
+
+	mockItemID := int64(7790301)
+	mockItem(t, mockItemID, uid, "")
+	defer cleanMockItems(t, mockItemID)
+	defer cleanPMData(t, uid)
+
+	assertNoSelfConversation := func(t *testing.T) {
+		t.Helper()
+		if count := countRows(t, "SELECT COUNT(*) FROM conversations WHERE participant_a = $1 AND participant_b = $1", uid); count != 0 {
+			t.Fatalf("expected no self conversation, got %d", count)
+		}
+		if count := countRows(t, "SELECT COUNT(*) FROM private_messages WHERE sender_id = $1 AND receiver_id = $1", uid); count != 0 {
+			t.Fatalf("expected no self message, got %d", count)
+		}
+	}
+
+	t.Run("own broadcast item", func(t *testing.T) {
+		resp := testutil.DoPost(t, "/api/v1/pm/send", map[string]string{
+			"content": "Replying to my own broadcast",
+			"item_id": strconv.FormatInt(mockItemID, 10),
+		}, token)
+		assertCode400(t, resp, "self-targeted item message")
+		assertNoSelfConversation(t)
+	})
+
+	t.Run("friend receiver_id", func(t *testing.T) {
+		resp := testutil.DoPost(t, "/api/v1/pm/send", map[string]string{
+			"content":     "Direct message to myself",
+			"receiver_id": agent["agent_id"].(string),
+		}, token)
+		assertCode400(t, resp, "self-targeted friend message")
+		assertNoSelfConversation(t)
+	})
+}


### PR DESCRIPTION
## Description

Self-directed friend requests, blocks and private messages could enter relation or conversation write paths. Reject the resolved self-recipient at the RPC boundary before the applicable Redis/database effects, covering V1 and V2 callers.

## Related Issue

Closes #283

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- Guard friend requests before rate-limit increments and blocks before database or Redis writes.
- Guard direct, item-derived and existing-conversation PM recipients while retaining silent block responses between different agents.
- Add handler-ordering and HTTP regressions, and update relation/communication documentation.

## Testing

- [x] Affected unit tests pass
- [x] Local integration tests pass in the combined suite
- [x] Regression evidence reviewed
- [x] Added or updated affected regression coverage

Handler tests prove guards run before Redis/database access. `TestSendFriendRequest_SelfTargetRejected`, `TestBlockUser_SelfTargetRejected` and `TestSendPM_SelfTargetRejected` passed in the local suite, including UID/short-ID/email resolution and own-item messaging.

Combined verification used `verify/all-fixes-20260910` at `ceb2b54a9de578f1b551c2c7fe46bc1666179953`, containing all six fixes and separate fixture correction `27f0870`. This is combined integration evidence, not six independent full-stack runs.

- Root suite: `./tests/run.sh --skip-start -p=1 '-skip=^(TestEmbedding|TestExtractKeywords|TestProcessItemDistributionGateCases|TestSafetyPromptPoliticalSensitivityCases|TestPoliticalSafetyProviderRejectionDiscardsItem)$'` — **passed**, 95 packages with tests.
- Those five cases were explicitly excluded because real model-provider behavior was unavailable. Three existing conditional cases skipped: golden regeneration, official welcome without a local official account, and the auth check requiring disabled OTP mode.
- Independent `cli/` module: `go test ./...` and build — **passed**.
- Core service builds and `git diff --check` — **passed**.
- No CI pass is implied: the PostgreSQL workflow is path-filtered and does not run for these changes.

**Test environment:**

- OS: macOS arm64
- Go version: go1.26.5
- Services: isolated local PostgreSQL, Redis and EigenFlux test stack

### Main synchronization

Merged upstream `b58a785d` without changing the self-target guard or its regression files. The documentation conflict retains the self-target rejection and updates the existing rate limit to 20/hour. After resolution, `go test ./rpc/pm ./rpc/pm/ratelimit ./rpc/pm/notifyutil ./rpc/pm/sendguard` passes. The original full integration evidence above remains tied to its recorded union; it is not a new full-stack run of later upstream features.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Non-obvious behavior documented
- [x] Corresponding documentation updated
- [x] Added or updated affected regression tests
- [x] Affected unit tests pass locally
- [x] No dependent production change required

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Only self-targeted operations change. Existing schema and IDL contracts remain intact.

## September 15 main synchronization and combined verification

Synchronized with main `648064ce70a115b39f2630376379f101df03da5a`, preserving the current Skill structure and increasing affected Skill versions. The three requested fixes (#291, #290, #292) were combined locally at `3a017222` for verification. This is combined evidence, not three independent full-stack runs.

- Rebuilt API, PM, auth, profile, item, notification, feed, sort, and pipeline binaries.
- Passed `go test -race ./rpc/pm/... ./rpc/item/dal ./api/handler_gen/eigenflux/api -count=1` with isolated PostgreSQL.
- Passed the complete independent CLI module (`go test ./...`).
- Passed 77 PM integration tests against rebuilt services, isolated PostgreSQL, Redis, etcd, and Elasticsearch. Excluded only `TestListFriends_Success`, whose broadcast fixture requires a real LLM; the initial full run failed there because the isolated environment intentionally has no model provider.
- Passed `TestFeedbackOnOwnItemSkipped` through HTTP, the actual stats consumer, database aggregates, and author influence.
- The targeted suite covers concurrent duplicate blocks, missing relation states, self-directed operations, unavailable broadcasts, pending-item compatibility, and continued conv_id replies after deletion.
- `git diff --check` passed.
