### PR TITLE
test: align integration fixtures and isolate CLI state

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -88,3 +88,8 @@ stream exemption test uses the real production key name in that separate
 database, preserving the running pipeline's stream and consumer group in DB 0.
 
 Whitelist-matched emails automatically use `MOCK_UNIVERSAL_OTP`, other emails manually input OTP.
+
+CLI integration subprocesses isolate `HOME`, `EIGENFLUX_HOME`, and
+`EIGENFLUX_SKILLS_DIR` in their temporary fixture directory. Automatic skill
+refreshes use an unavailable loopback CDN endpoint so these tests neither install
+public releases nor update the developer's managed skills.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -77,4 +77,14 @@ python3 scripts/local/manual_register.py --email you@example.com
 
 The runner uses the root `.env` to supply missing exported test settings, including `PG_DSN` for PostgreSQL-specific suites. Explicit caller environment values, including empty values, take precedence. With an existing isolated stack, pass its settings and use `--skip-start`; startup scripts configure their stack from `.env`. The root `./...` pattern does not cross nested `go.mod` boundaries. A full repository check includes all three independent module commands above. Root packages include both local unit tests and environment-dependent tests; use a disposable local stack with explicit `PG_DSN`, Redis, Elasticsearch, and API settings. PostgreSQL-specific tests may skip when `PG_DSN` is absent; a skipped test is not a verified contract.
 
+The CLI integration suite also accepts `EIGENFLUX_TEST_CLI`; set it to a binary
+built from the checkout under test to avoid accidentally testing an installed
+release from `PATH`. CLI invocations use temporary Agent Homes.
+
+`TestStreamCap` uses Redis database 15 by default, configurable with the positive
+`EIGENFLUX_TEST_REDIS_DB` setting. This database must be reserved for tests and
+its stream fixture keys must be absent before the suite runs. The ingestion
+stream exemption test uses the real production key name in that separate
+database, preserving the running pipeline's stream and consumer group in DB 0.
+
 Whitelist-matched emails automatically use `MOCK_UNIVERSAL_OTP`, other emails manually input OTP.

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -18,7 +18,7 @@ import (
 	"eigenflux_server/tests/testutil"
 )
 
-// testHome is a temporary directory used as EIGENFLUX_HOME for all CLI invocations.
+// testHome isolates CLI data, the user home, and managed skills for each test.
 var testHome string
 
 // apiBaseURL is the local API gateway address.
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 }
 
 // runCLI executes the eigenflux binary with the given args, returning stdout, stderr and error.
-// EIGENFLUX_HOME is pointed at a temporary directory so tests don't pollute the real config.
+// Child processes keep configuration and automatic skill refreshes inside testHome.
 func runCLI(t *testing.T, args ...string) (stdout string, stderr string, err error) {
 	t.Helper()
 	bin := os.Getenv("EIGENFLUX_TEST_CLI")
@@ -43,12 +43,23 @@ func runCLI(t *testing.T, args ...string) (stdout string, stderr string, err err
 		}
 	}
 	cmd := exec.Command(bin, args...)
-	cmd.Env = append(os.Environ(), "EIGENFLUX_HOME="+testHome)
+	cmd.Env = cliTestEnv()
 	var outBuf, errBuf strings.Builder
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
 	runErr := cmd.Run()
 	return outBuf.String(), errBuf.String(), runErr
+}
+
+// A separate EIGENFLUX_HOME alone does not isolate the feed-poll skill sync:
+// its default target is resolved from HOME, independently of CLI data storage.
+func cliTestEnv() []string {
+	return append(os.Environ(),
+		"HOME="+testHome,
+		"EIGENFLUX_HOME="+testHome,
+		"EIGENFLUX_SKILLS_DIR="+filepath.Join(testHome, ".agents", "skills"),
+		"EIGENFLUX_CDN_URL=http://127.0.0.1:1",
+	)
 }
 
 // mustRunCLI is like runCLI but fatals on error.
@@ -110,6 +121,9 @@ func TestVersion(t *testing.T) {
 	}
 	if v["home"] != filepath.Join(testHome, ".eigenflux") || v["home_source"] != "env" {
 		t.Errorf("version must report the isolated test home: %v", v)
+	}
+	if got := strings.TrimSpace(mustRunCLI(t, "skills", "path")); got != filepath.Join(testHome, ".agents", "skills") {
+		t.Fatalf("skills target escaped test home: %s", got)
 	}
 	t.Logf("version: %v", v)
 }
@@ -584,7 +598,7 @@ func TestStreamReceivesPush(t *testing.T) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bin, "stream", "--format", "json")
-	cmd.Env = append(os.Environ(), "EIGENFLUX_HOME="+testHome)
+	cmd.Env = cliTestEnv()
 	var outBuf strings.Builder
 	cmd.Stdout = &outBuf
 	cmd.Stderr = os.Stderr

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -34,9 +34,13 @@ func TestMain(m *testing.M) {
 // EIGENFLUX_HOME is pointed at a temporary directory so tests don't pollute the real config.
 func runCLI(t *testing.T, args ...string) (stdout string, stderr string, err error) {
 	t.Helper()
-	bin, lookErr := exec.LookPath("eigenflux")
-	if lookErr != nil {
-		t.Fatalf("eigenflux binary not found in PATH: %v", lookErr)
+	bin := os.Getenv("EIGENFLUX_TEST_CLI")
+	if bin == "" {
+		var lookErr error
+		bin, lookErr = exec.LookPath("eigenflux")
+		if lookErr != nil {
+			t.Fatalf("eigenflux binary not found in PATH: %v", lookErr)
+		}
 	}
 	cmd := exec.Command(bin, args...)
 	cmd.Env = append(os.Environ(), "EIGENFLUX_HOME="+testHome)
@@ -100,8 +104,12 @@ func TestVersion(t *testing.T) {
 	if _, ok := v["cli_version"]; !ok {
 		t.Error("expected cli_version in version output")
 	}
-	if v["os"] == nil || v["arch"] == nil {
-		t.Error("expected os and arch in version output")
+	platform, _ := v["os"].(string)
+	if parts := strings.Split(platform, "/"); len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		t.Errorf("expected os/arch platform in version output, got %q", platform)
+	}
+	if v["home"] != filepath.Join(testHome, ".eigenflux") || v["home_source"] != "env" {
+		t.Errorf("version must report the isolated test home: %v", v)
 	}
 	t.Logf("version: %v", v)
 }
@@ -176,12 +184,21 @@ func TestConfigKV(t *testing.T) {
 	setup(t)
 
 	// Global set/get — values are free-form strings.
-	mustRunCLI(t, "config", "set", "--key", "recurring_publish", "--value", "true")
-	out := mustRunCLI(t, "config", "get", "--key", "recurring_publish")
+	mustRunCLI(t, "config", "set", "--key", "verification_note", "--value", "true")
+	out := mustRunCLI(t, "config", "get", "--key", "verification_note")
 	if strings.TrimSpace(out) != "true" {
-		t.Errorf("expected recurring_publish=\"true\", got %q", strings.TrimSpace(out))
+		t.Errorf("expected verification_note=\"true\", got %q", strings.TrimSpace(out))
+	}
+	for _, key := range []string{"recurring_publish", "auto_reply_pm", "auto_comment", "show_add_friend"} {
+		_, stderr, err := runCLI(t, "config", "set", "--key", key, "--value", "true")
+		if err == nil || !strings.Contains(stderr, "context security set") {
+			t.Fatalf("security setting %s must require the versioned command: err=%v stderr=%q", key, err, stderr)
+		}
 	}
 
+	email := fmt.Sprintf("cli_config_%d@test.com", time.Now().UnixNano())
+	t.Cleanup(func() { testutil.CleanupTestEmails(t, email) })
+	loginAndAuth(t, email)
 	mustRunCLI(t, "config", "set", "--key", "feed_delivery_preference", "--value", "push urgent signals")
 
 	// Per-server scope (server-first read, global fallback) applies to ordinary
@@ -206,31 +223,36 @@ func TestConfigKV(t *testing.T) {
 
 	// Backend-synced keys are account-level: --server is ignored and the value
 	// is forced into the GLOBAL kv (the sync layer reads global-only), with any
-	// stray per-server copy scrubbed. Setting auto_reply_pm with --server local
+	// stray per-server copy scrubbed. Setting official_pm_optout with --server local
 	// must land in global kv, not server_kv.
-	mustRunCLI(t, "config", "set", "--key", "auto_reply_pm", "--value", "true", "--server", "local")
+	mustRunCLI(t, "config", "set", "--key", "official_pm_optout", "--value", "true", "--server", "local")
 	out = mustRunCLI(t, "config", "show", "--server", "local", "--format", "json")
 	v := parseJSON(t, out)
 	kv, _ := v["kv"].(map[string]interface{})
-	if kv["auto_reply_pm"] != "true" {
-		t.Errorf("synced key set with --server must land in global kv; show.kv.auto_reply_pm = %v, want \"true\"", kv["auto_reply_pm"])
+	if kv["official_pm_optout"] != "true" {
+		t.Errorf("synced key set with --server must land in global kv; show.kv.official_pm_optout = %v, want \"true\"", kv["official_pm_optout"])
 	}
 	if serverKV, _ := v["server_kv"].(map[string]interface{}); serverKV != nil {
-		if _, ok := serverKV["auto_reply_pm"]; ok {
-			t.Errorf("synced key must not be stored under server_kv; got server_kv.auto_reply_pm = %v", serverKV["auto_reply_pm"])
+		if _, ok := serverKV["official_pm_optout"]; ok {
+			t.Errorf("synced key must not be stored under server_kv; got server_kv.official_pm_optout = %v", serverKV["official_pm_optout"])
 		}
 	}
-	if kv["recurring_publish"] != "true" {
-		t.Errorf("show.kv.recurring_publish = %v, want \"true\"", kv["recurring_publish"])
+	if kv["verification_note"] != "true" {
+		t.Errorf("show.kv.verification_note = %v, want \"true\"", kv["verification_note"])
+	}
+	for _, key := range []string{"recurring_publish", "auto_reply_pm", "auto_comment", "show_add_friend"} {
+		if _, exists := kv[key]; exists {
+			t.Errorf("rejected security setting %s was persisted in ordinary config", key)
+		}
 	}
 
-	// auto_comment is backend-synced too: same global-only scoping contract.
-	mustRunCLI(t, "config", "set", "--key", "auto_comment", "--value", "false", "--server", "local")
+	// Account language uses the same global-only scoping contract.
+	mustRunCLI(t, "config", "set", "--key", "lang", "--value", "en", "--server", "local")
 	out = mustRunCLI(t, "config", "show", "--server", "local", "--format", "json")
 	v = parseJSON(t, out)
 	kv, _ = v["kv"].(map[string]interface{})
-	if kv["auto_comment"] != "false" {
-		t.Errorf("synced key set with --server must land in global kv; show.kv.auto_comment = %v, want \"false\"", kv["auto_comment"])
+	if kv["lang"] != "en" {
+		t.Errorf("synced key set with --server must land in global kv; show.kv.lang = %v, want \"en\"", kv["lang"])
 	}
 	if kv["feed_delivery_preference"] != "push urgent signals" {
 		t.Errorf("show.kv.feed_delivery_preference = %v, want \"push urgent signals\"", kv["feed_delivery_preference"])
@@ -737,4 +759,3 @@ func loginAndAuth(t *testing.T, email string) {
 		t.Fatalf("verify did not return access_token: %v", verifyResult)
 	}
 }
-

--- a/tests/cli/cli_test.go
+++ b/tests/cli/cli_test.go
@@ -34,6 +34,18 @@ func TestMain(m *testing.M) {
 // Child processes keep configuration and automatic skill refreshes inside testHome.
 func runCLI(t *testing.T, args ...string) (stdout string, stderr string, err error) {
 	t.Helper()
+	bin := resolveTestCLI(t)
+	cmd := exec.Command(bin, args...)
+	cmd.Env = cliTestEnv()
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	runErr := cmd.Run()
+	return outBuf.String(), errBuf.String(), runErr
+}
+
+func resolveTestCLI(t *testing.T) string {
+	t.Helper()
 	bin := os.Getenv("EIGENFLUX_TEST_CLI")
 	if bin == "" {
 		var lookErr error
@@ -42,13 +54,7 @@ func runCLI(t *testing.T, args ...string) (stdout string, stderr string, err err
 			t.Fatalf("eigenflux binary not found in PATH: %v", lookErr)
 		}
 	}
-	cmd := exec.Command(bin, args...)
-	cmd.Env = cliTestEnv()
-	var outBuf, errBuf strings.Builder
-	cmd.Stdout = &outBuf
-	cmd.Stderr = &errBuf
-	runErr := cmd.Run()
-	return outBuf.String(), errBuf.String(), runErr
+	return bin
 }
 
 // A separate EIGENFLUX_HOME alone does not isolate the feed-poll skill sync:
@@ -593,7 +599,8 @@ func TestStreamReceivesPush(t *testing.T) {
 	t.Cleanup(func() { cleanMockItem(t, itemID) })
 
 	// Start `eigenflux stream` as a background process.
-	bin, _ := exec.LookPath("eigenflux")
+	bin := resolveTestCLI(t)
+	t.Logf("stream CLI binary: %s", bin)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 

--- a/tests/console/console_v1_test.go
+++ b/tests/console/console_v1_test.go
@@ -263,25 +263,70 @@ func TestConsoleActivityCalendarReturnsCalendar(t *testing.T) {
 
 func TestConsoleHighlightsReturnsItems(t *testing.T) {
 	testutil.WaitForAPI(t)
-	token, _, _ := testutil.LoginAndGetToken(t, testEmail)
-
-	result := testutil.DoGet(t, "/api/v1/console/highlights?limit=5", token)
-	assertCode(t, result, 0)
-
-	data := result["data"].(map[string]interface{})
-	highlights, ok := data["highlights"].([]interface{})
-	if !ok {
-		t.Fatal("expected highlights array")
-	}
-	// impression_id lives on each highlight (per-delivery), not at the top level.
-	for i, h := range highlights {
-		hl := h.(map[string]interface{})
-		requireKey(t, hl, "item_id")
-		requireKey(t, hl, "impression_id")
-		if i >= 2 {
-			break
+	email := fmt.Sprintf("console-highlights-%d@test.com", time.Now().UnixNano())
+	token, agentID, _ := testutil.LoginAndGetToken(t, email)
+	t.Cleanup(func() { testutil.CleanupTestEmails(t, email) })
+	readHighlights := func(t *testing.T) []interface{} {
+		t.Helper()
+		result := testutil.DoGet(t, "/api/v1/console/highlights?limit=5&lang=en", token)
+		assertCode(t, result, 0)
+		data := result["data"].(map[string]interface{})
+		highlights, ok := data["highlights"].([]interface{})
+		if !ok {
+			t.Fatal("expected highlights array")
 		}
+		return highlights
 	}
+	t.Run("daily picks without deliveries", func(t *testing.T) {
+		highlights := readHighlights(t)
+		if len(highlights) != 3 {
+			t.Fatalf("expected three daily picks, got %d", len(highlights))
+		}
+		for _, h := range highlights {
+			hl := h.(map[string]interface{})
+			if hl["global_pick"] != true || hl["source"] != "EigenFlux" {
+				t.Fatalf("expected global daily pick: %v", hl)
+			}
+			for _, key := range []string{"content", "summary"} {
+				if value, _ := hl[key].(string); value == "" {
+					t.Fatalf("daily pick missing %s: %v", key, hl)
+				}
+			}
+		}
+	})
+	t.Run("delivered broadcast", func(t *testing.T) {
+		authorEmail := fmt.Sprintf("console-highlight-author-%d@test.com", time.Now().UnixNano())
+		_, authorID, _ := testutil.LoginAndGetToken(t, authorEmail)
+		t.Cleanup(func() { testutil.CleanupTestEmails(t, authorEmail) })
+		itemID := time.Now().UnixNano()
+		now := time.Now().UnixMilli()
+		impressionID := fmt.Sprintf("console-highlight-%d", itemID)
+		t.Cleanup(func() {
+			testutil.TestDB.Exec("DELETE FROM replay_logs WHERE item_id = $1", itemID)
+			testutil.TestDB.Exec("DELETE FROM processed_items WHERE item_id = $1", itemID)
+			testutil.TestDB.Exec("DELETE FROM raw_items WHERE item_id = $1", itemID)
+		})
+		if _, err := testutil.TestDB.Exec(`INSERT INTO raw_items (item_id, author_agent_id, raw_content, created_at) VALUES ($1, $2, 'Delivered highlight fixture', $3)`, itemID, authorID, now); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := testutil.TestDB.Exec(`INSERT INTO processed_items (item_id, status, broadcast_type, summary, updated_at) VALUES ($1, 3, 'info', 'Delivered summary', $2)`, itemID, now); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := testutil.TestDB.Exec(`INSERT INTO replay_logs (id, impression_id, agent_id, item_id, item_score, served_at, created_at, delivered) VALUES ($1,$2,$3,$1,1,$4,$4,true)`, itemID, impressionID, agentID, now); err != nil {
+			t.Fatal(err)
+		}
+		highlights := readHighlights(t)
+		if len(highlights) != 1 {
+			t.Fatalf("expected one delivered broadcast, got %d", len(highlights))
+		}
+		hl := highlights[0].(map[string]interface{})
+		if testutil.MustID(t, hl["item_id"], "item_id") != itemID || hl["impression_id"] != impressionID {
+			t.Fatalf("highlight must preserve delivery identity: %v", hl)
+		}
+		if hl["summary"] != "Delivered summary" || hl["global_pick"] == true {
+			t.Fatalf("expected the delivered broadcast content: %v", hl)
+		}
+	})
 }
 
 // ---------- Highlight Feedback ----------

--- a/tests/e2e/feedback_test.go
+++ b/tests/e2e/feedback_test.go
@@ -33,7 +33,7 @@ func TestFeedbackFlow(t *testing.T) {
 
 	// Step 2: Register User Agent
 	t.Log("=== Step 2: Register User Agent ===")
-	userResp := testutil.RegisterAgent(t, "user@test.com", "UserBot", "I am interested in AI")
+	userResp := testutil.RegisterAgent(t, "user@test.com", "UserBot", "Domains: chain-of-thought reasoning, mathematical problem-solving. Looking for: chain-of-thought benchmark improvements.")
 	userToken := userResp["token"].(string)
 	userIDStr := userResp["agent_id"].(string)
 	var userID int64
@@ -48,7 +48,7 @@ func TestFeedbackFlow(t *testing.T) {
 	t.Log("=== Step 4: Author publishes items ===")
 	item1 := testutil.PublishItem(t, authorToken,
 		"Researchers at DeepMind published a new paper on chain-of-thought reasoning in large language models. The study demonstrates that structured prompting techniques can improve mathematical problem-solving accuracy by 40% compared to standard approaches. The team evaluated their method across multiple benchmarks including GSM8K and MATH.",
-		"Significant advancement in LLM reasoning capabilities with real benchmark improvements",
+		`{"summary":"Significant advancement in LLM reasoning capabilities with real benchmark improvements","keywords":["chain-of-thought"]}`,
 		"https://example.com/ai-reasoning-paper")
 	item1IDStr := item1["item_id"].(string)
 	var item1ID int64

--- a/tests/e2e/milestone_notification_test.go
+++ b/tests/e2e/milestone_notification_test.go
@@ -23,12 +23,12 @@ func TestMilestoneNotificationFlow(t *testing.T) {
 	user1Resp := testutil.RegisterAgent(t, "milestone_user1@test.com", "MilestoneUser1", "")
 	user1Token := user1Resp["token"].(string)
 	user1ID := testutil.MustID(t, user1Resp["agent_id"], "agent_id")
-	testutil.UpdateProfile(t, user1Token, "I care about AI infrastructure, agent systems, and LLM deployment")
+	testutil.UpdateProfile(t, user1Token, "Domains: deterministic checkpointing, milestone notifications, distributed task recovery")
 
 	user2Resp := testutil.RegisterAgent(t, "milestone_user2@test.com", "MilestoneUser2", "")
 	user2Token := user2Resp["token"].(string)
 	user2ID := testutil.MustID(t, user2Resp["agent_id"], "agent_id")
-	testutil.UpdateProfile(t, user2Token, "I care about AI infrastructure, agent systems, and LLM deployment")
+	testutil.UpdateProfile(t, user2Token, "Domains: deterministic checkpointing, milestone notifications, distributed task recovery")
 
 	testutil.WaitForProfileProcessed(t, user1ID)
 	testutil.WaitForProfileProcessed(t, user2ID)
@@ -36,7 +36,7 @@ func TestMilestoneNotificationFlow(t *testing.T) {
 	t.Log("=== Publish item ===")
 	published := testutil.PublishItem(t, authorToken,
 		"EigenFlux team shipped a new agent orchestration runtime with distributed task recovery, deterministic checkpointing, and lower tail latency under bursty workloads. The release also adds multi-agent milestone notifications for content producers and improved queue observability for operators.",
-		"Agent orchestration runtime release with milestone notifications and checkpointing",
+		`{"summary":"Agent orchestration runtime release with milestone notifications and checkpointing","keywords":["checkpointing","milestone","notification"]}`,
 		"https://example.com/eigenflux-runtime")
 	itemID := testutil.MustID(t, published["item_id"], "item_id")
 

--- a/tests/e2e/sort_context_features_test.go
+++ b/tests/e2e/sort_context_features_test.go
@@ -48,14 +48,14 @@ func TestSortContextFeaturesInReplayLog(t *testing.T) {
 	userID := testutil.MustID(t, userReg["agent_id"], "agent_id")
 
 	testutil.UpdateProfile(t, userToken,
-		"Interested in artificial intelligence, machine learning, large language models")
+		"Domains: retrieval-augmented generation, enterprise knowledge management, semantic chunking, RAG")
 	testutil.WaitForProfileProcessed(t, userID)
 
 	// Use the longer-form study content known to survive the LLM filter
 	// (same shape as items in TestE2EFullFlow / TestGetItemErrorCases).
 	publishResp := testutil.PublishItem(t, authorToken,
 		"Microsoft Research released a comprehensive study on retrieval-augmented generation (RAG) techniques for enterprise knowledge management. The paper evaluates 12 different chunking strategies across 5 embedding models and finds that semantic chunking with overlap produces 35% better recall than fixed-size approaches. The study also introduces a novel hybrid retrieval pipeline combining dense and sparse retrievers that achieves state-of-the-art performance on domain-specific QA benchmarks.",
-		"RAG techniques study with practical enterprise recommendations",
+		`{"summary":"RAG techniques study with practical enterprise recommendations","keywords":["rag","chunking","retrieval-augmented"]}`,
 		"")
 	itemID := testutil.MustID(t, publishResp["item_id"], "item_id")
 	testutil.WaitForItemsProcessed(t, []int64{itemID})

--- a/tests/item/delete_item_test.go
+++ b/tests/item/delete_item_test.go
@@ -3,7 +3,6 @@ package item_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"eigenflux_server/pkg/config"
 	"eigenflux_server/pkg/db"
@@ -31,10 +30,15 @@ func TestDeleteMyItem(t *testing.T) {
 	myItems := testutil.GetMyItems(t, token, 0, 20)
 	items := myItems["items"].([]interface{})
 	for _, item := range items {
-		if testutil.MustID(t, item.(map[string]interface{})["item_id"], "item_id") == itemID {
-			t.Fatal("deleted item still in my items")
+		ownItem := item.(map[string]interface{})
+		if testutil.MustID(t, ownItem["item_id"], "item_id") == itemID {
+			if ownItem["retracted"] != true {
+				t.Fatalf("own deleted item must be marked retracted: %v", ownItem)
+			}
+			return
 		}
 	}
+	t.Fatal("own retracted item must remain visible in the author's history")
 }
 
 func TestDeleteItemUnauthorized(t *testing.T) {
@@ -70,9 +74,6 @@ func TestDeleteItemRaceCondition(t *testing.T) {
 	itemResp := testutil.PublishItem(t, token, "Test content for race condition", `{"type":"info","domains":["tech"],"summary":"test"}`, "")
 	itemID := testutil.MustID(t, itemResp["item_id"], "item_id")
 
-	// Wait for item to be created in DB
-	time.Sleep(100 * time.Millisecond)
-
 	// Simulate: item is being processed
 	err := dal.UpdateProcessedItemStatus(db.DB, itemID, dal.StatusProcessing)
 	if err != nil {
@@ -93,6 +94,7 @@ func TestDeleteItemRaceCondition(t *testing.T) {
 	if item.Status != dal.StatusDeleted {
 		t.Fatalf("expected status=%d (deleted), got %d", dal.StatusDeleted, item.Status)
 	}
+	summaryBeforeUpdate := item.Summary
 
 	// Simulate: async pipeline tries to update the item to completed
 	// This should be IGNORED because deleted is terminal
@@ -130,8 +132,8 @@ func TestDeleteItemRaceCondition(t *testing.T) {
 	if item.Status != dal.StatusDeleted {
 		t.Fatalf("item should remain deleted, got status=%d", item.Status)
 	}
-	if item.Summary != "" {
-		t.Fatalf("summary should not be updated, got: %s", item.Summary)
+	if item.Summary != summaryBeforeUpdate {
+		t.Fatalf("deleted item summary changed: before=%q after=%q", summaryBeforeUpdate, item.Summary)
 	}
 
 	// Also test UpdateProcessedItemStatus

--- a/tests/pm/relations_test.go
+++ b/tests/pm/relations_test.go
@@ -799,7 +799,10 @@ func TestSendFriendRequest_NotifiesRecipient(t *testing.T) {
 	if notif["notification_id"] != requestID {
 		t.Fatalf("expected notification_id=%s, got %v", requestID, notif["notification_id"])
 	}
-	expectedContent := "You have a new friend request\nGreeting: Hey, let's be friends!"
+	if notif["peer_display_name"] != "Notif A" || notif["peer_short_id"] == nil || notif["peer_short_id"] == "" {
+		t.Fatalf("friend request notification must identify its sender: %v", notif)
+	}
+	expectedContent := "You have a new friend request from Notif A\nGreeting: Hey, let's be friends!"
 	if notif["content"] != expectedContent {
 		t.Fatalf("expected content=%q, got %v", expectedContent, notif["content"])
 	}
@@ -894,7 +897,10 @@ func TestSendFriendRequest_MutualAccept_Notification(t *testing.T) {
 		}
 		if notif["type"] == "friend_accepted" {
 			found = true
-			if notif["content"] != "Your friend request has been accepted" {
+			if notif["peer_display_name"] != "MutualNotif B" || notif["peer_short_id"] == nil || notif["peer_short_id"] == "" {
+				t.Fatalf("friend acceptance notification must identify its sender: %v", notif)
+			}
+			if notif["content"] != "Your friend request has been accepted by MutualNotif B" {
 				t.Fatalf("unexpected notification content: %v", notif["content"])
 			}
 			break
@@ -1392,7 +1398,10 @@ func TestHandleFriendRequest_RejectNotifiesWithReason(t *testing.T) {
 	if notif["type"] != "friend_rejected" {
 		t.Fatalf("expected type=friend_rejected, got %v", notif["type"])
 	}
-	expectedContent := "Your friend request has been declined\nReason: " + rejectReason
+	if notif["peer_display_name"] != "RejectNotif B" || notif["peer_short_id"] == nil || notif["peer_short_id"] == "" {
+		t.Fatalf("friend rejection notification must identify its sender: %v", notif)
+	}
+	expectedContent := "Your friend request has been declined by RejectNotif B\nReason: " + rejectReason
 	if notif["content"] != expectedContent {
 		t.Fatalf("expected content=%q, got %v", expectedContent, notif["content"])
 	}

--- a/tests/replay/stream_cap_test.go
+++ b/tests/replay/stream_cap_test.go
@@ -2,11 +2,13 @@ package replay_test
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"testing"
 
 	"eigenflux_server/pkg/config"
 	"eigenflux_server/pkg/mq"
+	"github.com/redis/go-redis/v9"
 )
 
 // TestStreamCap verifies mq.Publish bounds ordinary streams via approximate
@@ -16,12 +18,29 @@ import (
 // from a stream.
 func TestStreamCap(t *testing.T) {
 	cfg := config.Load()
-	mq.Init(cfg.RedisAddr, cfg.RedisPassword)
+	// The exemption must use the production key name, so use a separate Redis
+	// database. Deleting that key in DB 0 would destroy the live pipeline group.
+	testDB := 15
+	if raw := os.Getenv("EIGENFLUX_TEST_REDIS_DB"); raw != "" {
+		var err error
+		testDB, err = strconv.Atoi(raw)
+		if err != nil || testDB <= 0 {
+			t.Fatal("EIGENFLUX_TEST_REDIS_DB must be a positive isolated Redis database number")
+		}
+	}
+	previous := mq.RDB
+	mq.RDB = redis.NewClient(&redis.Options{Addr: cfg.RedisAddr, Password: cfg.RedisPassword, DB: testDB})
+	t.Cleanup(func() {
+		_ = mq.RDB.Close()
+		mq.RDB = previous
+	})
 	mq.SetDefaultStreamMaxLen(20000)
 
 	ctx := context.Background()
 	publishN := func(stream string, n int, capped func(string, int) error) {
-		mq.RDB.Del(ctx, stream)
+		if exists, err := mq.RDB.Exists(ctx, stream).Result(); err != nil || exists != 0 {
+			t.Fatalf("isolated Redis DB %d key %s must be unused: exists=%d err=%v", testDB, stream, exists, err)
+		}
 		t.Cleanup(func() { mq.RDB.Del(ctx, stream) })
 		for i := range n {
 			if err := capped(stream, i); err != nil {

--- a/tests/sanity/services_test.go
+++ b/tests/sanity/services_test.go
@@ -134,6 +134,17 @@ func TestServiceListConsistency(t *testing.T) {
 		}
 	}
 
+	// Replay is an independently started offline service, not part of the
+	// local/cloud core service loop. Its separate launcher must use the built binary.
+	if !buildServices["replay"] {
+		t.Fatal("replay must remain in the core build output")
+	}
+	replayLauncher := readFile(t, root+"/replay/scripts/start.sh")
+	if !strings.Contains(replayLauncher, "./build/replay") {
+		t.Fatal("standalone replay launcher must start build/replay")
+	}
+	delete(buildServices, "replay")
+
 	// Check: build.sh vs start_local.sh
 	if missing := diff(buildServices, localServices); len(missing) > 0 {
 		t.Errorf("services in build.sh but missing from start_local.sh SERVICE_MAP: %v", sorted(missing))

--- a/tests/sort/ranker_config_test.go
+++ b/tests/sort/ranker_config_test.go
@@ -1,7 +1,6 @@
 package sort_test
 
 import (
-	"os"
 	"testing"
 
 	"eigenflux_server/pkg/config"
@@ -18,7 +17,9 @@ func TestScoringConfigDefaults(t *testing.T) {
 		"FRESHNESS_ALERT_OFFSET", "FRESHNESS_ALERT_SCALE", "FRESHNESS_ALERT_DECAY",
 		"FRESHNESS_SUPPLY_OFFSET", "FRESHNESS_SUPPLY_SCALE", "FRESHNESS_SUPPLY_DECAY",
 	} {
-		os.Unsetenv(key)
+		// An explicitly empty value selects the built-in default and prevents
+		// config.Load from reintroducing a caller's local .env value.
+		t.Setenv(key, "")
 	}
 
 	cfg := config.Load()
@@ -48,24 +49,14 @@ func TestScoringConfigDefaults(t *testing.T) {
 }
 
 func TestScoringConfigOverrides(t *testing.T) {
-	os.Setenv("SCORE_WEIGHT_SEMANTIC", "0.5")
-	os.Setenv("EXPLORATION_SLOTS", "0")
-	os.Setenv("FRESHNESS_ALERT_OFFSET", "1h")
-	os.Setenv("MIN_RELEVANCE_SCORE", "0.25")
-	os.Setenv("ENABLE_KNN_RECALL", "true")
-	os.Setenv("ENABLE_SWING_I2I_RECALL", "true")
-	os.Setenv("SWING_I2I_RECALL_SEEDS", "12")
-	os.Setenv("SWING_I2I_RECALL_K", "60")
-	defer func() {
-		os.Unsetenv("SCORE_WEIGHT_SEMANTIC")
-		os.Unsetenv("EXPLORATION_SLOTS")
-		os.Unsetenv("FRESHNESS_ALERT_OFFSET")
-		os.Unsetenv("MIN_RELEVANCE_SCORE")
-		os.Unsetenv("ENABLE_KNN_RECALL")
-		os.Unsetenv("ENABLE_SWING_I2I_RECALL")
-		os.Unsetenv("SWING_I2I_RECALL_SEEDS")
-		os.Unsetenv("SWING_I2I_RECALL_K")
-	}()
+	t.Setenv("SCORE_WEIGHT_SEMANTIC", "0.5")
+	t.Setenv("EXPLORATION_SLOTS", "0")
+	t.Setenv("FRESHNESS_ALERT_OFFSET", "1h")
+	t.Setenv("MIN_RELEVANCE_SCORE", "0.25")
+	t.Setenv("ENABLE_KNN_RECALL", "true")
+	t.Setenv("ENABLE_SWING_I2I_RECALL", "true")
+	t.Setenv("SWING_I2I_RECALL_SEEDS", "12")
+	t.Setenv("SWING_I2I_RECALL_K", "60")
 
 	cfg := config.Load()
 

--- a/tests/testutil/db.go
+++ b/tests/testutil/db.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"eigenflux_server/pkg/config"
+	"eigenflux_server/pkg/milestone"
 	"eigenflux_server/pkg/recall"
 )
 
@@ -84,6 +85,9 @@ func CleanTestData(t *testing.T, emails ...string) {
 		TestDB.Exec("DELETE FROM auth_email_challenges WHERE email = $1", email)
 	}
 	resetMilestoneRules()
+	if err := milestone.PublishRuleInvalidation(ctx, rdb, ""); err != nil {
+		t.Fatalf("invalidate reset milestone rule cache: %v", err)
+	}
 	TestDB.Exec("DELETE FROM system_notifications")
 
 	// --- Redis ---

--- a/tests/testutil/milestone.go
+++ b/tests/testutil/milestone.go
@@ -1,9 +1,12 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	"eigenflux_server/pkg/milestone"
 )
 
 func ConfigureMilestoneRuleForTest(t *testing.T, metricKey string, threshold int64, contentTemplate string) {
@@ -31,6 +34,9 @@ func ConfigureMilestoneRuleForTest(t *testing.T, metricKey string, threshold int
 			updated_at = EXCLUDED.updated_at
 	`, metricKey, threshold, contentTemplate, now); err != nil {
 		t.Fatalf("upsert milestone rule failed for metric %s threshold %d: %v", metricKey, threshold, err)
+	}
+	if err := milestone.PublishRuleInvalidation(context.Background(), GetTestRedis(), metricKey); err != nil {
+		t.Fatalf("invalidate milestone rule cache for metric %s: %v", metricKey, err)
 	}
 }
 


### PR DESCRIPTION
## Description

Restore integration assertions and fixtures to the current product contracts. The historical frozen-main assertions reproduced failures against the same local runtime: CLI version/settings, Console highlights, peer-named PM notifications, retracted author history, ranker defaults, and standalone replay startup. The repairs preserve their behavioral coverage and make ingestion tests deterministic under the local provider fixture.

## Related Issue

Closes #302

## Type of Change

- [x] Test addition or update
- [x] Documentation update

## Changes Made

- Assert the current CLI platform/home fields, synchronized supported settings, and rejection of prohibited autonomous-action flags. Use one `EIGENFLUX_TEST_CLI` resolver for ordinary commands and the WebSocket stream subprocess.
- Isolate CLI subprocess HOME and managed-skill targets; direct automatic skill refreshes to an unavailable loopback CDN. Verify `skills path` stays within the fixture home.
- Cover both Console global highlights and a delivered-item highlight using explicit database fixtures. Preserve notification identity/reason and retracted-item lifecycle assertions.
- Give ingestion fixtures meaningful shared interests and invalidate cached milestone rules after direct fixture writes. Keep feed/feedback/milestone/replay assertions intact.
- Put the destructive Redis stream-cap fixture in a separate empty test database so it cannot delete the live pipeline consumer group.

## Testing

- Original main assertions, with only the API readiness helper overlaid, reproduce the contract failures (`main-contract-baseline-ready`, exit 1).
- Corrected fixture/contract regressions pass (`contracts-final-regressions`, exit 0).
- Combined verification on union `ceb2b54a`: root suite exit 0, 95 packages with tests pass, no package fails. Five provider-dependent semantic tests explicitly excluded; three ordinary conditional skips remain.
- Root command: `./tests/run.sh --skip-start -p=1 '-skip=^(TestEmbedding|TestExtractKeywords|TestProcessItemDistributionGateCases|TestSafetyPromptPoliticalSensitivityCases|TestPoliticalSafetyProviderRejectionDiscardsItem)$'`.
- Separate CLI module, Console API module, and Console Web tests pass. Core services build successfully.
- Follow-up isolation: `TestVersion` and `TestPublishAndFeed` pass with the built union CLI. Before/after SHA-256 and mtime snapshots confirm the installed host binary and all official skill files stayed unchanged.

- Stream subprocess verification after commit `8ff0eab`: `TestStreamReceivesPush` passes against the explicit union CLI `eigenflux-c10bc4d3`; the real local WebSocket delivers a PM push and the CLI writes it to its isolated cache (`cli-stream-explicit-binary`, exit 0).

**Test environment:** macOS arm64, Go 1.26.5, isolated PostgreSQL 16 / Redis 7 / etcd / Elasticsearch, local mock provider for pipeline plumbing.

### Main synchronization

Merged upstream `b58a785d`. The three notification conflicts retain the additional peer identity assertions; the resolved `tests/pm/relations_test.go` is byte-for-byte unchanged from the previously tested PR head. Its remaining diff from current main adds only those identity assertions. The updated PM integration package compiles with `go test -c ./tests/pm`; the rate-limit, notification, send-guard and PM unit packages pass in the synchronized self-target branch. Full integration results above remain evidence for their recorded revisions, not a rerun of later upstream features.

## Checklist

- [x] Self-reviewed and documented current fixtures/contracts.
- [x] Meaningful prior assertions retained.
- [x] Changed integration coverage passes against local services.
- [x] No product behavior changed.

## Additional Notes

The real-provider semantic tests are not claimed as passing: the available Micu embeddings route returned 503 with no usable model channel, and actual keyword extraction via the Go SDK timed out or returned no text content. Provider exclusions are explicit invocation flags, not removed tests or weakened assertions. Verification logs are saved locally under `go-verification/`.
