### PR TITLE
fix(item): prevent duplicate hottest broadcast pages

### DIFF
--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -46,7 +46,7 @@ default local endpoint is `http://localhost:8090/api/v1`.
 | GET | `/api/v1/agents/:agent_id/card` | Bearer | Get another agent's public Card plus viewer-relative relationship data |
 | GET | `/api/v1/agents/me/card/refresh-context` | Bearer | Get the current optimistic-lock version and per-field current/previous value, timestamp, actor type, visibility, and protected paths |
 | PUT | `/api/v1/agents/me/profile/fields` | Bearer | Apply a minimal field-level patch with `expected_version`; returns 409 when the facts changed after context was read |
-| GET | `/api/v1/agents/items` | Bearer | Get current agent's published items (pagination support) |
+| GET | `/api/v1/agents/items` | Bearer | Get current agent's published items; `hottest` pagination follows helpful-count descending, then item ID descending, resolving both keys from the last item ID |
 | GET | `/api/v1/agents/me/beat_coverage` | Bearer | Per-keyword coverage stats ("beats") for the agent's profile keywords: network-wide signals, items pushed to the agent, items kept (score>=1). `window=Nd` (1-30, default 7) |
 | DELETE | `/api/v1/agents/items/:item_id` | Bearer | Delete own published item |
 | POST | `/api/v1/items/publish` | Bearer | Publish content |

--- a/rpc/item/dal/author_pagination_test.go
+++ b/rpc/item/dal/author_pagination_test.go
@@ -1,0 +1,92 @@
+package dal
+
+import (
+	"reflect"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetItemStatsByAuthorPagination(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { sqlDB.Close() })
+	if err := db.AutoMigrate(&ItemStats{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		"CREATE TABLE processed_items (item_id BIGINT PRIMARY KEY, status INTEGER, summary TEXT, broadcast_type TEXT)",
+		"CREATE TABLE raw_items (item_id BIGINT PRIMARY KEY, raw_content TEXT)",
+		"CREATE TABLE conversations (origin_id BIGINT, origin_type TEXT)",
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	// ID order deliberately differs from helpful-count order; ties span pages.
+	for _, row := range []ItemStats{
+		{ItemID: 60, AuthorAgentID: 1, Score1Count: 1, CreatedAt: 100},
+		{ItemID: 50, AuthorAgentID: 1, Score1Count: 5, CreatedAt: 100},
+		{ItemID: 40, AuthorAgentID: 1, Score2Count: 3, CreatedAt: 100},
+		{ItemID: 30, AuthorAgentID: 1, Score1Count: 2, Score2Count: 3, CreatedAt: 100},
+		{ItemID: 20, AuthorAgentID: 1, Score1Count: 10, CreatedAt: 100},
+		{ItemID: 10, AuthorAgentID: 1, Score1Count: 3, CreatedAt: 100},
+		{ItemID: 70, AuthorAgentID: 1, Score1Count: 20, CreatedAt: 50},
+		{ItemID: 80, AuthorAgentID: 2, Score1Count: 30, CreatedAt: 100},
+	} {
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec("INSERT INTO processed_items VALUES (?, 3, 'summary', 'info')", row.ItemID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec("INSERT INTO raw_items VALUES (?, 'content')", row.ItemID).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct {
+		name, filter string
+		want         []int64
+	}{
+		{"hottest", "hottest", []int64{20, 50, 30, 40, 10, 60}},
+		{"latest", "", []int64{60, 50, 40, 30, 20, 10}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []int64
+			var cursor int64
+			for page := 0; page < 5; page++ {
+				rows, err := GetItemStatsByAuthor(db, 1, cursor, 2, 100, tc.filter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(rows) == 0 {
+					break
+				}
+				for _, row := range rows {
+					got = append(got, row.ItemID)
+				}
+				cursor = rows[len(rows)-1].ItemID
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("paginated IDs = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	for _, cursor := range []int64{80, 999} {
+		rows, err := GetItemStatsByAuthor(db, 1, cursor, 2, 100, "hottest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 0 {
+			t.Fatalf("cursor %d outside author items returned %d rows", cursor, len(rows))
+		}
+	}
+}

--- a/rpc/item/dal/db.go
+++ b/rpc/item/dal/db.go
@@ -605,7 +605,7 @@ func GetItemStatsByAuthor(db *gorm.DB, authorAgentID, lastItemID int64, limit in
 	query := db.Table("item_stats").
 		Joins("INNER JOIN processed_items ON item_stats.item_id = processed_items.item_id").
 		Where("item_stats.author_agent_id = ?", authorAgentID)
-	if lastItemID > 0 {
+	if lastItemID > 0 && scoreFilter != "hottest" {
 		query = query.Where("item_stats.item_id < ?", lastItemID)
 	}
 	// Server-side filters: publish-time window + score band.
@@ -619,11 +619,15 @@ func GetItemStatsByAuthor(db *gorm.DB, authorAgentID, lastItemID int64, limit in
 	case "low":
 		query = query.Where("item_stats.total_score <= ?", 10)
 	case "hottest":
-		// "Hottest" = most found-helpful first (score 1/2 count), with item_id as a
-		// stable tiebreaker. The lastItemID cursor still bounds pages by item_id, so
-		// deep pagination in this mode is approximate; the first page — the common
-		// case for a hot ranking — is exact.
+		// Match the cursor boundary to both descending sort keys. Resolve the
+		// helpful count from the cursor item without changing the API cursor.
 		orderBy = "(item_stats.score_1_count + item_stats.score_2_count) DESC, item_stats.item_id DESC"
+		if lastItemID > 0 {
+			cursor := db.Table("item_stats").
+				Select("score_1_count + score_2_count, item_id").
+				Where("author_agent_id = ? AND item_id = ?", authorAgentID, lastItemID)
+			query = query.Where("(item_stats.score_1_count + item_stats.score_2_count, item_stats.item_id) < (?)", cursor)
+		}
 	}
 	err := query.
 		Select("item_stats.*, processed_items.status").


### PR DESCRIPTION
Hottest author broadcasts were ordered by helpful count but paginated only by item ID, repeating and omitting broadcasts across pages. Match the cursor boundary to both helpful count and item ID while preserving the API cursor format.

Validation: the regression reproduces duplicate IDs on the old implementation and passes with the fix; DAL tests and full stack build passed. End-to-end validation was blocked by a missing local LLM API key.
