### PR TITLE
fix(gateway): route the Agent V2 event stream to the WebSocket service

### DIFF
--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -62,7 +62,11 @@ www.eigenflux.ai {
 }
 
 stream.eigenflux.ai {
-	@ws path /ws /ws/*
+	# The WebSocket service serves two routes (ws/main.go): the legacy /ws/pm stream and the
+	# Agent V2 event stream, which is not under /ws. Matching only /ws left the V2 path
+	# matching nothing, so Caddy answered it with an empty 200 and never upgraded, and
+	# `eigenflux stream` could not connect on a V2 Home.
+	@ws path /ws /ws/* /api/v2/agent/events/ws
 	handle @ws {
 		reverse_proxy 127.0.0.1:8088
 	}


### PR DESCRIPTION
## What is broken

`eigenflux stream` cannot connect on production for a V2 Home, and has not been able to since at least 2026-09-02.

The CLI opens `wss://stream.eigenflux.ai/api/v2/agent/events/ws` (`cli/cmd/stream.go`). That host's Caddy site matches only `/ws` and `/ws/*`, so the V2 path matches no handler, Caddy answers the handshake itself with an empty `200`, and the connection never upgrades.

## Evidence

The WebSocket service has served both routes all along (`ws/main.go`):

```go
h.GET("/ws/pm", wsHandler.Serve)
h.GET("/api/v2/agent/events/ws", wsHandler.ServeAgentV2)
```

Against `127.0.0.1:8088` **on the production host**, so the gateway is out of the picture:

| path | status |
|---|---|
| `/ws/pm` | `401` — reaches the service, wants a token |
| `/api/v2/agent/events/ws` | `401` — same, so the service is fine |
| `/nope` | `404` — the service does discriminate |

Through the edge, HTTP/1.1, from a host outside the office network:

| path | status |
|---|---|
| `/ws/pm` | `401 Unauthorized` |
| `/api/v2/agent/events/ws` | `200 OK`, `Content-Length: 0` — never upgrades |

The same route is **11/11 green on the isolated Hub** (`communication/websocket_push` in the Arena harness), which is what narrowed this to routing rather than code. The production scenario has been failing at 3/10 on exactly these steps.

## The change

One matcher gains the V2 path.

Checked before writing it: the deployed `/etc/caddy/Caddyfile` matches this file for the `stream.eigenflux.ai` block apart from its `tls` line, so there is no configuration drift to reconcile first. `caddy validate` passes on the gateway host itself.

## Noted, not changed here

An unmatched path on this host falls through to an empty `200` rather than a `404`. That is what made the symptom look like a broken WebSocket rather than a missing route, and it is worth a follow-up, but it is not this fix.

## After merging

This takes effect only once the gateway config is deployed and Caddy reloads. Re-running `scenarios/communication/external_websocket_push.yaml` against production confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2x1nMHn3HmtTJWh4aHaJt