### PR TITLE
fix(pm): preserve topic-status activity time and V2 CLI routing

### DIFF
--- a/cli/cmd/msg.go
+++ b/cli/cmd/msg.go
@@ -200,7 +200,12 @@ Examples:
 		if status != "pending_verify" && status != "open" && status != "closed" {
 			return fmt.Errorf("--status must be pending_verify, open, or closed")
 		}
-		resp, err := newClient().Post("/pm/topic-status", map[string]interface{}{
+		c := newClient()
+		path := "/pm/topic-status"
+		if strings.HasSuffix(c.BaseURL, "/api/v2") {
+			path = "/pm/conversations/topic-status"
+		}
+		resp, err := c.Post(path, map[string]interface{}{
 			"conv_id": convID, "topic_status": status,
 		})
 		if err != nil {

--- a/cli/cmd/msg_topic_status_test.go
+++ b/cli/cmd/msg_topic_status_test.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/config"
 )
 
 func TestMsgTopicStatusValidatesRequiredValues(t *testing.T) {
@@ -21,5 +28,80 @@ func TestMsgTopicStatusValidatesRequiredValues(t *testing.T) {
 	_ = msgTopicStatusCmd.Flags().Set("status", "waiting")
 	if err := msgTopicStatusCmd.RunE(msgTopicStatusCmd, nil); err == nil || !strings.Contains(err.Error(), "--status must be") {
 		t.Fatalf("invalid status error=%v", err)
+	}
+}
+
+func TestMsgTopicStatusUsesAuthenticatedAPIRoute(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		v2   bool
+		path string
+	}{
+		{name: "legacy", path: "/api/v1/pm/topic-status"},
+		{name: "agent v2", v2: true, path: "/api/v2/pm/conversations/topic-status"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempHome(t)
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if r.Method != http.MethodPost || r.URL.Path != tc.path {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer topic-token" {
+					t.Errorf("authorization=%q", got)
+				}
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+				}
+				if body["conv_id"] != "123" || body["topic_status"] != "pending_verify" {
+					t.Errorf("topic request body=%v", body)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"code":0,"msg":"success","data":{"conv_id":"123","topic_status":"pending_verify","changed":true}}`))
+			}))
+			defer server.Close()
+
+			cfg, err := config.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			active, err := cfg.GetActive("")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cfg.UpdateServer(active.Name, server.URL, ""); err != nil {
+				t.Fatal(err)
+			}
+			if tc.v2 {
+				err = auth.SaveV2Credentials(active.Name, &auth.V2Credentials{
+					AgentID: "42", PrincipalID: "24", AccessToken: "topic-token", RefreshToken: "topic-refresh",
+					ExpiresAt: time.Now().Add(time.Hour).UnixMilli(),
+				})
+			} else {
+				err = auth.SaveCredentials(active.Name, &auth.Credentials{AgentID: "42", AccessToken: "topic-token"})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			previousServer := serverFlag
+			serverFlag = ""
+			t.Cleanup(func() {
+				serverFlag = previousServer
+				_ = msgTopicStatusCmd.Flags().Set("conv-id", "")
+				_ = msgTopicStatusCmd.Flags().Set("status", "")
+			})
+			_ = msgTopicStatusCmd.Flags().Set("conv-id", "123")
+			_ = msgTopicStatusCmd.Flags().Set("status", "pending_verify")
+			if err := msgTopicStatusCmd.RunE(msgTopicStatusCmd, nil); err != nil {
+				t.Fatalf("topic-status command failed: %v", err)
+			}
+			if requests != 1 {
+				t.Fatalf("requests=%d, want one topic-status write", requests)
+			}
+		})
 	}
 }

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -50,10 +50,15 @@ authenticated Console session and never accept an Agent ID from the client.
 Every conversation has one shared `topic_status`: `pending_verify`, `open`, or
 `closed`. Either participant may update it. Each effective change is appended to
 `conversation_topic_events` in the same transaction; repeated writes of the
-current value are no-ops. Topic ordering is opt-in with `sort=topic_status` and
+current value are no-ops. Effective changes refresh `updated_at` in Unix
+milliseconds; no-op writes preserve both the timestamp and event count. Topic
+ordering is opt-in with `sort=topic_status` and
 sorts by status priority, then oldest activity, then conversation ID. Its opaque
 cursor includes all three ordering values. The default recent-activity ordering
 remains backward compatible.
+
+`eigenflux msg topic-status` uses `/api/v2/pm/conversations/topic-status` with
+Agent V2 credentials and `/api/v1/pm/topic-status` with legacy credentials.
 
 ## Core Components
 

--- a/rpc/pm/dal/db.go
+++ b/rpc/pm/dal/db.go
@@ -20,7 +20,7 @@ type Conversation struct {
 	MsgCount         int    `gorm:"column:msg_count;not null;default:0"`
 	Status           int16  `gorm:"column:status;type:smallint;not null;default:0"`
 	TopicStatus      int16  `gorm:"column:topic_status;type:smallint;not null;default:1"`
-	UpdatedAt        int64  `gorm:"column:updated_at;not null"`
+	UpdatedAt        int64  `gorm:"column:updated_at;not null;autoUpdateTime:milli"`
 	ParticipantAName string `gorm:"column:participant_a_name;type:varchar(100);not null;default:''"`
 	ParticipantBName string `gorm:"column:participant_b_name;type:varchar(100);not null;default:''"`
 }

--- a/rpc/pm/dal/topic_status_test.go
+++ b/rpc/pm/dal/topic_status_test.go
@@ -1,0 +1,81 @@
+package dal
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestPostgresTopicStatusUsesMillisecondActivityTime(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for the PostgreSQL topic-status contract")
+	}
+	clockNow := time.UnixMilli(1789000000123)
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{NowFunc: func() time.Time { return clockNow }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	// Connection-local tables keep the real row-lock and transaction semantics
+	// without touching conversations in the shared integration database.
+	for _, statement := range []string{
+		`CREATE TEMP TABLE conversations (
+			conv_id BIGINT PRIMARY KEY, participant_a BIGINT NOT NULL, participant_b BIGINT NOT NULL,
+			status SMALLINT NOT NULL, topic_status SMALLINT NOT NULL, updated_at BIGINT NOT NULL)`,
+		`CREATE TEMP TABLE conversation_topic_events (
+			event_id BIGSERIAL PRIMARY KEY, conv_id BIGINT NOT NULL, actor_id BIGINT NOT NULL,
+			previous_status SMALLINT NOT NULL, new_status SMALLINT NOT NULL, created_at BIGINT NOT NULL)`,
+		`INSERT INTO conversations VALUES (1, 10, 20, 0, 1, 1788990000000)`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	previous, changed, err := UpdateConversationTopicStatus(db, 1, 10, TopicStatusPendingVerify)
+	if err != nil || previous != TopicStatusOpen || !changed {
+		t.Fatalf("topic update: previous=%d changed=%v err=%v", previous, changed, err)
+	}
+	firstUpdatedAt := clockNow.UnixMilli()
+	assertState := func(wantStatus int16, wantUpdatedAt, wantEvents int64) {
+		t.Helper()
+		conv, err := GetConversationByID(db, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if conv.TopicStatus != wantStatus || conv.UpdatedAt != wantUpdatedAt {
+			t.Fatalf("conversation status=%d updated_at=%d, want status=%d updated_at=%d", conv.TopicStatus, conv.UpdatedAt, wantStatus, wantUpdatedAt)
+		}
+		var events int64
+		if err := db.Model(&ConversationTopicEvent{}).Where("conv_id = ?", 1).Count(&events).Error; err != nil {
+			t.Fatal(err)
+		}
+		if events != wantEvents {
+			t.Fatalf("topic event count=%d, want %d", events, wantEvents)
+		}
+	}
+	assertState(TopicStatusPendingVerify, firstUpdatedAt, 1)
+
+	clockNow = clockNow.Add(time.Minute)
+	previous, changed, err = UpdateConversationTopicStatus(db, 1, 20, TopicStatusPendingVerify)
+	if err != nil || previous != TopicStatusPendingVerify || changed {
+		t.Fatalf("no-op topic update: previous=%d changed=%v err=%v", previous, changed, err)
+	}
+	assertState(TopicStatusPendingVerify, firstUpdatedAt, 1)
+
+	previous, changed, err = UpdateConversationTopicStatus(db, 1, 20, TopicStatusClosed)
+	if err != nil || previous != TopicStatusPendingVerify || !changed {
+		t.Fatalf("second participant update: previous=%d changed=%v err=%v", previous, changed, err)
+	}
+	assertState(TopicStatusClosed, clockNow.UnixMilli(), 2)
+}

--- a/skills/ef-communication/SKILL.md
+++ b/skills/ef-communication/SKILL.md
@@ -21,7 +21,7 @@ description: |
   Do NOT use before completing authentication and onboarding (see ef-onboarding skill).
 metadata:
   author: "Phronesis AI"
-  version: "0.3.4"
+  version: "0.3.5"
   requires:
     bins: ["eigenflux"]
   cliHelps: ["eigenflux msg --help", "eigenflux relation --help", "eigenflux stream --help"]

--- a/skills/ef-communication/references/message.md
+++ b/skills/ef-communication/references/message.md
@@ -161,7 +161,7 @@ Use `--sort topic_status` to order `pending_verify`, `open`, and `closed` conver
 
 Use `last_sender_id` to identify the latest sender. `needs_reply` is true when the peer sent the latest message and the current agent has not replied after it. Build pending-reply lists from this response without fetching conversation history.
 
-Set the shared topic status with `eigenflux msg topic-status --conv-id CONV_ID --status STATUS`. `STATUS` must be `pending_verify`, `open`, or `closed`.
+Set the shared topic status with `eigenflux msg topic-status --conv-id CONV_ID --status STATUS`. `STATUS` must be `pending_verify`, `open`, or `closed`. An effective change refreshes the conversation's activity time; repeating its current status leaves that time unchanged.
 
 ### Get Conversation History
 

--- a/tests/pm/pm_test.go
+++ b/tests/pm/pm_test.go
@@ -580,7 +580,7 @@ func TestConversationTopicStatus(t *testing.T) {
 			(conv_id, participant_a, participant_b, initiator_id, last_sender_id, origin_type, origin_id,
 			 msg_count, status, updated_at, participant_a_name, participant_b_name)
 			VALUES ($1, $2, $3, $2, $2, 'broadcast', $4, 1, 0, $5, 'Topic First', 'Topic Second')`,
-			convID, participantA, participantB, suffix+int64(index)+100, now+int64(index)); err != nil {
+			convID, participantA, participantB, suffix+int64(index)+100, now-60000+int64(index)); err != nil {
 			t.Fatalf("insert conversation %d: %v", convID, err)
 		}
 	}
@@ -603,6 +603,28 @@ func TestConversationTopicStatus(t *testing.T) {
 	}
 	if changed := update(second["token"].(string), convIDs[2], "closed")["changed"]; changed != false {
 		t.Fatalf("no-op topic update changed=%v", changed)
+	}
+	for _, convID := range []int64{convIDs[0], convIDs[2]} {
+		var updatedAt int64
+		if err := testutil.TestDB.QueryRow("SELECT updated_at FROM conversations WHERE conv_id = $1", convID).Scan(&updatedAt); err != nil {
+			t.Fatalf("read conversation activity time: %v", err)
+		}
+		if updatedAt < now {
+			t.Fatalf("topic update stored updated_at=%d, want a current Unix millisecond timestamp >= %d", updatedAt, now)
+		}
+	}
+	recent := testutil.DoGet(t, "/api/v1/pm/conversations?limit=10", first["token"].(string))
+	if code := int(recent["code"].(float64)); code != 0 {
+		t.Fatalf("recent conversations failed: code=%d msg=%v", code, recent["msg"])
+	}
+	recentRows := recent["data"].(map[string]interface{})["conversations"].([]interface{})
+	if len(recentRows) != 3 {
+		t.Fatalf("recent conversation count=%d, want 3", len(recentRows))
+	}
+	for index, wantConvID := range []int64{convIDs[2], convIDs[0], convIDs[1]} {
+		if got := recentRows[index].(map[string]interface{})["conv_id"]; got != strconv.FormatInt(wantConvID, 10) {
+			t.Fatalf("recent row %d conv_id=%v, want %d", index, got, wantConvID)
+		}
 	}
 
 	resp := testutil.DoGet(t, "/api/v1/pm/conversations?sort=topic_status&limit=10", first["token"].(string))


### PR DESCRIPTION
## Description

Changing a conversation's topic status wrote its activity time in Unix seconds
through GORM, causing recent-conversation ordering to mix seconds with
milliseconds. The Agent V2 CLI also posted `msg topic-status` to an unregistered
route and returned HTTP 404. Conversation updates now use milliseconds, and the
CLI selects the registered route for its credential version.

## Related Issue

Closes #300

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Changes Made

- Configure GORM's conversation activity updates with `autoUpdateTime:milli`.
- Use `/api/v2/pm/conversations/topic-status` for Agent V2 credentials and retain
  `/api/v1/pm/topic-status` for legacy credentials.
- Add real PostgreSQL state/event/no-op regression coverage, command-level
  routing tests for both credential versions, and HTTP integration assertions
  for recent ordering. Update PM documentation and the communication Skill.

## Testing

- [x] Affected unit and PostgreSQL contract tests pass
- [x] Integration tests pass — serial rebuilt-service run completed
- [x] Manual regression comparison performed
- [x] Added new tests for new functionality

Observed commands:

- `PG_DSN=<isolated local PostgreSQL> go test -race ./rpc/pm/dal -count=1`
- From `cli/`: `go test ./...`
- `go build -o build/pm-topic-status ./rpc/pm`
- From `cli/`: `go build -o ../build/cli/eigenflux-topic-status .`
- `go test -c -o build/tests/pm.test ./tests/pm`
- `git diff --check`

Both targeted regressions fail against their original behavior: the PostgreSQL
test observes a seconds-scale timestamp, and the V2 command test observes the
unregistered route's 404. Both pass with the fixes.

Combined verification used `verify/all-fixes-20260910` at `ceb2b54a9de578f1b551c2c7fe46bc1666179953`, containing all six fixes and separate fixture correction `27f0870`. This is combined integration evidence, not six independent full-stack runs.

- Root suite: `./tests/run.sh --skip-start -p=1 '-skip=^(TestEmbedding|TestExtractKeywords|TestProcessItemDistributionGateCases|TestSafetyPromptPoliticalSensitivityCases|TestPoliticalSafetyProviderRejectionDiscardsItem)$'` — **passed**, 95 packages with tests.
- Those five cases were explicitly excluded because real model-provider behavior was unavailable. Three existing conditional cases skipped: golden regeneration, official welcome without a local official account, and the auth check requiring disabled OTP mode.
- Independent `cli/` module: `go test ./...` and build — **passed**.
- Core service builds and `git diff --check` — **passed**.
- No CI pass is implied: the PostgreSQL workflow is path-filtered and does not run for these changes.

The rebuilt-service `TestConversationTopicStatus` regression also passed in a
separate targeted run before the final combined suite. It verifies current
millisecond activity timestamps and recent-conversation ordering.

The Arena `communication-topic-status-reply-state` journey also passed **50/50 checks** on the initial combined `46c7c523` Hub (run `communication-topic-stat-20260910-154817-884c`). This covers the CLI and HTTP flow through the rebuilt service.

**Test environment:**
- OS: macOS arm64
- Go version: go1.26.5
- PostgreSQL: isolated local integration instance; the package-level contract
  test uses connection-local temporary tables

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the commands above
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing affected unit tests pass locally with my changes
- [x] No dependent changes are required

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The repair corrects subsequent activity updates. Historical values already
written in seconds are not backfilled by this change. The communication Skill
version is increased under `skills/AGENTS.md`.
