### PR TITLE
fix(cli): a mistyped subcommand fails instead of reporting success

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -65,6 +65,13 @@ func init() {
 
 	defaultHelp := rootCmd.HelpFunc()
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		// Cobra prints a group's help whenever the group is not runnable, including when it
+		// was reached through an argument it could not resolve. The root command does not
+		// behave that way: an unknown command there prints the error by itself. Keep the two
+		// consistent, and let Execute report the error.
+		if unknownSubcommand(cmd) != nil {
+			return
+		}
 		// Apply --homedir before resolving, since help runs before PersistentPreRun.
 		if homeDirFlag != "" {
 			config.SetHomeDir(homeDirFlag)
@@ -75,8 +82,56 @@ func init() {
 	})
 }
 
+// unknownSubcommand reports an argument that a command group could not resolve.
+//
+// A group holds subcommands and runs nothing itself. Cobra checks Runnable() before it
+// validates arguments, so a group's Args validator is never consulted: `eigenflux profile
+// card shwo` printed the group's help and exited 0, which makes a mistyped subcommand in a
+// script or a skill indistinguishable from one that did its job. Cobra applies this check
+// to the root command only, through legacyArgs. ExecuteC hands back the command it
+// resolved, so the leftover argument can be reported here, in the same words and with the
+// same suggestions the root command already uses.
+func unknownSubcommand(cmd *cobra.Command) error {
+	if cmd == nil || cmd.Runnable() || !cmd.HasSubCommands() {
+		return nil
+	}
+	// `--help` on a group is a request for that help, whatever else is on the line.
+	if help, err := cmd.Flags().GetBool("help"); err == nil && help {
+		return nil
+	}
+	args := cmd.Flags().Args()
+	if len(args) == 0 {
+		return nil
+	}
+	suggestions := ""
+	if !cmd.DisableSuggestions {
+		// SuggestionsFor compares against this threshold directly; Cobra only defaults it
+		// inside its own unexported helper, so an unset group would suggest nothing.
+		if cmd.SuggestionsMinimumDistance <= 0 {
+			cmd.SuggestionsMinimumDistance = 2
+		}
+		if candidates := cmd.SuggestionsFor(args[0]); len(candidates) > 0 {
+			suggestions = "\n\nDid you mean this?\n"
+			for _, candidate := range candidates {
+				suggestions += fmt.Sprintf("\t%v\n", candidate)
+			}
+		}
+	}
+	return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), suggestions)
+}
+
+// run resolves and runs the command line, returning the error Execute turns into an exit
+// code. Kept separate from Execute so tests can exercise the resolution without exiting.
+func run() error {
+	cmd, err := rootCmd.ExecuteC()
+	if err != nil {
+		return err
+	}
+	return unknownSubcommand(cmd)
+}
+
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		// Map a server-side 401 to the auth-required exit code so adapters
 		// (which key off exit 4) prompt re-login even when the local token

--- a/cli/cmd/unknown_subcommand_test.go
+++ b/cli/cmd/unknown_subcommand_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// A command group holds subcommands and runs nothing itself. Cobra checks Runnable()
+// before it validates arguments, so a group's Args validator never runs and the group
+// swallows whatever it was given: `eigenflux profile card shwo` printed the group's help
+// and exited 0. A mistyped subcommand in a script or a skill then looks exactly like a
+// command that did its job. Cobra applies the check to the root command only.
+
+// commandGroups returns every non-runnable command that owns subcommands.
+func commandGroups(t *testing.T) []*cobra.Command {
+	t.Helper()
+	var groups []*cobra.Command
+	var walk func(*cobra.Command)
+	walk = func(command *cobra.Command) {
+		if command != rootCmd && command.HasSubCommands() && !command.Runnable() {
+			groups = append(groups, command)
+		}
+		for _, child := range command.Commands() {
+			walk(child)
+		}
+	}
+	walk(rootCmd)
+	if len(groups) == 0 {
+		t.Fatal("no command groups found; the walk is broken, not the command tree")
+	}
+	return groups
+}
+
+// runArgs drives the same path main() takes, without exiting the test binary.
+func runArgs(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	// run() must finish before the buffer is read: a single return statement would
+	// evaluate out.String() first and hand back an empty string every time.
+	err := run()
+	return out.String(), err
+}
+
+func TestEveryCommandGroupRejectsAnUnknownSubcommand(t *testing.T) {
+	for _, group := range commandGroups(t) {
+		path := strings.Fields(group.CommandPath())[1:] // drop the binary name
+		args := append(append([]string{}, path...), "definitely-not-a-subcommand")
+		_, err := runArgs(t, args...)
+		if err == nil {
+			t.Errorf("%q accepted an argument that is not one of its subcommands and reported success",
+				group.CommandPath())
+		}
+	}
+}
+
+func TestUnknownSubcommandNamesTheArgumentAndTheCommand(t *testing.T) {
+	_, err := runArgs(t, "profile", "card", "shwo")
+	if err == nil {
+		t.Fatal("a mistyped subcommand reported success")
+	}
+	if !strings.Contains(err.Error(), `"shwo"`) || !strings.Contains(err.Error(), `"eigenflux profile card"`) {
+		t.Errorf("message must name the argument and the command, got %q", err.Error())
+	}
+}
+
+func TestUnknownSubcommandStillSuggestsTheNearMiss(t *testing.T) {
+	// The root command offers suggestions for a near miss; a group must not be worse.
+	_, err := runArgs(t, "profile", "crd")
+	if err == nil {
+		t.Fatal("a near-miss subcommand reported success")
+	}
+	if !strings.Contains(err.Error(), "Did you mean this?") || !strings.Contains(err.Error(), "card") {
+		t.Errorf("expected a suggestion of %q, got %q", "card", err.Error())
+	}
+}
+
+func TestUnknownSubcommandPrintsNoHelpBeforeTheError(t *testing.T) {
+	// The root command prints the error alone. A group used to print its whole help first,
+	// which buries the one line that says what was wrong.
+	out, err := runArgs(t, "profile", "card", "shwo")
+	if err == nil {
+		t.Fatal("a mistyped subcommand reported success")
+	}
+	if strings.Contains(out, "Usage:") || strings.Contains(out, "Available Commands:") {
+		t.Errorf("help was printed before the error:\n%s", out)
+	}
+}
+
+func TestAskingAGroupForHelpIsUnchanged(t *testing.T) {
+	// The fix is about a wrong subcommand, never about asking a group what it offers.
+	for _, args := range [][]string{{"profile", "card"}, {"profile", "card", "--help"}, {"agent"}} {
+		out, err := runArgs(t, args...)
+		if err != nil {
+			t.Errorf("%v returned an error: %v", args, err)
+		}
+		if !strings.Contains(out, "Available Commands:") {
+			t.Errorf("%v printed no command list:\n%s", args, out)
+		}
+	}
+}
+
+func TestARunnableCommandKeepsItsOwnArgumentHandling(t *testing.T) {
+	// unknownSubcommand must never speak for a command that runs something: those validate
+	// their own arguments, and some of them take positional ones.
+	for _, name := range []string{"show", "version"} {
+		var found *cobra.Command
+		var walk func(*cobra.Command)
+		walk = func(command *cobra.Command) {
+			if command.Name() == name && command.Runnable() && found == nil {
+				found = command
+			}
+			for _, child := range command.Commands() {
+				walk(child)
+			}
+		}
+		walk(rootCmd)
+		if found == nil {
+			t.Fatalf("expected to find a runnable %q command", name)
+		}
+		if err := unknownSubcommand(found); err != nil {
+			t.Errorf("%q was treated as a command group: %v", found.CommandPath(), err)
+		}
+	}
+}


### PR DESCRIPTION
## What was wrong

`eigenflux profile card shwo` printed the group's help and **exited 0**. The same held for a wrong subcommand under every command group in the tree:

`agent` `attention` `auth` `config` `context` `context goal` `context intent` `context security` `feed` `feed event` `heartbeat` `msg` `profile` `profile card` `relation` `runtime` `runtime command` `server` `settings` `skills` `skills target`

A typo in a script, an adapter or a skill was indistinguishable from a command that did its job. `eigenflux zzz` at the top level already failed correctly, so the two halves of the CLI disagreed.

## Why the obvious fix does not work

Cobra runs its default argument check (`legacyArgs`) only for the root command. Setting `Args: cobra.NoArgs` on the groups looks like the fix but is inert: `(*Command).execute` returns `flag.ErrHelp` for any command that is not `Runnable()` **before** it reaches `ValidateArgs`, and `ExecuteC` turns `ErrHelp` into a nil error. I built that version first and the binary still exited 0.

Making the groups runnable would work, but it changes `Runnable()` for 21 commands, and `capability_registry_contract_test.go` keys its contract off exactly that.

## What this does

`ExecuteC` returns the command it resolved, so the leftover argument is reported there. The message and the near-miss suggestions match what the root command already prints, and the group's help is no longer dumped ahead of the error.

```
$ eigenflux profile card shwo
unknown command "shwo" for "eigenflux profile card"

Did you mean this?
	show

$ echo $?
2
```

Unchanged: asking a group for its help (`eigenflux profile card`, `eigenflux profile card --help`), every runnable command's own argument handling, and the exit codes including the 401 to exit-4 mapping.

## Verification

- `go build`, `go vet`, and all **12 CLI packages** pass.
- Four tests drive the real path `main()` takes rather than asserting the field. One walks the whole command tree, so a group added later cannot reintroduce this.
- Each test was confirmed to fail with the fix disabled: `TestEveryCommandGroupRejectsAnUnknownSubcommand`, `TestUnknownSubcommandNamesTheArgumentAndTheCommand`, `TestUnknownSubcommandStillSuggestsTheNearMiss`, `TestUnknownSubcommandPrintsNoHelpBeforeTheError`.
- Binary built from this branch, checked by hand across every group above and across the unchanged paths.

Found by the Arena harness, which had been crediting interface coverage to two commands that do not exist because they exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2x1nMHn3HmtTJWh4aHaJt