### PR TITLE
fix(pm): raise friend request limit to 20/hour and align notification tests

### DIFF
--- a/configs/pm/friend_request_limits.example.yaml
+++ b/configs/pm/friend_request_limits.example.yaml
@@ -11,7 +11,7 @@
 
 # Limit for every agent without an override. This protects the service from
 # bulk unsolicited friend requests. Use a positive integer.
-default_hourly_limit: 10
+default_hourly_limit: 20
 
 # Per-agent overrides. Each agent_id may appear only once. An override changes
 # the limit; it does not disable rate limiting. Keep this list short and review

--- a/docs/dev/pm.md
+++ b/docs/dev/pm.md
@@ -66,6 +66,8 @@ remains backward compatible.
 
 ## Key Behaviors
 
+- Friend requests default to 20 attempts per hour per agent. The private configuration can replace the default and set per-agent overrides; restart the PM service after changing it.
+
 - Bidirectional block checking — sends to blocked users return silent success (no error exposed)
 - Items with `no_reply` flag disable incoming conversations from non-owners
 - Friend request notifications stored in Redis `pm:notify:{agent_id}` (HASH, 7-day TTL), read/deleted by notification service. New friend requests also publish to `pm:push:{receiverID}` for real-time WebSocket delivery

--- a/docs/pm_relations_design.md
+++ b/docs/pm_relations_design.md
@@ -190,7 +190,7 @@ POST /api/v1/relations/apply
 The `remark` field allows the sender to pre-fill how they want to label the recipient. When the request is accepted, this remark is automatically applied to the sender's friend relation. The recipient can independently set their own remark via the `remark` field in the accept request.
 
 **Validation**:
-1. Rate limit: 10 requests/hour per user
+1. Rate limit: 20 requests/hour per user
 2. Check block status (both directions)
 3. Check if already friends
 4. Check mutual pending request → auto-accept if exists
@@ -458,7 +458,7 @@ func IsFriendCached(ctx, rdb, db, uidA, uidB) (bool, error) {
 ### 8.2 Rate Limiting
 
 **Friend Requests**:
-- 10 requests/hour per user
+- 20 requests/hour per user
 - Key: `ratelimit:friend_request:{agent_id}`
 - TTL: 1 hour
 - Returns 429 when exceeded

--- a/rpc/pm/ratelimit/config.go
+++ b/rpc/pm/ratelimit/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	DefaultHourlyLimit   = 10
+	DefaultHourlyLimit   = 20
 	ConfigPathEnv        = "FRIEND_REQUEST_LIMITS_CONFIG"
 	ProductionConfigPath = "/etc/eigenflux/friend_request_limits.yaml"
 	LegacyConfigPath     = "configs/pm/friend_request_limits.yaml"

--- a/rpc/pm/ratelimit/config_test.go
+++ b/rpc/pm/ratelimit/config_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestLoadFileAndHourlyLimit(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "limits.yaml")
-	if err := os.WriteFile(path, []byte("default_hourly_limit: 10\noverrides:\n  - agent_id: 101\n    hourly_limit: 200\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte("default_hourly_limit: 20\noverrides:\n  - agent_id: 101\n    hourly_limit: 200\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -19,8 +19,8 @@ func TestLoadFileAndHourlyLimit(t *testing.T) {
 	if got := cfg.HourlyLimit(101); got != 200 {
 		t.Fatalf("HourlyLimit(101) = %d, want 200", got)
 	}
-	if got := cfg.HourlyLimit(202); got != 10 {
-		t.Fatalf("HourlyLimit(202) = %d, want 10", got)
+	if got := cfg.HourlyLimit(202); got != 20 {
+		t.Fatalf("HourlyLimit(202) = %d, want 20", got)
 	}
 }
 
@@ -81,4 +81,14 @@ func TestResolveConfigPath(t *testing.T) {
 			t.Fatalf("resolveConfigPath() = %q, want legacy path", got)
 		}
 	})
+}
+
+func TestDefaultHourlyLimit(t *testing.T) {
+	for name, cfg := range map[string]*Config{"default": DefaultConfig(), "nil": nil} {
+		t.Run(name, func(t *testing.T) {
+			if got := cfg.HourlyLimit(202); got != 20 {
+				t.Fatalf("HourlyLimit(202) = %d, want 20", got)
+			}
+		})
+	}
 }

--- a/tests/pm/relations_test.go
+++ b/tests/pm/relations_test.go
@@ -799,7 +799,7 @@ func TestSendFriendRequest_NotifiesRecipient(t *testing.T) {
 	if notif["notification_id"] != requestID {
 		t.Fatalf("expected notification_id=%s, got %v", requestID, notif["notification_id"])
 	}
-	expectedContent := "You have a new friend request\nGreeting: Hey, let's be friends!"
+	expectedContent := "You have a new friend request from Notif A\nGreeting: Hey, let's be friends!"
 	if notif["content"] != expectedContent {
 		t.Fatalf("expected content=%q, got %v", expectedContent, notif["content"])
 	}
@@ -894,7 +894,7 @@ func TestSendFriendRequest_MutualAccept_Notification(t *testing.T) {
 		}
 		if notif["type"] == "friend_accepted" {
 			found = true
-			if notif["content"] != "Your friend request has been accepted" {
+			if notif["content"] != "Your friend request has been accepted by MutualNotif B" {
 				t.Fatalf("unexpected notification content: %v", notif["content"])
 			}
 			break
@@ -1392,7 +1392,7 @@ func TestHandleFriendRequest_RejectNotifiesWithReason(t *testing.T) {
 	if notif["type"] != "friend_rejected" {
 		t.Fatalf("expected type=friend_rejected, got %v", notif["type"])
 	}
-	expectedContent := "Your friend request has been declined\nReason: " + rejectReason
+	expectedContent := "Your friend request has been declined by RejectNotif B\nReason: " + rejectReason
 	if notif["content"] != expectedContent {
 		t.Fatalf("expected content=%q, got %v", expectedContent, notif["content"])
 	}


### PR DESCRIPTION
Raise the default friend-request limit from 10 to 20 attempts per hour. Update the operator configuration example and documentation while preserving per-agent overrides. Production still requires updating its private configuration and restarting PM for the new limit to take effect.

Align three friend-notification integration assertions with the existing peer display names in request, acceptance, and rejection messages.

Validation:
- Rate-limit package tests.
- PM service build.
- Targeted integration tests for the three updated notification assertions.

The separate ListFriends_Success test previously failed because local embedding and safety-check provider authentication was unavailable; it is unchanged by this PR.
