### PR TITLE
fix(pm): honor friend page limits with official-first cursors

### DIFF
--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -16,7 +16,7 @@ Private messaging and friend/block relationship management. Registered as `PMSer
 | `SendFriendRequest` | Send friend request |
 | `HandleFriendRequest` | Accept/reject/cancel friend requests |
 | `ListFriendRequests` | List pending friend requests (incoming/outgoing) with cursor pagination and `has_more` flag (LIMIT+1 probe) |
-| `ListFriends` | List friends |
+| `ListFriends` | List friends with official accounts first, then relation ID descending within each group; `limit` bounds the complete page and the integer cursor continues across both groups |
 | `UpdateFriendRemark` | Update remark/note for a friend |
 | `Unfriend` | Remove friend relationship |
 | `BlockUser` / `UnblockUser` | Block/unblock another user |

--- a/rpc/pm/dal/relations.go
+++ b/rpc/pm/dal/relations.go
@@ -304,53 +304,37 @@ func ListFriendRequests(db *gorm.DB, agentID int64, direction string, cursor int
 	return requests, false, nil
 }
 
-// officialFriendIDs returns the subset of an agent's friends that are ops-flagged
-// official accounts (agents.is_official) — normally just the singleton new-user
-// guide. Used to pin the official account to the top of the relations list.
-func officialFriendIDs(db *gorm.DB, agentID int64) ([]int64, error) {
-	var ids []int64
-	err := db.Model(&UserRelation{}).
-		Joins("JOIN agents a ON a.agent_id = user_relations.to_uid").
-		Where("user_relations.from_uid = ? AND user_relations.rel_type = ? AND a.is_official",
-			agentID, RelTypeFriend).
-		Pluck("user_relations.to_uid", &ids).Error
-	if err != nil {
-		return nil, err
-	}
-	return ids, nil
-}
-
-// ListFriends retrieves friends with names and pagination. Official accounts are
-// pinned to the very top of the first page (cursor == 0) and excluded from the
-// normal id-DESC body on every page, so the official account always leads the
-// list and never appears twice across pages.
+// ListFriends pages the complete (official first, relation ID descending) order.
+// The integer cursor is the last relation ID, whose official status determines
+// whether the next page continues the official group or the ordinary group.
 func ListFriends(db *gorm.DB, agentID int64, cursor int64, limit int) ([]*Friend, error) {
-	official, err := officialFriendIDs(db, agentID)
-	if err != nil {
-		return nil, err
+	query := db.Table("user_relations r").
+		Select("r.*").
+		Joins("LEFT JOIN agents a ON a.agent_id = r.to_uid").
+		Where("r.from_uid = ? AND r.rel_type = ?", agentID, RelTypeFriend)
+	if cursor > 0 {
+		var officialCursor bool
+		// Scope the anchor to this user's current friendships. Missing anchors
+		// retain the ordinary ID-cursor behavior, including after unfriend.
+		if err := db.Table("user_relations r").
+			Select("COALESCE(a.is_official, FALSE)").
+			Joins("LEFT JOIN agents a ON a.agent_id = r.to_uid").
+			Where("r.id = ? AND r.from_uid = ? AND r.rel_type = ?", cursor, agentID, RelTypeFriend).
+			Scan(&officialCursor).Error; err != nil {
+			return nil, err
+		}
+		if officialCursor {
+			// Ordinary IDs may be newer than the last pinned official relation.
+			query = query.Where("NOT COALESCE(a.is_official, FALSE) OR r.id < ?", cursor)
+		} else {
+			query = query.Where("NOT COALESCE(a.is_official, FALSE) AND r.id < ?", cursor)
+		}
 	}
 
 	var relations []UserRelation
-	query := db.Where("from_uid = ? AND rel_type = ?", agentID, RelTypeFriend)
-	if len(official) > 0 {
-		query = query.Where("to_uid NOT IN ?", official)
-	}
-	if cursor > 0 {
-		query = query.Where("id < ?", cursor)
-	}
-	if err := query.Order("id DESC").Limit(limit).Find(&relations).Error; err != nil {
+	if err := query.Order("COALESCE(a.is_official, FALSE) DESC, r.id DESC").
+		Limit(limit).Find(&relations).Error; err != nil {
 		return nil, err
-	}
-
-	// First page: prepend the official account(s) ahead of the id-DESC body.
-	if cursor == 0 && len(official) > 0 {
-		var pinned []UserRelation
-		if err := db.Where("from_uid = ? AND rel_type = ? AND to_uid IN ?",
-			agentID, RelTypeFriend, official).
-			Order("id DESC").Find(&pinned).Error; err != nil {
-			return nil, err
-		}
-		relations = append(pinned, relations...)
 	}
 
 	if len(relations) == 0 {

--- a/rpc/pm/dal/relations_pagination_test.go
+++ b/rpc/pm/dal/relations_pagination_test.go
@@ -1,0 +1,101 @@
+package dal
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestPostgresListFriendsOfficialPagination(t *testing.T) {
+	dsn := os.Getenv("PG_DSN")
+	if dsn == "" {
+		t.Skip("PG_DSN is required for the PostgreSQL friend-pagination contract")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	// Connection-local tables exercise PostgreSQL ordering without modifying
+	// any shared integration accounts or their relationships.
+	for _, statement := range []string{
+		`CREATE TEMP TABLE agents (agent_id BIGINT PRIMARY KEY, agent_name TEXT, bio TEXT, is_official BOOLEAN)`,
+		`CREATE TEMP TABLE user_relations (id BIGINT PRIMARY KEY, from_uid BIGINT, to_uid BIGINT, rel_type SMALLINT, created_at BIGINT, remark TEXT)`,
+		`INSERT INTO agents VALUES (11,'official old','bio',true),(12,'official new','bio',true),(13,'normal old','bio',false),(14,'normal new','bio',false),(15,'nullable normal','bio',null)`,
+		`INSERT INTO user_relations VALUES
+          (10,1,11,1,1000,'old official'), (30,1,12,1,3000,'new official'),
+          (20,1,13,1,2000,'old normal'), (50,1,14,1,5000,'new normal'),
+          (40,1,15,1,4000,'nullable'), (60,2,11,1,6000,'other owner'),
+          (70,1,11,2,7000,'block')`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, limit := range []int{1, 2, 3, 5, 10} {
+		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+			var got []int64
+			var cursor int64
+			for page := 0; page < 7; page++ {
+				friends, err := ListFriends(db, 1, cursor, limit)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(friends) > limit {
+					t.Fatalf("page returned %d friends, limit %d", len(friends), limit)
+				}
+				total, err := CountFriends(db, 1)
+				if err != nil || total != 5 {
+					t.Fatalf("total=%d err=%v, want 5", total, err)
+				}
+				if len(friends) == 0 {
+					break
+				}
+				for _, friend := range friends {
+					got = append(got, friend.RelationID)
+					if friend.AgentName == "" || friend.Bio != "bio" || friend.Remark == "" || friend.FriendSince != friend.RelationID*100 {
+						t.Fatalf("lost friend metadata: %+v", friend)
+					}
+				}
+				cursor = friends[len(friends)-1].RelationID
+			}
+			if want := []int64{30, 10, 50, 40, 20}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("paged relation IDs=%v, want %v", got, want)
+			}
+		})
+	}
+	// Foreign and non-friend anchors cannot restart the official group.
+	for _, cursor := range []int64{60, 70, 99} {
+		friends, err := ListFriends(db, 1, cursor, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []int64
+		for _, friend := range friends {
+			got = append(got, friend.RelationID)
+		}
+		if want := []int64{50, 40, 20}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("out-of-scope cursor %d returned %v, want %v", cursor, got, want)
+		}
+	}
+	if err := db.Exec(`UPDATE agents SET is_official = false`).Error; err != nil {
+		t.Fatal(err)
+	}
+	friends, err := ListFriends(db, 1, 40, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(friends) != 2 || friends[0].RelationID != 30 || friends[1].RelationID != 20 {
+		t.Fatalf("ordinary cursor order changed: %+v", friends)
+	}
+}

--- a/tests/pm/friends_official_pagination_test.go
+++ b/tests/pm/friends_official_pagination_test.go
@@ -1,0 +1,83 @@
+package pm
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"eigenflux_server/tests/testutil"
+)
+
+func TestListFriends_OfficialPagesRespectLimit(t *testing.T) {
+	testutil.WaitForAPI(t)
+	emails := []string{"official_page_owner@test.com", "official_page_old@test.com", "official_page_new@test.com", "official_page_normal_old@test.com", "official_page_normal_new@test.com"}
+	testutil.CleanupTestEmails(t, emails...)
+	t.Cleanup(func() { testutil.CleanupTestEmails(t, emails...) })
+	var ids []int64
+	var owner map[string]interface{}
+	for i, email := range emails {
+		account := testutil.RegisterAgent(t, email, fmt.Sprintf("Pagination %d", i), "pagination regression")
+		id, err := strconv.ParseInt(account["agent_id"].(string), 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, id)
+		if i == 0 {
+			owner = account
+		}
+	}
+	defer cleanRelationsData(t, ids...)
+	// Create both official relations before the ordinary ones: their older IDs
+	// must not exclude newer ordinary friends when an official page ends.
+	for _, id := range ids[1:3] {
+		if _, err := testutil.TestDB.Exec("UPDATE agents SET is_official = true WHERE agent_id = $1", id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, id := range ids[1:] {
+		if _, err := testutil.TestDB.Exec("INSERT INTO user_relations (from_uid,to_uid,rel_type,created_at,remark) VALUES ($1,$2,1,$3,'pagination remark')", ids[0], id, time.Now().UnixMilli()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := []string{strconv.FormatInt(ids[2], 10), strconv.FormatInt(ids[1], 10), strconv.FormatInt(ids[4], 10), strconv.FormatInt(ids[3], 10)}
+	for _, limit := range []int{1, 2, 3} {
+		t.Run(fmt.Sprintf("limit_%d", limit), func(t *testing.T) {
+			cursor := "0"
+			var got []string
+			for page := 0; page < 6; page++ {
+				response := testutil.DoGet(t, fmt.Sprintf("/api/v1/relations/friends?limit=%d&cursor=%s", limit, cursor), owner["token"].(string))
+				if response["code"] != float64(0) {
+					t.Fatalf("list failed: %v", response)
+				}
+				data := response["data"].(map[string]interface{})
+				if data["total"] != float64(4) {
+					t.Fatalf("total=%v, want 4", data["total"])
+				}
+				friends, _ := data["friends"].([]interface{})
+				if len(friends) > limit {
+					t.Fatalf("returned %d friends, limit %d", len(friends), limit)
+				}
+				if len(friends) == 0 {
+					break
+				}
+				for _, entry := range friends {
+					friend := entry.(map[string]interface{})
+					got = append(got, friend["agent_id"].(string))
+					if friend["remark"] != "pagination remark" {
+						t.Fatalf("lost remark: %v", friend)
+					}
+				}
+				next, _ := data["next_cursor"].(string)
+				if next == "" || next == "0" || next == cursor {
+					t.Fatalf("invalid next cursor: %v", data)
+				}
+				cursor = next
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("paged friends=%v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Friend pages can exceed the requested limit when official accounts are present. For example, the CLI requests two friends and receives one official account plus two ordinary friends. Apply the limit to the complete official-first order and use the existing integer relation cursor to continue across the official and ordinary groups without dropping newer ordinary relations.

## Related Issue

Closes #301

## Type of Change

- [x] Bug fix (non-breaking change)
- [x] Test addition or update
- [x] Documentation update

## Changes Made

- Order the complete relation query by official status first, then relation ID descending, and apply one page limit.
- Resolve a cursor's official status only within the caller's current friendship rows. An official anchor continues remaining officials and then all ordinary friends; an ordinary anchor continues only older ordinary relations.
- Preserve relation IDs, friend metadata, existing integer cursor shape, and exact total counts.
- Add PostgreSQL temporary-table and real HTTP regressions for multiple officials, page sizes 1/2/3, transitions to newer ordinary relation IDs, complete ordering without duplicates or omissions, and stable totals. DAL tests also cover foreign/block/missing anchors, nullable official flags, and ordinary-only compatibility.

## Testing

- New PostgreSQL regression against original main function fails for limits 1/2/3; the repaired function passes all page sizes 1/2/3/5/10.
- Real HTTP regression against the previous runtime fails (limit 1 returns 3; limit 2 returns 4). The repaired runtime passes all three page sizes plus existing `TestListFriends_IDCursor` and `TestListFriends_Success`.
- `PG_DSN=<local fixture> go test -race -count=1 ./rpc/pm/dal` passes with the real PostgreSQL regression included.
- `go build -o build/pm ./rpc/pm` passes on the independent repair branch.
- Combined-union PM build with only the pagination change applied passes. HTTP checks use this rebuilt local PM and the existing isolated service stack.

**Test environment:** macOS arm64, Go 1.26.5, PostgreSQL 16, local API gateway and PM RPC service.

## Checklist

- [x] Self-reviewed the diff and cursor boundary behavior.
- [x] Added regressions that fail before the fix and pass after it.
- [x] Updated PM documentation.
- [x] No schema or public API changes.

## Additional Notes

For a missing cursor relation, the existing ordinary ID-cursor fallback is preserved. Like the existing API, pages are reads of current friendship and official-account state rather than a frozen multi-request snapshot.
