### PR TITLE
fix(cli): release V2 topic status and feed routing fixes

### DIFF
--- a/cli/.cli.config
+++ b/cli/.cli.config
@@ -3,7 +3,7 @@
 # Source this file in build/publish scripts: source .cli.config
 
 # CLI version (semver) — bump before each CLI binary release
-CLI_VERSION=0.0.43
+CLI_VERSION=0.0.44
 
 # Skills revision — bump to ship a skill change WITHOUT a CLI release.
 # (release-skills.sh stamps the manifest; the content revision is what clients

--- a/cli/cmd/feed.go
+++ b/cli/cmd/feed.go
@@ -4,9 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -40,6 +38,9 @@ var feedPollCmd = &cobra.Command{
 	Short: "Pull personalized feed",
 	Long: `Fetch your personalized feed with curated content.
 
+Agent V2 pulls the latest feed without cursor pagination. --action more pulls
+again; it does not guarantee a distinct next page. --cursor is V1-only.
+
 Examples:
   eigenflux feed poll
   eigenflux feed poll --limit 20 --action refresh
@@ -69,16 +70,9 @@ Examples:
 		cfg, _ := config.Load()
 		maybeSyncSkills(cfg)
 		if _, v2Err := auth.LoadV2Credentials(serverName); v2Err == nil {
-			if cursor == "" && (action == "" || action == "refresh") {
-				v2PollErr := pollFeedV2(cmd, serverName, limit)
-				if v2PollErr == nil {
-					return nil
-				}
-				var apiErr *client.APIError
-				if !errors.As(v2PollErr, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
-					return v2PollErr
-				}
-			}
+			return runFeedV2Poll(action, cursor, func() error {
+				return pollFeedV2(cmd, serverName, limit)
+			})
 		}
 		_, agentID := profileStateScopeForServer(serverName)
 		c := newClientForServer(serverName)
@@ -107,6 +101,16 @@ Examples:
 		}
 		return nil
 	},
+}
+
+func runFeedV2Poll(action, cursor string, poll func() error) error {
+	if cursor != "" {
+		return fmt.Errorf("--cursor is only supported by Feed V1; Agent V2 has no cursor pagination: omit --cursor to pull the latest feed")
+	}
+	if action != "" && action != "refresh" && action != "more" {
+		return fmt.Errorf("--action must be refresh or more for Feed V2")
+	}
+	return poll()
 }
 
 var feedGetCmd = &cobra.Command{

--- a/cli/cmd/msg.go
+++ b/cli/cmd/msg.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cli.eigenflux.ai/internal/auth"
 	"cli.eigenflux.ai/internal/cache"
 	"cli.eigenflux.ai/internal/output"
 	"github.com/spf13/cobra"
@@ -200,7 +201,15 @@ Examples:
 		if status != "pending_verify" && status != "open" && status != "closed" {
 			return fmt.Errorf("--status must be pending_verify, open, or closed")
 		}
-		resp, err := newClient().Post("/pm/topic-status", map[string]interface{}{
+		hasV2, err := auth.HasV2Credentials(activeServerName())
+		if err != nil {
+			return err
+		}
+		path := "/pm/topic-status"
+		if hasV2 {
+			path = "/pm/conversations/topic-status"
+		}
+		resp, err := newClient().Post(path, map[string]interface{}{
 			"conv_id": convID, "topic_status": status,
 		})
 		if err != nil {

--- a/cli/cmd/v2_route_compat_test.go
+++ b/cli/cmd/v2_route_compat_test.go
@@ -65,7 +65,8 @@ func TestTopicStatusRoutesByCredentials(t *testing.T) {
 				if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["conv_id"] != "456" || body["topic_status"] != "open" {
 					t.Errorf("unexpected body %v: %v", body, err)
 				}
-				writeTestEnvelope(w)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
 			}))
 			defer server.Close()
 			cfg, err := config.Load()
@@ -76,7 +77,7 @@ func TestTopicStatusRoutesByCredentials(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := cfg.UpdateServerWithCommission(active.Name, server.URL, "", ""); err != nil {
+			if err := cfg.UpdateServer(active.Name, server.URL, ""); err != nil {
 				t.Fatal(err)
 			}
 			if v2 {

--- a/cli/cmd/v2_route_compat_test.go
+++ b/cli/cmd/v2_route_compat_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"cli.eigenflux.ai/internal/auth"
+	"cli.eigenflux.ai/internal/client"
+	"cli.eigenflux.ai/internal/config"
+)
+
+func TestFeedV2PollOptions(t *testing.T) {
+	for _, tc := range []struct{ action, cursor, wantError string }{
+		{"", "", ""}, {"refresh", "", ""}, {"more", "", ""},
+		{"", "123", "--cursor"}, {"more", "123", "--cursor"},
+		{"refresh", "123", "--cursor"}, {"invalid", "", "--action"},
+	} {
+		t.Run(tc.action+"/"+tc.cursor, func(t *testing.T) {
+			calls := 0
+			err := runFeedV2Poll(tc.action, tc.cursor, func() error { calls++; return nil })
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) || calls != 0 {
+					t.Fatalf("err=%v calls=%d", err, calls)
+				}
+			} else if err != nil || calls != 1 {
+				t.Fatalf("err=%v calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestFeedV2PollPreservesErrors(t *testing.T) {
+	for _, status := range []int{401, 403, 404, 503} {
+		want := &client.APIError{StatusCode: status}
+		calls := 0
+		err := runFeedV2Poll("more", "", func() error { calls++; return want })
+		if !errors.Is(err, want) || calls != 1 {
+			t.Fatalf("status=%d err=%v calls=%d", status, err, calls)
+		}
+	}
+}
+
+func TestTopicStatusRoutesByCredentials(t *testing.T) {
+	for _, v2 := range []bool{false, true} {
+		name := "v1"
+		wantPath := "/api/v1/pm/topic-status"
+		if v2 {
+			name = "v2"
+			wantPath = "/api/v2/pm/conversations/topic-status"
+		}
+		t.Run(name, func(t *testing.T) {
+			tempHome(t)
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if r.Method != http.MethodPost || r.URL.Path != wantPath {
+					t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["conv_id"] != "456" || body["topic_status"] != "open" {
+					t.Errorf("unexpected body %v: %v", body, err)
+				}
+				writeTestEnvelope(w)
+			}))
+			defer server.Close()
+			cfg, err := config.Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			active, err := cfg.GetActive("")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := cfg.UpdateServerWithCommission(active.Name, server.URL, "", ""); err != nil {
+				t.Fatal(err)
+			}
+			if v2 {
+				err = auth.SaveV2Credentials(active.Name, &auth.V2Credentials{AgentID: "42", PrincipalID: "24", AccessToken: "v2-token", RefreshToken: "refresh", ExpiresAt: time.Now().Add(time.Hour).UnixMilli()})
+			} else {
+				err = auth.SaveCredentials(active.Name, &auth.Credentials{AgentID: "42", AccessToken: "v1-token"})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			for flag, value := range map[string]string{"conv-id": "456", "status": "open"} {
+				old := msgTopicStatusCmd.Flags().Lookup(flag).Value.String()
+				if err := msgTopicStatusCmd.Flags().Set(flag, value); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = msgTopicStatusCmd.Flags().Set(flag, old) })
+			}
+			if err := msgTopicStatusCmd.RunE(msgTopicStatusCmd, nil); err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 {
+				t.Fatalf("calls=%d", calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Scope: only CLI topic-status route selection and V2 feed more/cursor handling, with regression tests. V1 behavior is unchanged. V2 cursor is explicitly unsupported by the server contract; more pulls the latest view. Preserve V2 errors without legacy-path fallback. Bump CLI 0.0.43 to 0.0.44 for binary publication. No Commission, Skills, API, database, or frontend changes. Validation: CLI module tests and local release build.