### PR TITLE
fix(api): expose Commission discovery to Agent V2 CLI

### DIFF
--- a/api/consolev2/commission_discovery.go
+++ b/api/consolev2/commission_discovery.go
@@ -1,0 +1,17 @@
+package consolev2
+
+import (
+	"github.com/cloudwego/hertz/pkg/app/server"
+
+	"eigenflux_server/api/commissiondiscovery"
+)
+
+// RegisterCommissionDiscovery reuses the discovery facade with Agent V2 auth.
+// A nil facade keeps the discovery feature flag's disabled surface unchanged.
+func (s *Service) RegisterCommissionDiscovery(h *server.Hertz, discovery *commissiondiscovery.Service) {
+	if discovery == nil {
+		return
+	}
+	h.GET("/api/v2/commissions/search", s.agentAuth("feed:read"), s.requireCompleted, discovery.Search)
+	h.GET("/api/v2/commissions/recommendations", s.agentAuth("feed:read"), s.requireCompleted, discovery.Recommend)
+}

--- a/api/consolev2/commission_discovery_test.go
+++ b/api/consolev2/commission_discovery_test.go
@@ -1,0 +1,133 @@
+package consolev2
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"github.com/cloudwego/kitex/client/callopt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"eigenflux_server/api/commissionaccess"
+	"eigenflux_server/api/commissiondiscovery"
+	base "eigenflux_server/kitex_gen/eigenflux/base"
+	sortmodel "eigenflux_server/kitex_gen/eigenflux/sort"
+)
+
+type discoveryV2Sort struct {
+	search    *sortmodel.SearchCommissionsReq
+	recommend *sortmodel.RecommendCommissionsReq
+}
+
+func (f *discoveryV2Sort) SearchCommissions(_ context.Context, req *sortmodel.SearchCommissionsReq, _ ...callopt.Option) (*sortmodel.SearchCommissionsResp, error) {
+	f.search = req
+	return &sortmodel.SearchCommissionsResp{BaseResp: &base.BaseResp{}, Candidates: []*sortmodel.CommissionCandidate{{CommissionId: 355993847441915904}}}, nil
+}
+
+func (f *discoveryV2Sort) RecommendCommissions(_ context.Context, req *sortmodel.RecommendCommissionsReq, _ ...callopt.Option) (*sortmodel.RecommendCommissionsResp, error) {
+	f.recommend = req
+	return &sortmodel.RecommendCommissionsResp{BaseResp: &base.BaseResp{}, Candidates: []*sortmodel.CommissionCandidate{{CommissionId: 355993847441915904}}}, nil
+}
+
+func TestCommissionDiscoveryV2AuthenticationAndRouting(t *testing.T) {
+	for _, tc := range []struct {
+		name, token, scopes, state, update string
+		allowed, disabled                  bool
+		status                             int
+	}{
+		{name: "success", token: "efv2a_test", scopes: "{feed:read}", state: "completed", allowed: true, status: 200},
+		{name: "missing token", scopes: "{feed:read}", state: "completed", allowed: true, status: 401},
+		{name: "legacy token", token: "at_test", scopes: "{feed:read}", state: "completed", allowed: true, status: 401},
+		{name: "wrong scope", token: "efv2a_test", scopes: "{profile:read}", state: "completed", allowed: true, status: 401},
+		{name: "incomplete onboarding", token: "efv2a_test", scopes: "{feed:read}", state: "draft", allowed: true, status: 409},
+		{name: "not allowlisted", token: "efv2a_test", scopes: "{feed:read}", state: "completed", status: 403},
+		{name: "revoked", token: "efv2a_test", scopes: "{feed:read}", state: "completed", allowed: true, update: "UPDATE agent_credential_sessions SET revoked_at=1", status: 401},
+		{name: "expired", token: "efv2a_test", scopes: "{feed:read}", state: "completed", allowed: true, update: "UPDATE agent_credential_sessions SET expires_at=0", status: 401},
+		{name: "refresh required", token: "efv2a_test", scopes: "{feed:read}", state: "completed", allowed: true, update: "UPDATE agent_credential_sessions SET access_refresh_required=TRUE", status: 401},
+		{name: "inactive identity", token: "efv2a_test", scopes: "{feed:read}", state: "completed", allowed: true, update: "UPDATE agents SET identity_state='deleted'", status: 401},
+		{name: "disabled", token: "efv2a_test", scopes: "{feed:read}", state: "completed", allowed: true, disabled: true, status: 404},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			sqlDB, err := db.DB()
+			if err != nil {
+				t.Fatal(err)
+			}
+			sqlDB.SetMaxOpenConns(1)
+			t.Cleanup(func() { _ = sqlDB.Close() })
+			for _, sql := range []string{
+				"CREATE TABLE agents (agent_id INTEGER, identity_state TEXT)",
+				"CREATE TABLE agent_principals (principal_id INTEGER, agent_id INTEGER, status TEXT, revoked_at INTEGER)",
+				"CREATE TABLE agent_credential_sessions (session_id INTEGER, principal_id INTEGER, scopes TEXT, access_token_hash TEXT, audience TEXT, revoked_at INTEGER, expires_at INTEGER, access_refresh_required BOOLEAN)",
+				"CREATE TABLE agent_onboarding_v2 (agent_id INTEGER, state TEXT, current_step INTEGER)",
+				"INSERT INTO agents VALUES (42, 'active')",
+				"INSERT INTO agent_principals VALUES (1, 42, 'active', NULL)",
+			} {
+				if err := db.Exec(sql).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := db.Exec("INSERT INTO agent_credential_sessions VALUES (1,1,?,?,'agent_v2',NULL,?,FALSE)", tc.scopes, hashString("efv2a_test"), time.Now().Add(time.Hour).UnixMilli()).Error; err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Exec("INSERT INTO agent_onboarding_v2 VALUES (42,?,1)", tc.state).Error; err != nil {
+				t.Fatal(err)
+			}
+			if tc.update != "" {
+				if err := db.Exec(tc.update).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			ids := "43"
+			if tc.allowed {
+				ids = "42"
+			}
+			access, err := commissionaccess.New(true, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := &discoveryV2Sort{}
+			discovery := commissiondiscovery.New(backend, &fixedIDGenerator{}, nil, access)
+			h := server.New()
+			commissiondiscovery.Register(h, discovery)
+			if tc.disabled {
+				discovery = nil
+			}
+			svc := &Service{db: db}
+			svc.RegisterCommissionDiscovery(h, discovery)
+			for _, path := range []string{"/api/v2/commissions/search?query=prototype&limit=3", "/api/v2/commissions/search?commission_id=355993847441915904", "/api/v2/commissions/recommendations?agent_id=999"} {
+				response := ut.PerformRequest(h.Engine, "GET", path, nil, ut.Header{Key: "Authorization", Value: "Bearer " + tc.token}).Result()
+				if response.StatusCode() != tc.status {
+					t.Fatalf("%s: status=%d body=%s", path, response.StatusCode(), response.Body())
+				}
+				if tc.status == 200 && !strings.Contains(string(response.Body()), `"commission_id":"355993847441915904"`) {
+					t.Fatalf("missing string ID: %s", response.Body())
+				}
+				if tc.status == 200 && strings.Contains(path, "query=") {
+					if backend.search.Query != "prototype" || backend.search.GetLimit() != 3 {
+						t.Fatalf("search parameters changed: %+v", backend.search)
+					}
+				}
+			}
+			if tc.status == 200 {
+				if backend.search.GetCommissionId() != 355993847441915904 || backend.recommend.AgentId != 42 {
+					t.Fatalf("incorrect RPC arguments: %+v %+v", backend.search, backend.recommend)
+				}
+			} else if backend.search != nil || backend.recommend != nil {
+				t.Fatal("unauthorized request reached Sort")
+			}
+			for _, path := range []string{"/api/v1/commissions/search", "/api/v1/commissions/recommendations"} {
+				if status := ut.PerformRequest(h.Engine, "GET", path, nil).Result().StatusCode(); status != 401 {
+					t.Fatalf("V1 route %s changed: %d", path, status)
+				}
+			}
+		})
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -359,6 +359,7 @@ func main() {
 		h.GET("/api/v1/console/compatibility", middleware.AuthMiddleware(), consoleV2Service.LegacyConsoleCompatibilityHandler())
 		h.POST("/api/v1/console/agent-upgrade-challenges", middleware.AuthMiddleware(), consoleV2Service.LegacyAgentUpgradeChallengeHandler())
 		consoleV2Service.Register(h)
+		consoleV2Service.RegisterCommissionDiscovery(h, commissionDiscoveryService)
 		registerConsoleV2BusinessBFF(h, consoleV2Service, cfg)
 		log.Print("Console V2 routes registered")
 	}

--- a/docs/dev/api_endpoints.md
+++ b/docs/dev/api_endpoints.md
@@ -12,6 +12,13 @@ that can be carried into Commission order creation for attribution.
 | --- | --- | --- | --- |
 | GET | `/api/v1/commissions/search` | Bearer | Search commissions. Requires exactly one of full-text `query` or exact `commission_id`; supports `limit` (1-100), `min_price_fen`, `max_price_fen`, `min_promised_delivery_ms`, and `max_promised_delivery_ms`. |
 | GET | `/api/v1/commissions/recommendations` | Bearer | Recommend commissions for the authenticated agent. Supports `limit` and the same numeric filters. |
+| GET | `/api/v2/commissions/search` | Agent V2 Bearer, `feed:read` | Same search contract; requires completed onboarding. |
+| GET | `/api/v2/commissions/recommendations` | Agent V2 Bearer, `feed:read` | Same recommendation contract; requires completed onboarding. |
+
+V2 discovery additionally requires `ENABLE_CONSOLE_V2=true`. It reuses the
+existing network-read scope and discovery handlers, including the Commission
+Agent allowlist. CLI V2 sessions use these routes without a credential migration.
+V1 routes and their authentication remain unchanged.
 
 The Facade derives the actor from the validated Bearer token; callers must not
 send an `agent_id`. Discovery attribution is published best-effort to Redis
@@ -26,7 +33,7 @@ embedding. Supplying both `query` and `commission_id`, or neither, returns HTTP
 
 The routes are absent unless `ENABLE_COMMISSION_DISCOVERY_API=true`; that
 setting requires `ENABLE_COMMISSION_INDEX=true`. When
-`ENABLE_COMMISSION_AGENT_ID_WHITELIST=true`, both routes return HTTP 403 for an
+`ENABLE_COMMISSION_AGENT_ID_WHITELIST=true`, both API versions return HTTP 403 for an
 authenticated Agent whose positive ID is not listed in
 `COMMISSION_AGENT_ID_WHITELIST`. This check runs before Sort RPCs and impression
 creation and does not affect non-Commission EigenFlux APIs.


### PR DESCRIPTION
## Summary
- Register the existing Commission search and recommendation handlers under /api/v2 with Agent V2 feed:read authentication and completed onboarding.
- Preserve discovery feature gating, Commission allowlist checks, and all V1 routes.
- No database, CLI, frontend, Commission service, proxy, or deployment changes.

## Verification
- Five related Go packages passed: api/consolev2, api/commissiondiscovery, api/commissionaccess, api, pkg/config.
- API build passed.
- Targeted race tests passed.
- Added route/auth regression coverage for keyword and exact-ID search, recommendations, token scope/expiry/revocation/refresh, inactive identity, onboarding, allowlist, disabled discovery, and V1 route preservation.

## Release boundary
Not deployed. After merge and API release, verify real CLI discovery and index completeness separately. Local tests use SQLite authentication fixtures and a fake Sort RPC; no production orders or payments were created.